### PR TITLE
Don't block entire build chain when one package fails

### DIFF
--- a/db/schema/tables/execution.yaml
+++ b/db/schema/tables/execution.yaml
@@ -9,6 +9,11 @@ schema:
         - cause_id
         name: execution_cause_id_idx
         isUnique: false
+      - columns:
+        - cause_id
+        - created_at
+        name: execution_cause_id_created_at_idx
+        isUnique: false
     columns:
       - name: id
         type: text

--- a/integration/worker/buildqueue/buildqueue_test.go
+++ b/integration/worker/buildqueue/buildqueue_test.go
@@ -1,0 +1,68 @@
+package worker_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/securebuildhq/securebuild/integration/testutil"
+	"github.com/securebuildhq/securebuild/pkg/buildqueue"
+	"github.com/securebuildhq/securebuild/pkg/param"
+	"github.com/securebuildhq/securebuild/pkg/persistence"
+	pkgtestutil "github.com/securebuildhq/securebuild/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProcessRebuildChains runs ProcessRebuildChains; both links are processed in one pass:
+// one package queues a build (VM assignment from machine_pool), the other fails
+// CreateNewRelease and gets a failed execution recorded.
+//
+// Seed data includes 2 machine_pool rows per architecture so assignVMsWithTimeout
+// can assign both instantly without blocking.
+func TestProcessRebuildChains(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	testDB := testutil.SetupTestDatabase(ctx, t)
+	defer testutil.TeardownTestDatabase(ctx, t, testDB)
+
+	projectRoot, err := testutil.FindProjectRoot()
+	require.NoError(t, err)
+
+	seedDataDir := filepath.Join(projectRoot, "integration", "worker", "buildqueue", "testdata", "seed-data")
+	err = testutil.ApplySchemaHero(ctx, testDB.ConnStr, seedDataDir, true)
+	require.NoError(t, err)
+
+	overrides := map[string]string{
+		"DB_URI":       testDB.ConnStr,
+		"PIPELINE_DIR": pkgtestutil.SetupTestPipelineDir(t),
+	}
+	ctx, err = param.Init(param.InitSourceEnvironment, overrides)
+	require.NoError(t, err)
+
+	err = persistence.InitPostgres(ctx)
+	require.NoError(t, err)
+	defer persistence.ClosePool(ctx)
+
+	// One pass processes all ready links (both); one queues a build, one records failed execution.
+	err = buildqueue.ProcessRebuildChains(ctx)
+	require.NoError(t, err)
+
+	// Both links should have an execution with the expected statuses.
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+
+	var failStatus, okStatus string
+	err = conn.QueryRow(ctx, `SELECT status FROM execution WHERE cause_id = 'rcl-bq-fail'`).Scan(&failStatus)
+	require.NoError(t, err)
+	require.Equal(t, "failed", failStatus, "rcl-bq-fail (CreateNewRelease failed) should have execution status failed")
+
+	err = conn.QueryRow(ctx, `SELECT status FROM execution WHERE cause_id = 'rcl-bq-ok'`).Scan(&okStatus)
+	require.NoError(t, err)
+	require.Equal(t, "queued", okStatus, "rcl-bq-ok (HandleBuildPackage succeeded) should have execution status queued")
+}

--- a/integration/worker/buildqueue/testdata/seed-data/machine-pool.yaml
+++ b/integration/worker/buildqueue/testdata/seed-data/machine-pool.yaml
@@ -1,0 +1,143 @@
+database: securebuild
+name: machine_pool
+seedData:
+  rows:
+    # 2 VMs per architecture so whichever link is picked first can assign both archs instantly.
+    # tryTakeVMWithAssignment requires: architecture, status = 'running', assigned_task_id NULL,
+    # cleanup_locked_at NULL, is_on_demand = false.
+    - columns:
+        - column: id
+          value:
+            str: "vmbq-x86-64-00000000000000001"
+        - column: machine_id
+          value:
+            str: "fly-machine-bq-x86-1"
+        - column: created_at
+          value:
+            str: "2025-01-07T00:00:00Z"
+        - column: expires_at
+          value:
+            str: "2030-01-01T00:00:00Z"
+        - column: private_key
+          value:
+            str: "dummy-private-key-for-test"
+        - column: username
+          value:
+            str: "builder"
+        - column: status
+          value:
+            str: "running"
+        - column: ip_address
+          value:
+            str: "127.0.0.1"
+        - column: port
+          value:
+            str: "0"
+        - column: architecture
+          value:
+            str: "x86_64"
+        - column: is_on_demand
+          value:
+            str: "false"
+    - columns:
+        - column: id
+          value:
+            str: "vmbq-x86-64-00000000000000002"
+        - column: machine_id
+          value:
+            str: "fly-machine-bq-x86-2"
+        - column: created_at
+          value:
+            str: "2025-01-07T00:00:00Z"
+        - column: expires_at
+          value:
+            str: "2030-01-01T00:00:00Z"
+        - column: private_key
+          value:
+            str: "dummy-private-key-for-test"
+        - column: username
+          value:
+            str: "builder"
+        - column: status
+          value:
+            str: "running"
+        - column: ip_address
+          value:
+            str: "127.0.0.1"
+        - column: port
+          value:
+            str: "0"
+        - column: architecture
+          value:
+            str: "x86_64"
+        - column: is_on_demand
+          value:
+            str: "false"
+    - columns:
+        - column: id
+          value:
+            str: "vmbq-arm64-00000000000000001"
+        - column: machine_id
+          value:
+            str: "fly-machine-bq-arm-1"
+        - column: created_at
+          value:
+            str: "2025-01-07T00:00:00Z"
+        - column: expires_at
+          value:
+            str: "2030-01-01T00:00:00Z"
+        - column: private_key
+          value:
+            str: "dummy-private-key-for-test"
+        - column: username
+          value:
+            str: "builder"
+        - column: status
+          value:
+            str: "running"
+        - column: ip_address
+          value:
+            str: "127.0.0.1"
+        - column: port
+          value:
+            str: "0"
+        - column: architecture
+          value:
+            str: "aarch64"
+        - column: is_on_demand
+          value:
+            str: "false"
+    - columns:
+        - column: id
+          value:
+            str: "vmbq-arm64-00000000000000002"
+        - column: machine_id
+          value:
+            str: "fly-machine-bq-arm-2"
+        - column: created_at
+          value:
+            str: "2025-01-07T00:00:00Z"
+        - column: expires_at
+          value:
+            str: "2030-01-01T00:00:00Z"
+        - column: private_key
+          value:
+            str: "dummy-private-key-for-test"
+        - column: username
+          value:
+            str: "builder"
+        - column: status
+          value:
+            str: "running"
+        - column: ip_address
+          value:
+            str: "127.0.0.1"
+        - column: port
+          value:
+            str: "0"
+        - column: architecture
+          value:
+            str: "aarch64"
+        - column: is_on_demand
+          value:
+            str: "false"

--- a/integration/worker/buildqueue/testdata/seed-data/package-version.yaml
+++ b/integration/worker/buildqueue/testdata/seed-data/package-version.yaml
@@ -1,0 +1,83 @@
+database: securebuild
+name: package_version
+requires:
+  - package
+seedData:
+  rows:
+    # Package with epoch: CreateNewRelease succeeds; HandleBuildPackage runs and assigns VMs from machine_pool.
+    - columns:
+        - column: id
+          value:
+            str: "pkgver-bq-ok-1"
+        - column: package_id
+          value:
+            str: "pkg-bq-ok"
+        - column: version
+          value:
+            str: "1.0.0"
+        - column: melange_yaml
+          value:
+            str: |
+              package:
+                name: bq-ok-package
+                version: 1.0.0
+                epoch: 0
+                description: OK package for buildqueue test
+              pipeline:
+                - runs: echo test
+        - column: created_at
+          value:
+            str: "2025-01-07T00:00:00Z"
+        - column: updated_at
+          value:
+            str: "2025-01-07T00:00:00Z"
+        - column: apk_release
+          value:
+            str: "0"
+        - column: use_root
+          value:
+            str: "false"
+        - column: has_securebuild_edits
+          value:
+            str: "false"
+        - column: bootstrap_enabled
+          value:
+            str: "false"
+    # Package without epoch: CreateNewRelease fails (bumpReleaseInMelangeYAML); recordFailedExecutionForLink succeeds.
+    - columns:
+        - column: id
+          value:
+            str: "pkgver-bq-fail-1"
+        - column: package_id
+          value:
+            str: "pkg-bq-fail"
+        - column: version
+          value:
+            str: "1.0.0"
+        - column: melange_yaml
+          value:
+            str: |
+              package:
+                name: bq-fail-package
+                version: 1.0.0
+                description: No epoch - bump will fail
+              pipeline:
+                - runs: echo test
+        - column: created_at
+          value:
+            str: "2025-01-07T00:00:00Z"
+        - column: updated_at
+          value:
+            str: "2025-01-07T00:00:00Z"
+        - column: apk_release
+          value:
+            str: "0"
+        - column: use_root
+          value:
+            str: "false"
+        - column: has_securebuild_edits
+          value:
+            str: "false"
+        - column: bootstrap_enabled
+          value:
+            str: "false"

--- a/integration/worker/buildqueue/testdata/seed-data/package.yaml
+++ b/integration/worker/buildqueue/testdata/seed-data/package.yaml
@@ -1,0 +1,36 @@
+database: securebuild
+name: package
+seedData:
+  rows:
+    - columns:
+        - column: id
+          value:
+            str: "pkg-bq-ok"
+        - column: name
+          value:
+            str: "bq-ok-package"
+        - column: created_at
+          value:
+            str: "2025-01-07T00:00:00Z"
+        - column: updated_at
+          value:
+            str: "2025-01-07T00:00:00Z"
+        - column: is_delete_protection_enabled
+          value:
+            str: "false"
+    - columns:
+        - column: id
+          value:
+            str: "pkg-bq-fail"
+        - column: name
+          value:
+            str: "bq-fail-package"
+        - column: created_at
+          value:
+            str: "2025-01-07T00:00:00Z"
+        - column: updated_at
+          value:
+            str: "2025-01-07T00:00:00Z"
+        - column: is_delete_protection_enabled
+          value:
+            str: "false"

--- a/integration/worker/buildqueue/testdata/seed-data/rebuild-chain-link.yaml
+++ b/integration/worker/buildqueue/testdata/seed-data/rebuild-chain-link.yaml
@@ -1,0 +1,27 @@
+database: securebuild
+name: rebuild_chain_link
+requires:
+  - rebuild_chain
+  - package
+seedData:
+  rows:
+    - columns:
+        - column: link_id
+          value:
+            str: "rcl-bq-ok"
+        - column: rebuild_chain_id
+          value:
+            str: "rc-bq-test-1"
+        - column: package_id
+          value:
+            str: "pkg-bq-ok"
+    - columns:
+        - column: link_id
+          value:
+            str: "rcl-bq-fail"
+        - column: rebuild_chain_id
+          value:
+            str: "rc-bq-test-1"
+        - column: package_id
+          value:
+            str: "pkg-bq-fail"

--- a/integration/worker/buildqueue/testdata/seed-data/rebuild-chain.yaml
+++ b/integration/worker/buildqueue/testdata/seed-data/rebuild-chain.yaml
@@ -1,0 +1,19 @@
+database: securebuild
+name: rebuild_chain
+requires:
+  - package
+seedData:
+  rows:
+    - columns:
+        - column: id
+          value:
+            str: "rc-bq-test-1"
+        - column: package_id
+          value:
+            str: "pkg-bq-ok"
+        - column: created_at
+          value:
+            str: "2025-01-07T00:00:00Z"
+        - column: chain_name
+          value:
+            str: "bq-test-chain"

--- a/pkg/buildqueue/buildqueue.go
+++ b/pkg/buildqueue/buildqueue.go
@@ -21,24 +21,29 @@ func ProcessRebuildChains(ctx context.Context) error {
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
+	// Optimized: use NOT EXISTS for "no execution" (avoids large join) and a single
+	// CTE for latest execution per cause_id. EXPLAIN ANALYZE showed the previous
+	// inline ROW_NUMBER() subquery was executed ~14k times (once per candidate link),
+	// each doing a full execution scan+sort — moving it to a CTE runs it once.
+	// Index execution_cause_id_created_at_idx makes the CTE efficient.
 	query := `
+		WITH latest_execution AS (
+			SELECT DISTINCT ON (cause_id) cause_id, status
+			FROM execution
+			ORDER BY cause_id, created_at DESC
+		)
 		SELECT p.name, p.id, rcl.link_id, rc.chain_name
 		FROM rebuild_chain_link rcl
 		JOIN package p ON rcl.package_id = p.id
 		JOIN rebuild_chain rc ON rcl.rebuild_chain_id = rc.id
-		LEFT JOIN execution e ON rcl.link_id = e.cause_id
-		WHERE e.status IS NULL
+		WHERE NOT EXISTS (SELECT 1 FROM execution e WHERE e.cause_id = rcl.link_id)
 		AND NOT EXISTS (
 			SELECT 1
 			FROM rebuild_chain_dependency rcd
 			JOIN rebuild_chain_link dep_rcl ON rcd.dependency_id = dep_rcl.link_id
-			LEFT JOIN (
-				SELECT cause_id, status,
-					   ROW_NUMBER() OVER (PARTITION BY cause_id ORDER BY created_at DESC) as rn
-				FROM execution
-			) latest_dep_e ON dep_rcl.link_id = latest_dep_e.cause_id AND latest_dep_e.rn = 1
+			LEFT JOIN latest_execution le ON dep_rcl.link_id = le.cause_id
 			WHERE rcd.link_id = rcl.link_id
-			AND (latest_dep_e.status IS NULL OR latest_dep_e.status != 'success')
+			AND (le.status IS NULL OR le.status != 'success')
 		)
 	`
 

--- a/pkg/buildqueue/buildqueue.go
+++ b/pkg/buildqueue/buildqueue.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/securebuildhq/securebuild/pkg/execution"
+	executiontypes "github.com/securebuildhq/securebuild/pkg/execution/types"
 	"github.com/securebuildhq/securebuild/pkg/listener"
 	"github.com/securebuildhq/securebuild/pkg/logger"
 	sbpackage "github.com/securebuildhq/securebuild/pkg/package"
@@ -14,7 +15,12 @@ import (
 	"go.uber.org/zap"
 )
 
-func processBuildQueueItem(ctx context.Context, conn *pgxpool.Conn) (bool, error) {
+// ProcessRebuildChains processes all ready rebuild chain links in one pass.
+// It returns only an error (e.g. query failure); per-link failures are logged and processing continues.
+func ProcessRebuildChains(ctx context.Context) error {
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+
 	query := `
 		SELECT p.name, p.id, rcl.link_id, rc.chain_name
 		FROM rebuild_chain_link rcl
@@ -34,37 +40,40 @@ func processBuildQueueItem(ctx context.Context, conn *pgxpool.Conn) (bool, error
 			WHERE rcd.link_id = rcl.link_id
 			AND (latest_dep_e.status IS NULL OR latest_dep_e.status != 'success')
 		)
-		LIMIT 1
 	`
 
 	rows, err := conn.Query(ctx, query)
 	if err != nil {
-		return false, fmt.Errorf("failed to query rebuild chain links: %w", err)
+		return fmt.Errorf("failed to query rebuild chain links: %w", err)
 	}
-
-	var packageName, packageID, linkID, chainName string
-	var hasResult bool
+	defer rows.Close()
 
 	for rows.Next() {
+		var packageName, packageID, linkID, chainName string
 		if err := rows.Scan(&packageName, &packageID, &linkID, &chainName); err != nil {
-			rows.Close()
-			return false, fmt.Errorf("failed to scan package data: %w", err)
+			return fmt.Errorf("failed to scan package data: %w", err)
 		}
-		hasResult = true
-		break // Only process the first result since we have LIMIT 1
-	}
-	rows.Close()
 
-	if hasResult {
 		logger.Info("building package for rebuild chain",
 			zap.String("chainName", chainName),
 			zap.String("packageName", packageName),
 			zap.String("packageId", packageID))
 
-		// Increment epoch for the package before building
 		newPackageVersion, err := sbpackage.CreateNewReleaseForLatestPackageVersion(ctx, packageID, "", "")
 		if err != nil {
-			return false, fmt.Errorf("failed to increment epoch for package %s: %w", packageName, err)
+			// Record a failed execution for this link so the queue won't keep returning it.
+			if recordErr := recordFailedExecutionForLink(ctx, packageID, linkID, chainName); recordErr != nil {
+				logger.Error(fmt.Errorf("failed to record failed execution for link; queue may retry same package: %w", recordErr),
+					zap.String("linkId", linkID),
+					zap.String("packageName", packageName))
+			} else {
+				logger.Warn("increment epoch failed for rebuild chain link; recorded failed execution so queue can progress",
+					zap.String("chainName", chainName),
+					zap.String("packageName", packageName),
+					zap.String("linkId", linkID),
+					zap.Error(err))
+			}
+			continue
 		}
 
 		logger.Info("incremented epoch for package",
@@ -72,7 +81,6 @@ func processBuildQueueItem(ctx context.Context, conn *pgxpool.Conn) (bool, error
 			zap.String("packageVersionId", newPackageVersion.ID),
 			zap.Int("newEpoch", newPackageVersion.APKRelease))
 
-		// Create payload for HandleBuildPackage
 		payload := listener.BuildPackagePayload{
 			PackageID:        packageID,
 			PackageVersionID: newPackageVersion.ID,
@@ -82,35 +90,46 @@ func processBuildQueueItem(ctx context.Context, conn *pgxpool.Conn) (bool, error
 
 		payloadBytes, err := json.Marshal(payload)
 		if err != nil {
-			return false, fmt.Errorf("failed to marshal build package payload: %w", err)
+			return fmt.Errorf("failed to marshal build package payload: %w", err)
 		}
 
-		// Call HandleBuildPackage directly to avoid potentially duplicating the execution
 		err = listener.HandleBuildPackage(ctx, string(payloadBytes))
 		if err != nil {
-			return false, fmt.Errorf("failed to handle build package: %w", err)
+			logger.Error(fmt.Errorf("failed to handle build package: %w", err),
+				zap.String("chainName", chainName),
+				zap.String("packageName", packageName),
+				zap.String("linkId", linkID))
+			continue
 		}
 	}
 
-	return hasResult, nil
+	return nil
+}
+
+// recordFailedExecutionForLink creates an execution record with status failed for the given
+// rebuild chain link. This ensures the queue query (which only returns links with no execution)
+// will not keep returning this link, so other packages in the chain can progress.
+func recordFailedExecutionForLink(ctx context.Context, packageID, linkID, chainName string) error {
+	pkgVersion, err := sbpackage.GetLatestPackageVersion(ctx, packageID)
+	if err != nil {
+		return fmt.Errorf("get latest package version: %w", err)
+	}
+	cause := fmt.Sprintf("rebuild chain for %s", chainName)
+	exe, err := execution.CreateExecution(ctx, packageID, pkgVersion, cause, linkID)
+	if err != nil {
+		return fmt.Errorf("create execution: %w", err)
+	}
+	if err := execution.UpdateExecutionStatus(ctx, exe.ID, executiontypes.ExecutionStatusFailed); err != nil {
+		return fmt.Errorf("update execution status to failed: %w", err)
+	}
+	return nil
 }
 
 func StartBuildQueue(ctx context.Context) error {
-	conn := persistence.MustGetPooledPostgresSession(ctx)
-	defer conn.Release()
-
 	for {
-		hasResult, err := processBuildQueueItem(ctx, conn)
-		if err != nil {
-			logger.Error(fmt.Errorf("failed to process build queue item: %w", err))
-			// Continue processing instead of exiting
-			time.Sleep(time.Second * 5)
-			continue
+		if err := ProcessRebuildChains(ctx); err != nil {
+			logger.Error(fmt.Errorf("failed to process build queue: %w", err))
 		}
-
-		if !hasResult {
-			// if we didn't find any packages to build, sleep for 10 seconds
-			time.Sleep(time.Second * 10)
-		}
+		time.Sleep(time.Second * 10)
 	}
 }

--- a/pkg/package/package.go
+++ b/pkg/package/package.go
@@ -522,7 +522,11 @@ func GetLatestPackageVersion(ctx context.Context, packageID string) (*types.Pack
 
 	// If we found a valid semver version, use it
 	if latestID != "" {
-		return getPackageVersion(ctx, latestID)
+		pv, err := getPackageVersion(ctx, latestID)
+		if err != nil {
+			return nil, fmt.Errorf("get package version: %w", err)
+		}
+		return pv, nil
 	}
 
 	// Fall back to lexicographical comparison if no valid semver versions exist
@@ -531,7 +535,11 @@ func GetLatestPackageVersion(ctx context.Context, packageID string) (*types.Pack
 			zap.String("package_id", packageID),
 			zap.String("fallback_version_id", fallbackID),
 			zap.String("fallback_version", fallbackVersion))
-		return getPackageVersion(ctx, fallbackID)
+		pv, err := getPackageVersion(ctx, fallbackID)
+		if err != nil {
+			return nil, fmt.Errorf("get fallback package version: %w", err)
+		}
+		return pv, nil
 	}
 
 	return nil, fmt.Errorf("no versions found for package %s", packageID)


### PR DESCRIPTION
- Rebuild chains now process all package versions instead of failing on the first one.
- Add integration test
- Optimize the rebuild chain query


Second commit reduces query time from 48 seconds to 40ms


```
114c112
< Time: 48486.144 ms (00:48.486)
---
> Time: 40.586 ms
```

Slow vs fast analyze results (this did not use the new index in either case):

```                                                                                                QUERY PLAN                                                                                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=2281.36..3767.11 rows=1 width=157) (actual time=12642.893..55467.150 rows=89 loops=1)
   Buffers: shared hit=18859964 read=100
   ->  Nested Loop  (cost=2281.09..3766.82 rows=1 width=212) (actual time=9103.583..55466.364 rows=91 loops=1)
         Buffers: shared hit=18859694 read=99
         ->  Nested Loop Anti Join  (cost=2280.68..3766.24 rows=1 width=193) (actual time=80.536..55462.979 rows=186 loops=1)
               Buffers: shared hit=18859113 read=31
               ->  Hash Right Join  (cost=720.35..2103.22 rows=1 width=193) (actual time=9.297..16.948 rows=14031 loops=1)
                     Hash Cond: (e.cause_id = rcl.link_id)
                     Filter: (e.status IS NULL)
                     Rows Removed by Filter: 143
                     Buffers: shared hit=1745
                     ->  Seq Scan on execution e  (cost=0.00..1374.58 rows=3158 width=18) (actual time=0.005..2.485 rows=3158 loops=1)
                           Buffers: shared hit=1343
                     ->  Hash  (cost=543.49..543.49 rows=14149 width=193) (actual time=6.432..6.433 rows=14169 loops=1)
                           Buckets: 16384  Batches: 1  Memory Usage: 3250kB
                           Buffers: shared hit=402
                           ->  Seq Scan on rebuild_chain_link rcl  (cost=0.00..543.49 rows=14149 width=193) (actual time=0.014..2.960 rows=14169 loops=1)
                                 Buffers: shared hit=402
               ->  Hash Right Join  (cost=1560.32..1663.01 rows=1 width=65) (actual time=3.948..3.948 rows=1 loops=14031)
                     Hash Cond: (latest_dep_e.cause_id = dep_rcl.link_id)
                     Filter: ((latest_dep_e.status IS NULL) OR (latest_dep_e.status <> 'success'::text))
                     Rows Removed by Filter: 0
                     Buffers: shared hit=18857368 read=31
                     ->  Subquery Scan on latest_dep_e  (cost=1558.16..1660.77 rows=16 width=18) (actual time=3.348..3.911 rows=388 loops=13928)
                           Filter: (latest_dep_e.rn = 1)
                           Buffers: shared hit=18705304
                           ->  WindowAgg  (cost=1558.16..1621.30 rows=3158 width=34) (actual time=3.348..3.876 rows=388 loops=13928)
                                 Run Condition: (row_number() OVER (?) <= 1)
                                 Buffers: shared hit=18705304
                                 ->  Sort  (cost=1558.14..1566.03 rows=3158 width=26) (actual time=3.346..3.497 rows=3134 loops=13928)
                                       Sort Key: execution.cause_id, execution.created_at DESC
                                       Sort Method: quicksort  Memory: 246kB
                                       Buffers: shared hit=18705304
                                       ->  Seq Scan on execution  (cost=0.00..1374.58 rows=3158 width=26) (actual time=0.002..1.128 rows=3158 loops=13928)
                                             Buffers: shared hit=18705304
                     ->  Hash  (cost=2.13..2.13 rows=3 width=130) (actual time=0.023..0.023 rows=2 loops=14031)
                           Buckets: 1024  Batches: 1  Memory Usage: 17kB
                           Buffers: shared hit=152064 read=31
                           ->  Nested Loop  (cost=0.82..2.13 rows=3 width=130) (actual time=0.014..0.022 rows=2 loops=14031)
                                 Buffers: shared hit=152064 read=31
                                 ->  Index Only Scan using rebuild_chain_dependency_pkey on rebuild_chain_dependency rcd  (cost=0.41..0.75 rows=3 width=130) (actual time=0.008..0.009 rows=2 loops=14031)
                                       Index Cond: (link_id = rcl.link_id)
                                       Heap Fetches: 3111
                                       Buffers: shared hit=45247 read=31
                                 ->  Index Only Scan using rebuild_chain_link_pkey on rebuild_chain_link dep_rcl  (cost=0.41..0.46 rows=1 width=65) (actual time=0.005..0.005 rows=1 loops=34502)
                                       Index Cond: (link_id = rcd.dependency_id)
                                       Heap Fetches: 3310
                                       Buffers: shared hit=106817
         ->  Index Scan using package_pkey on package p  (cost=0.41..0.58 rows=1 width=82) (actual time=0.016..0.016 rows=0 loops=186)
               Index Cond: (id = rcl.package_id)
               Buffers: shared hit=581 read=68
   ->  Index Scan using rebuild_chain_pkey on rebuild_chain rc  (cost=0.27..0.29 rows=1 width=75) (actual time=0.006..0.006 rows=1 loops=91)
         Index Cond: (id = rcl.rebuild_chain_id)
         Buffers: shared hit=270 read=1
 Planning:
   Buffers: shared hit=55 read=8
 Planning Time: 1.218 ms
 Execution Time: 55467.259 ms
(58 rows)

Time: 55469.616 ms (00:55.470)
```

```
 Hash Join  (cost=3032.19..5481.87 rows=880 width=157) (actual time=62.538..64.147 rows=89 loops=1)
   Hash Cond: (rcl.rebuild_chain_id = rc.id)
   Buffers: shared hit=3232 read=719
   ->  Nested Loop  (cost=3024.08..5471.39 rows=880 width=212) (actual time=62.226..63.929 rows=91 loops=1)
         Buffers: shared hit=3227 read=719
         ->  Nested Loop Anti Join  (cost=3023.66..4977.33 rows=880 width=193) (actual time=61.937..62.782 rows=186 loops=1)
               Buffers: shared hit=2828 read=650
               ->  Hash Right Anti Join  (cost=3023.38..4704.47 rows=905 width=193) (actual time=61.906..62.218 rows=299 loops=1)
                     Hash Cond: (rcd.link_id = rcl.link_id)
                     Buffers: shared hit=2217 read=642
                     ->  Hash Left Join  (cost=2303.03..3535.92 rows=34375 width=65) (actual time=20.085..39.570 rows=34410 loops=1)
                           Hash Cond: (dep_rcl.link_id = le.cause_id)
                           Filter: ((le.status IS NULL) OR (le.status <> 'success'::text))
                           Rows Removed by Filter: 172
                           Buffers: shared hit=1815 read=642
                           ->  Hash Join  (cost=720.35..1862.53 rows=34547 width=130) (actual time=9.374..23.176 rows=34582 loops=1)
                                 Hash Cond: (rcd.dependency_id = dep_rcl.link_id)
                                 Buffers: shared hit=466 read=642
                                 ->  Seq Scan on rebuild_chain_dependency rcd  (cost=0.00..1051.47 rows=34547 width=130) (actual time=0.026..5.477 rows=34582 loops=1)
                                       Buffers: shared hit=64 read=642
                                 ->  Hash  (cost=543.49..543.49 rows=14149 width=65) (actual time=9.142..9.143 rows=14169 loops=1)
                                       Buckets: 16384  Batches: 1  Memory Usage: 1471kB
                                       Buffers: shared hit=402
                                       ->  Seq Scan on rebuild_chain_link dep_rcl  (cost=0.00..543.49 rows=14149 width=65) (actual time=0.013..2.586 rows=14169 loops=1)
                                             Buffers: shared hit=402
                           ->  Hash  (cost=1577.82..1577.82 rows=389 width=18) (actual time=10.679..10.680 rows=389 loops=1)
                                 Buckets: 1024  Batches: 1  Memory Usage: 40kB
                                 Buffers: shared hit=1349
                                 ->  Subquery Scan on le  (cost=1558.14..1577.82 rows=389 width=18) (actual time=9.869..10.568 rows=390 loops=1)
                                       Buffers: shared hit=1349
                                       ->  Unique  (cost=1558.14..1573.93 rows=389 width=26) (actual time=9.868..10.506 rows=390 loops=1)
                                             Buffers: shared hit=1349
                                             ->  Sort  (cost=1558.14..1566.03 rows=3158 width=26) (actual time=9.867..10.100 rows=3158 loops=1)
                                                   Sort Key: execution.cause_id, execution.created_at DESC
                                                   Sort Method: quicksort  Memory: 238kB
                                                   Buffers: shared hit=1349
                                                   ->  Seq Scan on execution  (cost=0.00..1374.58 rows=3158 width=26) (actual time=0.010..5.622 rows=3158 loops=1)
                                                         Buffers: shared hit=1343
                     ->  Hash  (cost=543.49..543.49 rows=14149 width=193) (actual time=14.538..14.538 rows=14169 loops=1)
                           Buckets: 16384  Batches: 1  Memory Usage: 3250kB
                           Buffers: shared hit=402
                           ->  Seq Scan on rebuild_chain_link rcl  (cost=0.00..543.49 rows=14149 width=193) (actual time=0.029..5.345 rows=14169 loops=1)
                                 Buffers: shared hit=402
               ->  Index Only Scan using execution_cause_id_idx on execution e  (cost=0.28..0.44 rows=8 width=11) (actual time=0.002..0.002 rows=0 loops=299)
                     Index Cond: (cause_id = rcl.link_id)
                     Heap Fetches: 20
                     Buffers: shared hit=611 read=8
         ->  Memoize  (cost=0.42..0.59 rows=1 width=82) (actual time=0.006..0.006 rows=0 loops=186)
               Cache Key: rcl.package_id
               Cache Mode: logical
               Hits: 54  Misses: 132  Evictions: 0  Overflows: 0  Memory Usage: 24kB
               Buffers: shared hit=399 read=69
               ->  Index Scan using package_pkey on package p  (cost=0.41..0.58 rows=1 width=82) (actual time=0.008..0.008 rows=1 loops=132)
                     Index Cond: (id = rcl.package_id)
                     Buffers: shared hit=399 read=69
   ->  Hash  (cost=6.38..6.38 rows=138 width=75) (actual time=0.148..0.149 rows=159 loops=1)
         Buckets: 1024  Batches: 1  Memory Usage: 25kB
         Buffers: shared hit=5
         ->  Seq Scan on rebuild_chain rc  (cost=0.00..6.38 rows=138 width=75) (actual time=0.011..0.055 rows=159 loops=1)
               Buffers: shared hit=5
 Planning:
   Buffers: shared hit=320 read=29 dirtied=1
 Planning Time: 4.047 ms
 Execution Time: 64.492 ms
(64 rows)

Time: 71.105 ms

```