### PR TITLE
Fix grype-db install path in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -215,7 +215,7 @@
               # Install grype-db if not already installed
               if ! command -v grype-db &> /dev/null; then
                 echo "📦 Installing grype-db..."
-                GOBIN=$GOBIN go install github.com/anchore/grype-db@latest
+                GOBIN=$GOBIN go install github.com/anchore/grype-db/cmd/grype-db@latest
               fi
               
               # Helper function to check and display tool status


### PR DESCRIPTION
## Summary
- `go install github.com/anchore/grype-db@latest` fails because the main package is in the `cmd/grype-db` subdirectory, not the module root
- Fix by using the correct path: `github.com/anchore/grype-db/cmd/grype-db@latest`

## Test plan
- [ ] Run `nix develop` and verify grype-db installs successfully
- [ ] Confirm `grype-db version` works after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)