### PR TITLE
Add default for new column since there is data in that table

### DIFF
--- a/db/schema/tables/machine-pool.yaml
+++ b/db/schema/tables/machine-pool.yaml
@@ -55,3 +55,4 @@ schema:
       type: text
       constraints:
         notNull: true
+      default: "cmx"


### PR DESCRIPTION
fixes

```
Executing query "alter table \"machine_pool\" add column \"type\" text not null;"
failed to apply commands: ERROR: column "type" of relation "machine_pool" contains null values (SQLSTATE 23502)
```