### PR TITLE
Run vunnel in container instead of on host

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thank you for your interest in contributing to SecureBuild! Please review our [C
 
 ## Development Setup
 
-The project uses a **Nix flake** for the development environment (Go, Node, SchemaHero, apko, melange, syft, Dagger, vunnel, etc.).
+The project uses a **Nix flake** for the development environment (Go, Node, SchemaHero, apko, melange, syft, Dagger, etc.). Vunnel runs via Docker in dev and production rather than being installed in the dev shell.
 
 ### Prerequisites
 

--- a/flake.nix
+++ b/flake.nix
@@ -180,7 +180,6 @@
               pkgs.docker
               pkgs.git
               pkgs.postgresql  # Provides pg_isready
-              pkgs.pipx        # For installing Python CLI tools like vunnel
               pkgs.grype
               apko
               melange
@@ -195,22 +194,14 @@
             ];
 
             shellHook = ''
-              # Ensure pipx and go install paths are available
-              export PIPX_HOME="$HOME/.local/pipx"
-              export PIPX_BIN_DIR="$HOME/.local/bin"
+              # Ensure go install path is available
               export GOBIN="$HOME/go/bin"
-              
+
               # Create directories if they don't exist
-              mkdir -p "$PIPX_BIN_DIR" "$GOBIN"
-              
+              mkdir -p "$GOBIN"
+
               # Prepend to PATH
-              export PATH="$PIPX_BIN_DIR:$GOBIN:$PATH"
-              
-              # Install vunnel if not already installed
-              if ! command -v vunnel &> /dev/null; then
-                echo "📦 Installing vunnel..."
-                pipx install vunnel
-              fi
+              export PATH="$GOBIN:$PATH"
               
               # Install grype-db if not already installed
               if ! command -v grype-db &> /dev/null; then
@@ -247,11 +238,7 @@
               else
                 echo "❌ Grype-DB failed"
               fi
-              if vunnel_version=$(vunnel --version 2>&1); then
-                echo "✅ Vunnel $vunnel_version"
-              else
-                echo "❌ Vunnel failed"
-              fi
+              echo "ℹ️  Vunnel runs in container (ghcr.io/anchore/vunnel)"
             '' + pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
               if colima_version=$(colima version 2>&1 | head -n1); then
                 echo "✅ Colima $colima_version"

--- a/pkg/param/param.go
+++ b/pkg/param/param.go
@@ -111,7 +111,8 @@ type Param struct {
 	LogLevel string `yaml:"log_level"`
 
 	// Vulnerability Database Configuration
-	GrypeDBRoot string `yaml:"grype_database_root"`
+	GrypeDBRoot  string `yaml:"grype_database_root"`
+	VunnelImage  string `yaml:"vunnel_image"`
 
 	// PProf Configuration
 	PProfEnabled bool `yaml:"pprof_enabled"`

--- a/pkg/scan/db_updater.go
+++ b/pkg/scan/db_updater.go
@@ -87,17 +87,16 @@ func updateDatabase(ctx context.Context, grypeDBRoot string) error {
 	logger.Info("Starting vulnerability database update")
 
 	dataDir := filepath.Join(grypeDBRoot, "data")
-	vunnelConfig := filepath.Join(grypeDBRoot, "vunnel.yaml")
 
 	// Step 1: Run vunnel for NVD provider
 	logger.Info("Running vunnel for NVD provider")
-	if err := runVunnel(ctx, grypeDBRoot, vunnelConfig, "nvd"); err != nil {
+	if err := runVunnel(ctx, grypeDBRoot, "nvd"); err != nil {
 		return fmt.Errorf("vunnel nvd failed: %w", err)
 	}
 
 	// Step 2: Run vunnel for GitHub provider
 	logger.Info("Running vunnel for GitHub provider")
-	if err := runVunnel(ctx, grypeDBRoot, vunnelConfig, "github"); err != nil {
+	if err := runVunnel(ctx, grypeDBRoot, "github"); err != nil {
 		return fmt.Errorf("vunnel github failed: %w", err)
 	}
 
@@ -121,21 +120,44 @@ func updateDatabase(ctx context.Context, grypeDBRoot string) error {
 	return nil
 }
 
-// runVunnel executes vunnel for a specific provider
-func runVunnel(ctx context.Context, grypeDBRoot, configPath, provider string) error {
-	cmd := exec.CommandContext(ctx, "vunnel",
-		"--config", configPath,
+// defaultVunnelImage is the default container image used to run vunnel.
+// Override via the VUNNEL_IMAGE param to pin a different version.
+const defaultVunnelImage = "ghcr.io/anchore/vunnel:v0.55.3"
+
+// runVunnel executes vunnel for a specific provider inside a container.
+// The grypeDBRoot directory is mounted into the container so vunnel can
+// read its config and write provider data.
+func runVunnel(ctx context.Context, grypeDBRoot, provider string) error {
+	image := param.GetParam(ctx).VunnelImage
+	if image == "" {
+		image = defaultVunnelImage
+	}
+
+	// Mount the entire grypeDBRoot as /data inside the container.
+	// The config file path needs to be translated to the container path.
+	containerDataDir := "/data"
+	containerConfigPath := containerDataDir + "/vunnel.yaml"
+
+	// Use a static container name per provider to ensure only one instance
+	// runs at a time. If a previous run is still active, docker will refuse
+	// to start a second container with the same name.
+	containerName := "vunnel-" + provider
+
+	cmd := exec.CommandContext(ctx, "docker", "run",
+		"--rm",
+		"--name", containerName,
+		"-v", grypeDBRoot+":"+containerDataDir,
+		image,
+		"--config", containerConfigPath,
 		"run",
 		provider,
 	)
 
-	// Set working directory to the grypeDBRoot directory
-	cmd.Dir = grypeDBRoot
-
-	logger.Info("running vunnel command",
-		zap.String("command", cmd.String()),
+	logger.Info("running vunnel in container",
+		zap.String("image", image),
+		zap.String("container", containerName),
 		zap.String("provider", provider),
-		zap.String("working_dir", grypeDBRoot))
+		zap.String("mount", grypeDBRoot+":"+containerDataDir))
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Run vunnel via `docker run ghcr.io/anchore/vunnel:v0.55.3` instead of expecting it on the host PATH
- Removes Python version dependency that was blocking upgrades past v0.44.0 (latest vunnel requires Python >=3.13)
- Adds `VUNNEL_IMAGE` config param to control the image version without code changes
- Uses static container names (`vunnel-nvd`, `vunnel-github`) to prevent concurrent runs
- Removes pipx from nix dev shell (was only needed for vunnel)

## Test plan
- [ ] Deploy to dev and verify the hourly vunnel update cycle completes successfully
- [ ] Confirm `vunnel.yaml` config is read correctly from the mounted volume
- [ ] Verify data files are written to `grypeDBRoot/data/` as before
- [ ] Test `VUNNEL_IMAGE` override with a different tag
- [ ] Confirm Docker rejects a second run while one is in progress (static name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)