### PR TITLE
Fix vunnel writing data outside container bind mount

### DIFF
--- a/pkg/scan/db_updater.go
+++ b/pkg/scan/db_updater.go
@@ -147,6 +147,7 @@ func runVunnel(ctx context.Context, grypeDBRoot, provider string) error {
 		"--rm",
 		"--name", containerName,
 		"-v", grypeDBRoot+":"+containerDataDir,
+		"-e", "VUNNEL_ROOT="+containerDataDir+"/data",
 		image,
 		"--config", containerConfigPath,
 		"run",


### PR DESCRIPTION
## Summary
- Vunnel's `root` config in `vunnel.yaml` uses a host path (`/var/lib/securebuild/grype/data`) that doesn't exist inside the Docker container, causing provider data to be written to the container's ephemeral filesystem instead of through the bind mount
- Added `VUNNEL_ROOT` env var override to the `docker run` command so vunnel writes to `/data/data` inside the container, which maps to `grypeDBRoot/data/` on the host where `grype-db build -d data` expects it

## Test plan
- [ ] Verify vunnel container writes NVD/GitHub provider data into `grypeDBRoot/data/` on host
- [ ] Verify `grype-db build -d data` finds the vunnel output and builds the database successfully
- [ ] Verify full `updateDatabase` pipeline completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)