### PR TITLE
Fix undici CVEs by updating testcontainers to v11

### DIFF
--- a/securebuild-app/package-lock.json
+++ b/securebuild-app/package-lock.json
@@ -102,7 +102,7 @@
         "lightningcss": "^1.29.2",
         "postcss": "^8",
         "tailwindcss": "^4.1.18",
-        "testcontainers": "^10.2.0",
+        "testcontainers": "^11.13.0",
         "ts-jest": "^29.4.6",
         "typescript": "5.9.3"
       },
@@ -895,16 +895,6 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -4638,83 +4628,6 @@
         "testcontainers": "^11.13.0"
       }
     },
-    "node_modules/@testcontainers/postgresql/node_modules/@types/dockerode": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-4.0.1.tgz",
-      "integrity": "sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/docker-modem": "*",
-        "@types/node": "*",
-        "@types/ssh2": "*"
-      }
-    },
-    "node_modules/@testcontainers/postgresql/node_modules/docker-compose": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.3.2.tgz",
-      "integrity": "sha512-FO/Jemn08gf9o9E6qtqOPQpyauwf2rQAzfpoUlMyqNpdaVb0ImR/wXKoutLZKp1tks58F8Z8iR7va7H1ne09cw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yaml": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@testcontainers/postgresql/node_modules/properties-reader": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-3.0.1.tgz",
-      "integrity": "sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@kwsites/file-exists": "^1.1.1",
-        "mkdirp": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/steveukx/properties?sponsor=1"
-      }
-    },
-    "node_modules/@testcontainers/postgresql/node_modules/testcontainers": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-11.13.0.tgz",
-      "integrity": "sha512-fzTvgOtd6U/esOzgmDatJh79OSK0tU6vjDOJ3B6ICrrJf0dqCWtFdpOr6f/g/KixMxKDTDbszmZYjSORJXsVCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@balena/dockerignore": "^1.0.2",
-        "@types/dockerode": "^4.0.1",
-        "archiver": "^7.0.1",
-        "async-lock": "^1.4.1",
-        "byline": "^5.0.0",
-        "debug": "^4.4.3",
-        "docker-compose": "^1.3.2",
-        "dockerode": "^4.0.9",
-        "get-port": "^7.1.0",
-        "proper-lockfile": "^4.1.2",
-        "properties-reader": "^3.0.1",
-        "ssh-remote-port-forward": "^1.0.4",
-        "tar-fs": "^3.1.2",
-        "tmp": "^0.2.5",
-        "undici": "^7.24.3"
-      }
-    },
-    "node_modules/@testcontainers/postgresql/node_modules/undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -4883,9 +4796,9 @@
       }
     },
     "node_modules/@types/dockerode": {
-      "version": "3.3.45",
-      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.45.tgz",
-      "integrity": "sha512-iYpZF+xr5QLpIICejLdUF2r5gh8IXY1Gw3WLmt41dUbS3Vn/3hVgL+6lJBVbmrhYBWfbWPPstdr6+A0s95DTWA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-4.0.1.tgz",
+      "integrity": "sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6783,9 +6696,9 @@
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/docker-compose": {
-      "version": "0.24.8",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
-      "integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.3.2.tgz",
+      "integrity": "sha512-FO/Jemn08gf9o9E6qtqOPQpyauwf2rQAzfpoUlMyqNpdaVb0ImR/wXKoutLZKp1tks58F8Z8iR7va7H1ne09cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9636,33 +9549,21 @@
       "license": "ISC"
     },
     "node_modules/properties-reader": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-2.3.0.tgz",
-      "integrity": "sha512-z597WicA7nDZxK12kZqHr2TcvwNU1GCfA5UwfDY/HDp3hXPoPlb5rlEx9bwGTiJnc0OqbBTkU975jDToth8Gxw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-3.0.1.tgz",
+      "integrity": "sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mkdirp": "^1.0.4"
+        "@kwsites/file-exists": "^1.1.1",
+        "mkdirp": "^3.0.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/steveukx/properties?sponsor=1"
-      }
-    },
-    "node_modules/properties-reader/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/protobufjs": {
@@ -10644,27 +10545,27 @@
       }
     },
     "node_modules/testcontainers": {
-      "version": "10.28.0",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-10.28.0.tgz",
-      "integrity": "sha512-1fKrRRCsgAQNkarjHCMKzBKXSJFmzNTiTbhb5E/j5hflRXChEtHvkefjaHlgkNUjfw92/Dq8LTgwQn6RDBFbMg==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-11.13.0.tgz",
+      "integrity": "sha512-fzTvgOtd6U/esOzgmDatJh79OSK0tU6vjDOJ3B6ICrrJf0dqCWtFdpOr6f/g/KixMxKDTDbszmZYjSORJXsVCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
-        "@types/dockerode": "^3.3.35",
+        "@types/dockerode": "^4.0.1",
         "archiver": "^7.0.1",
         "async-lock": "^1.4.1",
         "byline": "^5.0.0",
-        "debug": "^4.3.5",
-        "docker-compose": "^0.24.8",
-        "dockerode": "^4.0.5",
+        "debug": "^4.4.3",
+        "docker-compose": "^1.3.2",
+        "dockerode": "^4.0.9",
         "get-port": "^7.1.0",
         "proper-lockfile": "^4.1.2",
-        "properties-reader": "^2.3.0",
+        "properties-reader": "^3.0.1",
         "ssh-remote-port-forward": "^1.0.4",
-        "tar-fs": "^3.0.7",
-        "tmp": "^0.2.3",
-        "undici": "^5.29.0"
+        "tar-fs": "^3.1.2",
+        "tmp": "^0.2.5",
+        "undici": "^7.24.3"
       }
     },
     "node_modules/text-decoder": {
@@ -10826,16 +10727,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -11230,15 +11128,19 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/securebuild-app/package.json
+++ b/securebuild-app/package.json
@@ -110,7 +110,7 @@
     "lightningcss": "^1.29.2",
     "postcss": "^8",
     "tailwindcss": "^4.1.18",
-    "testcontainers": "^10.2.0",
+    "testcontainers": "^11.13.0",
     "ts-jest": "^29.4.6",
     "typescript": "5.9.3"
   },


### PR DESCRIPTION
## Summary
- Updates `testcontainers` from `^10.2.0` to `^11.13.0` in securebuild-app
- This bumps transitive `undici` dependency from 5.29.0 to 7.24.6
- Resolves Dependabot alert #31 (HTTP Request/Response Smuggling) and #43 (CRLF Injection via `upgrade` option), both requiring undici >= 6.24.0

## Test plan
- [ ] Verify `npm audit` no longer reports undici vulnerabilities
- [ ] Run integration tests (`npm run test:integration`) to confirm testcontainers v11 compatibility
- [ ] Verify Dependabot alerts #31 and #43 are auto-closed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)