### PR TITLE
Include apkoVersionId in GET /api/image-apko response

### DIFF
--- a/securebuild-app/app/api/image-apko/route.ts
+++ b/securebuild-app/app/api/image-apko/route.ts
@@ -6,6 +6,7 @@ import { ValidationError } from '@/lib/errors/validation-error'
 
 interface ApkoResponse {
   apkoId: string
+  apkoVersionId: string
   apkoYamlBase64: string
 }
 
@@ -53,6 +54,7 @@ export async function GET(request: NextRequest) {
 
     const response: ApkoResponse = {
       apkoId: result.apkoId,
+      apkoVersionId: result.apkoVersionId,
       apkoYamlBase64: Buffer.from(result.apkoYaml).toString('base64')
     }
 

--- a/securebuild-app/lib/image/apko.ts
+++ b/securebuild-app/lib/image/apko.ts
@@ -7,6 +7,7 @@ import { getImageTestForLatestVersion, createOrUpdateImageTest } from "./image-t
 
 interface ApkoVersion {
   apkoId: string
+  apkoVersionId: string
   apkoYaml: string
 }
 
@@ -35,7 +36,7 @@ export async function getLatestImageApkoYaml(imageName: string, imageTag: string
 
     // Now get the latest APKO YAML for this image_apko_id
     const versionQuery = `
-      SELECT apko_yaml, created_at
+      SELECT id, apko_yaml, created_at
       FROM image_apko_version
       WHERE image_apko_id = $1
       ORDER BY created_at DESC
@@ -51,6 +52,7 @@ export async function getLatestImageApkoYaml(imageName: string, imageTag: string
     const row = versionResult.rows[0]
     return {
       apkoId: imageApkoId,
+      apkoVersionId: row.id,
       apkoYaml: row.apko_yaml
     }
 


### PR DESCRIPTION
The version ID was already queried but not returned, making it impossible for API consumers to obtain the apkoVersionId needed by POST /api/image-test.