### PR TITLE
Fix OCI proxy attestation manifest format for cosign compatibility

### DIFF
--- a/pkg/oci/artifact.go
+++ b/pkg/oci/artifact.go
@@ -38,12 +38,40 @@ type ImageCatalogDigestInfo struct {
 	IndexDigest   string
 }
 
+const (
+	// MediaTypeOCIManifest is the standard OCI image manifest v1 media type.
+	MediaTypeOCIManifest = "application/vnd.oci.image.manifest.v1+json"
+	// MediaTypeArtifactManifest is the experimental (withdrawn) artifact manifest media type.
+	MediaTypeArtifactManifest = "application/vnd.oci.artifact.manifest.v1+json"
+	// EmptyConfigMediaType is the OCI empty config descriptor media type.
+	EmptyConfigMediaType = "application/vnd.oci.empty.v1+json"
+	// EmptyConfigDigest is the sha256 digest of "{}".
+	EmptyConfigDigest = "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+	// EmptyConfigSize is the byte size of "{}".
+	EmptyConfigSize = 2
+)
+
+// EmptyConfigBytes is the raw bytes of the OCI empty config.
+var EmptyConfigBytes = []byte("{}")
+
 // OCIArtifactManifest is a minimal struct for application/vnd.oci.artifact.manifest.v1+json
 // See: https://github.com/opencontainers/image-spec/blob/main/artifact.md
 type OCIArtifactManifest struct {
 	SchemaVersion int               `json:"schemaVersion"`
 	MediaType     string            `json:"mediaType"`
 	ArtifactType  string            `json:"artifactType"`
+	Layers        []Descriptor      `json:"layers"`
+	Subject       *Descriptor       `json:"subject,omitempty"`
+	Annotations   map[string]string `json:"annotations,omitempty"`
+}
+
+// OCIImageManifest is an OCI image manifest v1 with artifactType support (OCI v1.1).
+// This is the format that cosign/go-containerregistry can parse.
+type OCIImageManifest struct {
+	SchemaVersion int               `json:"schemaVersion"`
+	MediaType     string            `json:"mediaType"`
+	Config        Descriptor        `json:"config"`
+	ArtifactType  string            `json:"artifactType,omitempty"`
 	Layers        []Descriptor      `json:"layers"`
 	Subject       *Descriptor       `json:"subject,omitempty"`
 	Annotations   map[string]string `json:"annotations,omitempty"`
@@ -56,20 +84,77 @@ type Descriptor struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
-// NewOCIArtifactManifest constructs an OCI artifact manifest and returns its JSON bytes.
+// NewOCIArtifactManifest constructs an OCI image manifest (v1.1 format with artifactType)
+// and returns its JSON bytes. Despite the name, this now produces the standard OCI image
+// manifest format that cosign and go-containerregistry can parse, rather than the
+// experimental artifact manifest format that was never finalized.
 func NewOCIArtifactManifest(subject *Descriptor, artifactType string, layers []Descriptor, annotations map[string]string) ([]byte, error) {
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
-	manifest := OCIArtifactManifest{
+	manifest := OCIImageManifest{
 		SchemaVersion: 2,
-		MediaType:     "application/vnd.oci.artifact.manifest.v1+json",
-		ArtifactType:  artifactType,
-		Layers:        layers,
-		Subject:       subject,
-		Annotations:   annotations,
+		MediaType:     MediaTypeOCIManifest,
+		Config: Descriptor{
+			MediaType: EmptyConfigMediaType,
+			Digest:    EmptyConfigDigest,
+			Size:      EmptyConfigSize,
+		},
+		ArtifactType: artifactType,
+		Layers:       layers,
+		Subject:      subject,
+		Annotations:  annotations,
 	}
 	return json.Marshal(manifest)
+}
+
+// ConvertArtifactToImageManifest converts an old-format artifact manifest to an OCI image
+// manifest (v1.1). Returns the converted bytes and its digest. If the manifest is already
+// in image manifest format, it is returned unchanged.
+func ConvertArtifactToImageManifest(manifestBytes []byte) ([]byte, string, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(manifestBytes, &raw); err != nil {
+		return nil, "", fmt.Errorf("failed to parse manifest: %w", err)
+	}
+
+	var mediaType string
+	if mt, ok := raw["mediaType"]; ok {
+		if err := json.Unmarshal(mt, &mediaType); err != nil {
+			return nil, "", fmt.Errorf("failed to parse mediaType: %w", err)
+		}
+	}
+
+	if mediaType != MediaTypeArtifactManifest {
+		digest := "sha256:" + fmt.Sprintf("%x", sha256Sum(manifestBytes))
+		return manifestBytes, digest, nil
+	}
+
+	var artifact OCIArtifactManifest
+	if err := json.Unmarshal(manifestBytes, &artifact); err != nil {
+		return nil, "", fmt.Errorf("failed to parse artifact manifest: %w", err)
+	}
+
+	image := OCIImageManifest{
+		SchemaVersion: 2,
+		MediaType:     MediaTypeOCIManifest,
+		Config: Descriptor{
+			MediaType: EmptyConfigMediaType,
+			Digest:    EmptyConfigDigest,
+			Size:      EmptyConfigSize,
+		},
+		ArtifactType: artifact.ArtifactType,
+		Layers:       artifact.Layers,
+		Subject:      artifact.Subject,
+		Annotations:  artifact.Annotations,
+	}
+
+	converted, err := json.Marshal(image)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to marshal converted manifest: %w", err)
+	}
+
+	digest := "sha256:" + fmt.Sprintf("%x", sha256Sum(converted))
+	return converted, digest, nil
 }
 
 func RepositoryExists(ctx context.Context, repository string) (bool, error) {

--- a/pkg/ociproxy/proxy.go
+++ b/pkg/ociproxy/proxy.go
@@ -41,6 +41,7 @@ package ociproxy
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
@@ -63,6 +64,7 @@ import (
 	sbimage "github.com/securebuildhq/securebuild/pkg/image"
 	"github.com/securebuildhq/securebuild/pkg/oci"
 	"github.com/securebuildhq/securebuild/pkg/param"
+
 	"github.com/securebuildhq/securebuild/pkg/persistence"
 	"github.com/securebuildhq/securebuild/pkg/registry"
 	"github.com/securebuildhq/securebuild/pkg/team"
@@ -73,6 +75,11 @@ import (
 )
 
 var proxyLogger *zap.SugaredLogger
+
+// convertedManifestCache maps converted manifest digests to their content.
+// Populated when referrers or .att responses are built with converted digests;
+// consumed when cosign subsequently fetches those manifests by digest.
+var convertedManifestCache sync.Map // map[string][]byte
 
 // getClaims retrieves OCITokenClaims from Gin context
 func getClaims(c *gin.Context) *OCITokenClaims {
@@ -830,12 +837,53 @@ func handleLegacyCosignEndpoint(c *gin.Context) bool {
 						ctx := c.Request.Context()
 						manifests, err := oci.GetArtifactManifestsBySubjectDigest(ctx, imageDigest)
 						if err == nil && len(manifests) > 0 {
-							// Two different simple-signing manifests can
-							// exist for the same image digest: a *keyed*
-							// signature (verified with a public key) and a
-							// *keyless* one (Fulcio cert inside).  The
-							// legacy .sig endpoint must surface the keyed
-							// variant so that `cosign verify --key` works.
+							// For .att endpoints, build a single OCI image manifest
+							// with ALL attestation DSSE envelopes as separate layers.
+							// Cosign's legacy .att tag handling expects a single manifest
+							// where each layer is an attestation envelope, NOT an OCI index.
+							if entry.suffix == ".att" {
+								var allLayers []oci.Descriptor
+								for _, m := range manifests {
+									if m.ArtifactType != entry.artifactType {
+										continue
+									}
+									// Fetch the original manifest to extract its layer descriptor
+									content, _, blobErr := oci.GetArtifactBlobByDigest(ctx, m.ID)
+									if blobErr != nil || len(content) == 0 {
+										continue
+									}
+									var manifestPeek struct {
+										Layers []oci.Descriptor `json:"layers"`
+									}
+									if json.Unmarshal(content, &manifestPeek) != nil {
+										continue
+									}
+									allLayers = append(allLayers, manifestPeek.Layers...)
+								}
+								if len(allLayers) > 0 {
+									proxyLogger.Infow("Serving legacy .att endpoint as combined manifest from DB",
+										"imageDigest", imageDigest, "layerCount", len(allLayers))
+									combined, err := oci.NewOCIArtifactManifest(nil, entry.artifactType, allLayers, nil)
+									if err == nil {
+										h := sha256.Sum256(combined)
+										combinedDigest := fmt.Sprintf("sha256:%x", h)
+										convertedManifestCache.Store(combinedDigest, combined)
+										c.Header("Content-Type", oci.MediaTypeOCIManifest)
+										c.Header("Docker-Content-Digest", combinedDigest)
+										c.Writer.WriteHeader(http.StatusOK)
+										c.Writer.Write(combined)
+										return true
+									}
+									proxyLogger.Warnw("Failed to build combined .att manifest", "err", err)
+								}
+							} else {
+								// For .sig and .sbom endpoints, keep single-manifest selection.
+								// Two different simple-signing manifests can
+								// exist for the same image digest: a *keyed*
+								// signature (verified with a public key) and a
+								// *keyless* one (Fulcio cert inside).  The
+								// legacy .sig endpoint must surface the keyed
+								// variant so that `cosign verify --key` works.
 
 							var keyedManifest *oci.ArtifactManifest
 							var keylessManifest *oci.ArtifactManifest
@@ -911,6 +959,7 @@ func handleLegacyCosignEndpoint(c *gin.Context) bool {
 									return true
 								}
 							}
+							}
 						}
 						if err == nil && len(manifests) == 0 {
 							proxyLogger.Debugw("No artifact manifests found for image digest (legacy endpoint)", "endpoint", entry.suffix, "imageDigest", imageDigest)
@@ -947,8 +996,23 @@ func serveArtifactManifestFromDB(c *gin.Context) bool {
 					ctx := c.Request.Context()
 					content, mediaType, err := oci.GetArtifactBlobByDigest(ctx, digest)
 					if err == nil && len(content) > 0 {
+						// Convert old artifact manifests to OCI image manifest format
+						if mediaType == oci.MediaTypeArtifactManifest {
+							converted, newDigest, convErr := oci.ConvertArtifactToImageManifest(content)
+							if convErr == nil {
+								proxyLogger.Infow("Serving converted artifact manifest from DB", "originalDigest", digest, "convertedDigest", newDigest, "mediaType", oci.MediaTypeOCIManifest)
+								c.Header("Content-Type", oci.MediaTypeOCIManifest)
+								c.Header("Docker-Content-Digest", newDigest)
+								c.Header("OCI-Subject-Referrers-Support", "true")
+								c.Writer.WriteHeader(http.StatusOK)
+								c.Writer.Write(converted)
+								return true
+							}
+							proxyLogger.Warnw("Failed to convert artifact manifest, serving as-is", "digest", digest, "err", convErr)
+						}
 						proxyLogger.Infow("Serving artifact manifest from DB", "digest", digest, "mediaType", mediaType)
 						c.Header("Content-Type", mediaType)
+						c.Header("Docker-Content-Digest", digest)
 						c.Header("OCI-Subject-Referrers-Support", "true")
 						c.Writer.WriteHeader(http.StatusOK)
 						c.Writer.Write(content)
@@ -957,6 +1021,18 @@ func serveArtifactManifestFromDB(c *gin.Context) bool {
 						proxyLogger.Debugw("Artifact manifest digest not found in DB (empty content)", "digest", digest)
 					} else {
 						proxyLogger.Debugw("Artifact manifest digest not found in DB", "digest", digest, "err", err)
+					}
+
+					// Check the conversion cache for manifests whose digest changed after conversion
+					if cached, ok := convertedManifestCache.Load(digest); ok {
+						content := cached.([]byte)
+						proxyLogger.Infow("Serving converted manifest from cache", "digest", digest)
+						c.Header("Content-Type", oci.MediaTypeOCIManifest)
+						c.Header("Docker-Content-Digest", digest)
+						c.Header("OCI-Subject-Referrers-Support", "true")
+						c.Writer.WriteHeader(http.StatusOK)
+						c.Writer.Write(content)
+						return true
 					}
 				}
 			}
@@ -976,6 +1052,15 @@ func serveArtifactBlobFromDB(c *gin.Context) bool {
 			if idx != -1 {
 				digest := path[idx+len("/blobs/"):]
 				if strings.HasPrefix(digest, "sha256:") && len(digest) == 71 {
+					// Serve OCI empty config blob for converted image manifests
+					if digest == oci.EmptyConfigDigest {
+						proxyLogger.Infow("Serving OCI empty config blob", "digest", digest)
+						c.Header("Content-Type", oci.EmptyConfigMediaType)
+						c.Header("Docker-Content-Digest", digest)
+						c.Writer.WriteHeader(http.StatusOK)
+						c.Writer.Write(oci.EmptyConfigBytes)
+						return true
+					}
 					ctx := c.Request.Context()
 					content, mediaType, err := oci.GetArtifactBlobByDigest(ctx, digest)
 					if err == nil && len(content) > 0 {

--- a/pkg/ociproxy/referrer.go
+++ b/pkg/ociproxy/referrer.go
@@ -133,10 +133,29 @@ func (p *OCIProxy) handleReferrers(c *gin.Context, repository, digest string) {
 				}
 			}
 		}
+
+		descriptorMediaType := m.MediaType
+		descriptorDigest := m.ID
+		descriptorSize := m.ManifestSize
+
+		// Convert old artifact manifests to OCI image manifest format so cosign can parse them
+		if m.MediaType == oci.MediaTypeArtifactManifest {
+			content, _, err := oci.GetArtifactBlobByDigest(ctx, m.ID)
+			if err == nil && len(content) > 0 {
+				converted, newDigest, convErr := oci.ConvertArtifactToImageManifest(content)
+				if convErr == nil {
+					convertedManifestCache.Store(newDigest, converted)
+					descriptorMediaType = oci.MediaTypeOCIManifest
+					descriptorDigest = newDigest
+					descriptorSize = int64(len(converted))
+				}
+			}
+		}
+
 		d := ociv1.Descriptor{
-			MediaType:    m.MediaType,
-			Digest:       ocidigest.Digest(m.ID),
-			Size:         m.ManifestSize,
+			MediaType:    descriptorMediaType,
+			Digest:       ocidigest.Digest(descriptorDigest),
+			Size:         descriptorSize,
 			ArtifactType: m.ArtifactType,
 			Annotations:  annotations,
 		}


### PR DESCRIPTION
## Summary
- Fix attestation manifest format from experimental `artifact.manifest.v1` to standard `image.manifest.v1` (OCI v1.1) so cosign can parse them
- Fix legacy `.att` endpoint to return a single combined manifest with all attestation layers (SBOM + SLSA provenance) instead of an OCI index that cosign only reads the first entry from
- Add on-the-fly conversion for existing attestation data in the proxy's referrers and manifest-serving endpoints

## Test plan
- [ ] Run `./bin/worker oci-proxy` locally against dev DB with existing velero attestations
- [ ] Verify `cosign verify-attestation --type https://slsa.dev/provenance/v1` passes
- [ ] Verify `cosign verify` passes
- [ ] Verify `cosign verify-attestation --type https://spdx.dev/Document` passes (previously failed)
- [ ] Verify new builds produce correct OCI image manifest format