### PR TITLE
Fix o and m values in the APK index file

### DIFF
--- a/pkg/apk/apk.go
+++ b/pkg/apk/apk.go
@@ -86,7 +86,9 @@ func AddAPKToIndex(ctx context.Context, apkMeta map[string]string, pathToIndexTa
 	}
 	if v, ok := apkMeta["maintainer"]; ok {
 		indexMeta["m"] = v
-		indexMeta["o"] = v // origin maintainer
+	}
+	if v, ok := apkMeta["origin"]; ok {
+		indexMeta["o"] = v
 	}
 	if v, ok := apkMeta["depend"]; ok {
 		indexMeta["D"] = v

--- a/pkg/apk/index.go
+++ b/pkg/apk/index.go
@@ -74,7 +74,6 @@ func extractAPKIndexFromArchive(data []byte) ([]byte, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to read APKINDEX content: %w", err)
 			}
-			fmt.Printf("DEBUG: Extracted APKINDEX content: %d bytes\n", len(indexContent))
 			return indexContent, nil
 		}
 
@@ -147,8 +146,10 @@ func writeAPKIndex(path string, index *APKIndex) error {
 		}
 
 		buf.WriteString(fmt.Sprintf("L:%s\n", strings.TrimSpace(meta["L"])))
-		buf.WriteString(fmt.Sprintf("o:%s\n", strings.TrimSpace(meta["m"])))
-		// buf.WriteString(fmt.Sprintf("m:%s\n", strings.TrimSpace(meta["m"])))
+		buf.WriteString(fmt.Sprintf("o:%s\n", strings.TrimSpace(meta["o"])))
+		if m := strings.TrimSpace(meta["m"]); m != "" {
+			buf.WriteString(fmt.Sprintf("m:%s\n", m))
+		}
 		buf.WriteString(fmt.Sprintf("t:%d\n", 1700000000)) // TODO: real epoch
 
 		if meta["c"] != "" {


### PR DESCRIPTION
#### Fix the origin ("o:" line)
Right now origin is set to an empty string, except for the last package that was built. For that package it's set to `o:Securebuild`.  This causes melange to install wrong package version if a group of packages is versioned together (built from the same melange file: main package + some sub-packages).

#### Fix the maintainer ("m:" line)
The `o:Securebuild` value above is actually the maintainer value. Right now all "m" values are empty. When set correctly, they should all be `m:Securebuild`

#### Rebuild index
This change requires index files to be rebuilt prior to running the worker:
```
worker rebuild-apk --arch x86_64
worker rebuild-apk --arch aarch64
```

Postmigration contents:

```
% grep "o" -w  APKINDEX  
o:gcc-15.1
o:gperf-3.3
o:rqlite-9.1
o:rqlite-9.4
o:rqlite-9.4
o:go-1.24
o:erlang-28
o:ncurses
o:rqlite-9.4
...
```
```
% grep "m:" APKINDEX  
m:Securebuild
m:Securebuild
m:Securebuild
m:Securebuild
m:Securebuild
m:Securebuild
m:Securebuild
m:Securebuild
m:Securebuild
m:Securebuild
m:Securebuild
...
```