### PR TITLE
Fix on-demand custom-disk VMs deleted immediately after provisioning

### DIFF
--- a/pkg/listener/build-package-with-vms-assigned.go
+++ b/pkg/listener/build-package-with-vms-assigned.go
@@ -219,6 +219,15 @@ func startBuildPackage(ctx context.Context, pkgVersion *sbpackagetypes.PackageVe
 		if err != nil {
 			return fmt.Errorf("failed to get vm context: %w", err)
 		}
+		// On-demand VMs are provisioned without a work dir (the VM isn't
+		// SSH-reachable at provision time). Resolve it to the remote $HOME now
+		// that the VM is running.
+		if x86WorkDir == "" {
+			x86WorkDir, err = builder.GetRemoteHome(ctx, x86VM)
+			if err != nil {
+				return fmt.Errorf("failed to resolve x86_64 work dir: %w", err)
+			}
+		}
 		arches["x86_64"] = &archEntry{vm: &x86VM, workDir: x86WorkDir}
 	}
 
@@ -226,6 +235,12 @@ func startBuildPackage(ctx context.Context, pkgVersion *sbpackagetypes.PackageVe
 		armVM, err := builder.GetBuilderVM(ctx, armVMID)
 		if err != nil {
 			return fmt.Errorf("failed to get vm context: %w", err)
+		}
+		if armWorkDir == "" {
+			armWorkDir, err = builder.GetRemoteHome(ctx, armVM)
+			if err != nil {
+				return fmt.Errorf("failed to resolve aarch64 work dir: %w", err)
+			}
 		}
 		arches["aarch64"] = &archEntry{vm: &armVM, workDir: armWorkDir}
 	}

--- a/pkg/listener/provision-vms.go
+++ b/pkg/listener/provision-vms.go
@@ -56,13 +56,12 @@ func handleProvisionVMs(ctx context.Context, payload string) error {
 		return fmt.Errorf("failed to provision x86_64 VM: %w", err)
 	}
 
-	// Assign VM to this execution BEFORE provisioning completes (work dir = remote $HOME)
-	x86Home, err := builder.GetRemoteHome(ctx, vmx86)
-	if err != nil {
-		deleteVMBestEffort(ctx, vmx86.ID)
-		return fmt.Errorf("failed to get x86_64 VM home: %w", err)
-	}
-	if err := builder.AssignVMToTask(ctx, vmx86.ID, "build_package", p.ExecutionID, x86Home); err != nil {
+	// Assign the VM to this execution without a work dir. The VM was just
+	// created and is not yet network/SSH-reachable, so we must NOT SSH into it
+	// here (doing so fails and would trigger immediate teardown of the VM). The
+	// work dir (remote $HOME) is resolved later at build time, once the
+	// maintenance loop observes the VM as "running".
+	if err := builder.AssignVMToTask(ctx, vmx86.ID, "build_package", p.ExecutionID, ""); err != nil {
 		deleteVMBestEffort(ctx, vmx86.ID)
 		return fmt.Errorf("failed to assign x86_64 VM to task: %w", err)
 	}
@@ -83,13 +82,9 @@ func handleProvisionVMs(ctx context.Context, payload string) error {
 		return fmt.Errorf("failed to provision aarch64 VM: %w", err)
 	}
 
-	// Assign VM to this execution (work dir = remote $HOME)
-	armHome, err := builder.GetRemoteHome(ctx, vmaarch64)
-	if err != nil {
-		deleteVMBestEffort(ctx, vmx86.ID, vmaarch64.ID)
-		return fmt.Errorf("failed to get aarch64 VM home: %w", err)
-	}
-	if err := builder.AssignVMToTask(ctx, vmaarch64.ID, "build_package", p.ExecutionID, armHome); err != nil {
+	// Assign the VM without a work dir; resolved later at build time once the VM
+	// is running (see x86_64 note above).
+	if err := builder.AssignVMToTask(ctx, vmaarch64.ID, "build_package", p.ExecutionID, ""); err != nil {
 		deleteVMBestEffort(ctx, vmx86.ID, vmaarch64.ID)
 		return fmt.Errorf("failed to assign aarch64 VM to task: %w", err)
 	}


### PR DESCRIPTION
## Problem

On-demand builders with custom disk sizes (running on the Replicated Compatibility Matrix) were being deleted within seconds of starting.

A build is routed to the on-demand provisioning path **only** when `pkgVersion.CustomDiskSize > 0` (`build-package.go`). That path was the only package-build path that SSH'd into a VM the moment it was created:

1. `handleProvisionVMs` calls `ProvisionVMForBuild` (`POST /v3/vm`).
2. It then immediately calls `builder.GetRemoteHome(vm)` to compute the work dir.
3. A freshly-created CMX VM has no `direct_ssh_endpoint`/`direct_ssh_port` yet (still provisioning), so `GetSSHClient` dials `:0` and fails.
4. The error path runs `deleteVMBestEffort`, deleting the VM within seconds.

Pool VMs never hit this — they go through the maintenance loop's readiness gate (`checkAndUpdateVMStatus` waits for status `running` before any SSH), which is exactly the gate the on-demand path was bypassing.

## Fix

Defer work-dir resolution to the existing readiness gate:

- **`provision-vms.go`** — assign each VM with an empty work dir and stop SSHing at provision time. The VM now flows through the same maintenance-loop gate as pool VMs (`checkAndUpdateVMStatus` → `InstallBuildEnv`), which persists the IP/port and waits for `running` before doing any SSH work.
- **`build-package-with-vms-assigned.go`** — resolve an empty work dir to the VM's remote `$HOME` at build time, when the VM is confirmed running and SSH-reachable. (Necessary, not just cosmetic: the build does `mkdir -p ""` on an empty work dir, which fails.) Pool builds pass a non-empty work dir and skip this branch unchanged.

## Testing

- `make build-worker` ✅
- `go vet ./pkg/listener/... ./pkg/builder/...` ✅
- `go test ./pkg/listener/...` ✅

## Follow-ups (not in this PR)

- `buildbackend/cmx.go` `acquireOnDemand` has the identical immediate-SSH-then-delete bug, but is currently dead code (nothing sets `AcquireOptions.IsOnDemand = true`) and has no async readiness gate. Worth addressing if that path is ever wired up.
- `provisionVM` never copies `IPAddress`/`Port` into the returned `BuilderVM`. Now off the critical path (the build reads the VM fresh from the DB after the maintenance loop persists the IP), but still latent.