### PR TITLE
Persist resolved on-demand work dir to machine assignment

### DIFF
--- a/pkg/listener/build-package-with-vms-assigned.go
+++ b/pkg/listener/build-package-with-vms-assigned.go
@@ -221,11 +221,15 @@ func startBuildPackage(ctx context.Context, pkgVersion *sbpackagetypes.PackageVe
 		}
 		// On-demand VMs are provisioned without a work dir (the VM isn't
 		// SSH-reachable at provision time). Resolve it to the remote $HOME now
-		// that the VM is running.
+		// that the VM is running, and persist it to the assignment so the build
+		// status checker and cleanup can find it.
 		if x86WorkDir == "" {
 			x86WorkDir, err = builder.GetRemoteHome(ctx, x86VM)
 			if err != nil {
 				return fmt.Errorf("failed to resolve x86_64 work dir: %w", err)
+			}
+			if err := builder.AssignVMToTask(ctx, x86VMID, "build_package", executionID, x86WorkDir); err != nil {
+				return fmt.Errorf("failed to persist x86_64 work dir: %w", err)
 			}
 		}
 		arches["x86_64"] = &archEntry{vm: &x86VM, workDir: x86WorkDir}
@@ -240,6 +244,9 @@ func startBuildPackage(ctx context.Context, pkgVersion *sbpackagetypes.PackageVe
 			armWorkDir, err = builder.GetRemoteHome(ctx, armVM)
 			if err != nil {
 				return fmt.Errorf("failed to resolve aarch64 work dir: %w", err)
+			}
+			if err := builder.AssignVMToTask(ctx, armVMID, "build_package", executionID, armWorkDir); err != nil {
+				return fmt.Errorf("failed to persist aarch64 work dir: %w", err)
 			}
 		}
 		arches["aarch64"] = &archEntry{vm: &armVM, workDir: armWorkDir}


### PR DESCRIPTION
## Problem

Follow-up to #116. After deferring on-demand VM work-dir resolution to build time, the build **status checker** started failing:

```
failed to check x86_64 build status: failed to get work dir for build <id>:
machine assignment for build_package/<id> on machine <id> has no work_dir
```

`updateBuildPackageStatus` → `isBuildStatusComplete` resolves the work dir via `builder.GetWorkDirForTask`, which reads `work_dir` from the `machine_assignment` row. Since #116 now assigns on-demand VMs **without** a work dir (resolving it lazily at build time), that lookup hits the `has no work_dir` error path.

## Fix

When `startBuildPackage` resolves an empty work dir to the remote `$HOME`, persist it back to the assignment via `AssignVMToTask` (which upserts `work_dir` on conflict). The status checker and cleanup then read a consistent value.

The write happens while building the per-arch map, **before** the execution status is set to `building`. The status checker only polls executions in `building`/`testing`/`publishing`, so it can never observe the execution before the work_dir is persisted — no race.

## Testing

- `make build-worker` ✅
- `go vet ./pkg/listener/...` ✅
- `go test ./pkg/listener/...` ✅