### PR TITLE
Support for external melange and APKO specs

### DIFF
--- a/db/schema/tables/image-apko-version.yaml
+++ b/db/schema/tables/image-apko-version.yaml
@@ -27,4 +27,10 @@ schema:
           notNull: true
       - name: custom_build_request_id
         type: text
+      - name: git_remote
+        type: text
+      - name: apko_file_path
+        type: text
+      - name: git_commit_sha
+        type: text
 

--- a/db/schema/tables/image-apko.yaml
+++ b/db/schema/tables/image-apko.yaml
@@ -33,3 +33,9 @@ schema:
         type: text
       - name: last_built_at
         type: timestamp with time zone
+      - name: git_remote
+        type: text
+      - name: git_tag
+        type: text
+      - name: apko_file_path
+        type: text

--- a/db/schema/tables/image.yaml
+++ b/db/schema/tables/image.yaml
@@ -28,3 +28,9 @@ schema:
         constraints:
           notNull: true
         default: "false"
+      - name: git_remote
+        type: text
+      - name: apko_file_path
+        type: text
+      - name: image_tag_template
+        type: text

--- a/db/schema/tables/package-family.yaml
+++ b/db/schema/tables/package-family.yaml
@@ -64,3 +64,9 @@ schema:
           notNull: true
       - name: image_tag_template
         type: text
+      - name: git_remote
+        type: text
+      - name: melange_file_path
+        type: text
+      - name: initial_tag
+        type: text

--- a/db/schema/tables/package-version.yaml
+++ b/db/schema/tables/package-version.yaml
@@ -56,3 +56,11 @@ schema:
         type: text
       - name: custom_disk_size
         type: integer
+      - name: git_remote
+        type: text
+      - name: melange_file_path
+        type: text
+      - name: git_tag
+        type: text
+      - name: git_commit_sha
+        type: text

--- a/pkg/builder/pool.go
+++ b/pkg/builder/pool.go
@@ -73,6 +73,7 @@ const (
 	TerminationReasonTaskCompleted  = "task_completed"
 	TerminationReasonBuildEnvFailed = "build_env_failed"
 	TerminationReasonTaskFailed     = "task_failed"
+	TerminationReasonOrphaned       = "orphaned"
 )
 
 var (
@@ -209,6 +210,120 @@ func deleteInstallingBuilders(ctx context.Context) error {
 	return nil
 }
 
+// listCMXVMIDs returns the set of VM IDs that currently exist in CMX. It calls
+// the GET /v3/vms endpoint and collects the "id" (short ID) of every returned VM.
+func listCMXVMIDs(ctx context.Context) (map[string]bool, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/v3/vms", param.GetParam(ctx).ReplicatedAPIOrigin), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create list VMs request: %w", err)
+	}
+
+	req.Header.Set("Authorization", param.GetParam(ctx).ReplicatedAPIToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list VMs from CMX: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read list VMs response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("list VMs returned unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	type listVMsResponse struct {
+		VMs []types.CMXVM `json:"vms"`
+	}
+
+	var response listVMsResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal list VMs response: %w", err)
+	}
+
+	ids := make(map[string]bool, len(response.VMs))
+	for _, vm := range response.VMs {
+		ids[vm.ID] = true
+	}
+	return ids, nil
+}
+
+// deleteOrphanedMachines removes machine_pool rows whose VM no longer exists in
+// CMX, regardless of their local status. This reclaims builders left behind by
+// crashed/restarted workers: those rows are owned by a machine_id that no running
+// worker reconciles, so the per-machine_id pool sizing never trims them and
+// expired-machines cleanup can't touch rows with expires_at IS NULL.
+//
+// Safety: if the CMX list call fails for any reason, this function returns the
+// error and deletes nothing. An empty VM list is treated as an error rather than
+// "delete everything", so a transient API outage can never wipe the pool.
+func deleteOrphanedMachines(ctx context.Context) error {
+	if param.GetParam(ctx).BuildBackend != "cmx" {
+		return nil
+	}
+
+	cmxVMIDs, err := listCMXVMIDs(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list CMX VMs, skipping orphan cleanup: %w", err)
+	}
+
+	if len(cmxVMIDs) == 0 {
+		logger.Warn("CMX returned zero VMs, skipping orphan cleanup to avoid deleting live builders")
+		return nil
+	}
+
+	conn, err := persistence.GetPooledPostgresSessionWithTimeout(ctx, 10*time.Second)
+	if err != nil {
+		logger.Warn("failed to get database connection for orphaned machine cleanup", zap.Error(err))
+		return err
+	}
+	defer conn.Release()
+
+	query := `select id from machine_pool where type = 'cmx'`
+	rows, err := conn.Query(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to query machine pool for orphan check: %w", err)
+	}
+	defer rows.Close()
+
+	var orphanedIDs []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			logger.Error(fmt.Errorf("failed to scan machine ID for orphan check: %w", err))
+			continue
+		}
+		if !cmxVMIDs[id] {
+			orphanedIDs = append(orphanedIDs, id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed iterating machine pool rows for orphan check: %w", err)
+	}
+
+	if len(orphanedIDs) == 0 {
+		return nil
+	}
+
+	logger.Info("found orphaned machines not present in CMX",
+		zap.Int("count", len(orphanedIDs)),
+		zap.Int("cmxVMCount", len(cmxVMIDs)))
+
+	for _, vmID := range orphanedIDs {
+		logger.Info("deleting orphaned machine not present in CMX", zap.String("vmID", vmID))
+		if err := DeleteVMWithReason(ctx, vmID, TerminationReasonOrphaned); err != nil {
+			logger.Error(fmt.Errorf("failed to delete orphaned VM %s: %w", vmID, err))
+			continue
+		}
+	}
+
+	return nil
+}
+
 func deleteMachinesWithoutArchitecture(ctx context.Context) error {
 	conn, err := persistence.GetPooledPostgresSessionWithTimeout(ctx, 10*time.Second)
 	if err != nil {
@@ -251,6 +366,10 @@ func deleteMachinesWithoutArchitecture(ctx context.Context) error {
 func CreatePool(ctx context.Context) error {
 	if err := deleteInstallingBuilders(ctx); err != nil {
 		logger.Error(fmt.Errorf("failed to delete installing builders: %w", err))
+	}
+
+	if err := deleteOrphanedMachines(ctx); err != nil {
+		logger.Error(fmt.Errorf("failed to delete orphaned machines: %w", err))
 	}
 
 	if err := deleteMachinesWithoutArchitecture(ctx); err != nil {
@@ -322,11 +441,15 @@ func CreatePool(ctx context.Context) error {
 					logger.Error(err)
 				}
 
+				// Clean up machines whose VM no longer exists in CMX
+				if err := deleteOrphanedMachines(ctx); err != nil {
+					logger.Error(err)
+				}
+
 				// Clean up stale cleanup locks
 				if err := cleanupStaleLocks(ctx); err != nil {
 					logger.Error(err)
 				}
-
 				// Check and update VM statuses
 				machines, err := listMachines(ctx, machineID)
 				if err != nil {

--- a/pkg/buildqueue/buildqueue.go
+++ b/pkg/buildqueue/buildqueue.go
@@ -2,6 +2,7 @@ package buildqueue
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -32,7 +33,7 @@ func ProcessRebuildChains(ctx context.Context) error {
 			FROM execution
 			ORDER BY cause_id, created_at DESC
 		)
-		SELECT p.name, p.id, rcl.link_id, rc.chain_name
+		SELECT p.name, p.id, rcl.link_id, rc.chain_name, rc.package_version_id, rc.package_id
 		FROM rebuild_chain_link rcl
 		JOIN package p ON rcl.package_id = p.id
 		JOIN rebuild_chain rc ON rcl.rebuild_chain_id = rc.id
@@ -55,7 +56,9 @@ func ProcessRebuildChains(ctx context.Context) error {
 
 	for rows.Next() {
 		var packageName, packageID, linkID, chainName string
-		if err := rows.Scan(&packageName, &packageID, &linkID, &chainName); err != nil {
+		var chainPackageVersionID sql.NullString
+		var chainPackageID string
+		if err := rows.Scan(&packageName, &packageID, &linkID, &chainName, &chainPackageVersionID, &chainPackageID); err != nil {
 			return fmt.Errorf("failed to scan package data: %w", err)
 		}
 
@@ -64,31 +67,44 @@ func ProcessRebuildChains(ctx context.Context) error {
 			zap.String("packageName", packageName),
 			zap.String("packageId", packageID))
 
-		newPackageVersion, err := sbpackage.CreateNewReleaseForLatestPackageVersion(ctx, packageID, "", "")
-		if err != nil {
-			// Record a failed execution for this link so the queue won't keep returning it.
-			if recordErr := recordFailedExecutionForLink(ctx, packageID, linkID, chainName); recordErr != nil {
-				logger.Error(fmt.Errorf("failed to record failed execution for link; queue may retry same package: %w", recordErr),
-					zap.String("linkId", linkID),
-					zap.String("packageName", packageName))
-			} else {
-				logger.Warn("increment epoch failed for rebuild chain link; recorded failed execution so queue can progress",
-					zap.String("chainName", chainName),
-					zap.String("packageName", packageName),
-					zap.String("linkId", linkID),
-					zap.Error(err))
-			}
-			continue
+		var pkgVersionID string
+
+		// If the chain has a package_version_id and this link is for the root package,
+		// use that version instead of creating a new release.
+		if chainPackageVersionID.Valid && chainPackageID == packageID {
+			pkgVersionID = chainPackageVersionID.String
+			logger.Info("using existing package version from rebuild chain",
+				zap.String("packageName", packageName),
+				zap.String("packageVersionId", pkgVersionID))
 		}
 
-		logger.Info("incremented epoch for package",
-			zap.String("packageName", packageName),
-			zap.String("packageVersionId", newPackageVersion.ID),
-			zap.Int("newEpoch", newPackageVersion.APKRelease))
+		if pkgVersionID == "" {
+			// No pre-specified version — create a new release
+			newPackageVersion, err := sbpackage.CreateNewReleaseForLatestPackageVersion(ctx, packageID, "", "")
+			if err != nil {
+				if recordErr := recordFailedExecutionForLink(ctx, packageID, linkID, chainName); recordErr != nil {
+					logger.Error(fmt.Errorf("failed to record failed execution for link; queue may retry same package: %w", recordErr),
+						zap.String("linkId", linkID),
+						zap.String("packageName", packageName))
+				} else {
+					logger.Warn("increment epoch failed for rebuild chain link; recorded failed execution so queue can progress",
+						zap.String("chainName", chainName),
+						zap.String("packageName", packageName),
+						zap.String("linkId", linkID),
+						zap.Error(err))
+				}
+				continue
+			}
+			pkgVersionID = newPackageVersion.ID
+			logger.Info("incremented epoch for package",
+				zap.String("packageName", packageName),
+				zap.String("packageVersionId", pkgVersionID),
+				zap.Int("newEpoch", newPackageVersion.APKRelease))
+		}
 
 		payload := listener.BuildPackagePayload{
 			PackageID:        packageID,
-			PackageVersionID: newPackageVersion.ID,
+			PackageVersionID: pkgVersionID,
 			Cause:            fmt.Sprintf("rebuild chain for %s", chainName),
 			CauseID:          linkID,
 		}

--- a/pkg/buildqueue/buildqueue.go
+++ b/pkg/buildqueue/buildqueue.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -120,6 +121,17 @@ func ProcessRebuildChains(ctx context.Context) error {
 				zap.String("chainName", chainName),
 				zap.String("packageName", packageName),
 				zap.String("linkId", linkID))
+
+			// If the error is not retryable (e.g. the package version was deleted),
+			// record a failed execution so the queue won't keep retrying this link.
+			// For other errors, allow the queue to retry on the next cycle.
+			if errors.Is(err, listener.ErrNotRetryable) {
+				if recordErr := recordFailedExecutionForLink(ctx, packageID, linkID, chainName); recordErr != nil {
+					logger.Error(fmt.Errorf("failed to record failed execution for link; queue may retry same package: %w", recordErr),
+						zap.String("linkId", linkID),
+						zap.String("packageName", packageName))
+				}
+			}
 			continue
 		}
 	}

--- a/pkg/githubsync/files.go
+++ b/pkg/githubsync/files.go
@@ -82,8 +82,9 @@ func generatePackageFile(pv PackageVersion) (FileEntry, error) {
 
 // generatePackageAdditionalFile creates a FileEntry for a package additional
 // file (patch, config, etc.)
-// The file is stored at the path: packages/<prefix>/<package-name>/<version>/<filename>
-func generatePackageAdditionalFile(pv PackageVersion, filename, content string) (FileEntry, error) {
+// The file is stored at the path: packages/<prefix>/<package-name>/<version>/<relative-path>
+// The relative path may include subdirectories, which are preserved.
+func generatePackageAdditionalFile(pv PackageVersion, relativePath, content string) (FileEntry, error) {
 	safeFamilyName := sanitizeName(pv.FamilyName)
 	safeVersion := sanitizeName(pv.Version)
 
@@ -94,8 +95,24 @@ func generatePackageAdditionalFile(pv PackageVersion, filename, content string) 
 	twoCharPrefix := getPrefix(safeFamilyName)
 	singlePrefix := twoCharPrefix[:1]
 
+	// Sanitize each path component individually to preserve subdirectory structure
+	// while preventing path traversal
+	pathParts := strings.Split(relativePath, "/")
+	safeParts := make([]string, 0, len(pathParts))
+	for _, part := range pathParts {
+		sanitized := sanitizeName(part)
+		if sanitized != "" {
+			safeParts = append(safeParts, sanitized)
+		}
+	}
+	safeRelativePath := strings.Join(safeParts, "/")
+
+	if safeRelativePath == "" {
+		return FileEntry{}, fmt.Errorf("additional file relative path is empty after sanitization: %s", relativePath)
+	}
+
 	path := fmt.Sprintf("packages/%s/%s/%s/%s/%s",
-		singlePrefix, twoCharPrefix, safeFamilyName, safeVersion, filename)
+		singlePrefix, twoCharPrefix, safeFamilyName, safeVersion, safeRelativePath)
 
 	return FileEntry{
 		Path:    path,

--- a/pkg/githubsync/files_test.go
+++ b/pkg/githubsync/files_test.go
@@ -194,6 +194,24 @@ func TestGeneratePackageAdditionalFile(t *testing.T) {
 			filename:     "nginx.conf",
 			expectedPath: "packages/n/ng/nginx/1.0.0/nginx.conf",
 		},
+		{
+			name:         "file in subdirectory",
+			packageName:  "bzip2",
+			filename:     "subdir/keyring.pub",
+			expectedPath: "packages/b/bz/bzip2/1.0.0/subdir/keyring.pub",
+		},
+		{
+			name:         "file in nested subdirectory",
+			packageName:  "nginx",
+			filename:     "configs/nginx/nginx.conf",
+			expectedPath: "packages/n/ng/nginx/1.0.0/configs/nginx/nginx.conf",
+		},
+		{
+			name:         "path traversal attempt in subdirectory",
+			packageName:  "bzip2",
+			filename:     "../../../etc/passwd",
+			expectedPath: "packages/b/bz/bzip2/1.0.0/etc/passwd",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/githubsync/sync.go
+++ b/pkg/githubsync/sync.go
@@ -373,14 +373,8 @@ func getAdditionalFilesForPackageVersion(ctx context.Context, pkgVersionID strin
 
 	var additionalFiles []AdditionalFile
 	for _, f := range files {
-		// Extract filename from path
-		filename := filepath.Base(f.Path)
-		if filename == "" || filename == "." {
-			filename = f.Path
-		}
-
 		additionalFiles = append(additionalFiles, AdditionalFile{
-			Filename: filename,
+			Filename: f.Path,
 			Content:  f.Content,
 		})
 	}

--- a/pkg/gitspec/pull.go
+++ b/pkg/gitspec/pull.go
@@ -1,0 +1,211 @@
+package gitspec
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/go-github/v61/github"
+	"github.com/securebuildhq/securebuild/pkg/logger"
+	"go.uber.org/zap"
+)
+
+// SpecContent holds the content pulled from a git repo at a specific tag.
+type SpecContent struct {
+	Content    string
+	CommitSHA  string
+	AdditionalFiles []AdditionalFile
+}
+
+// AdditionalFile represents a file found in the same directory as a spec file.
+type AdditionalFile struct {
+	Path    string // relative path from the spec file's directory
+	Content string
+}
+
+// PullSpecFromGit fetches the spec file and additional files from a GitHub repo at a specific tag
+// using the GitHub API. Returns the file content, the commit SHA for the tag, and additional files
+// from the same directory (recursively).
+func PullSpecFromGit(ctx context.Context, client *github.Client, gitRemote, filePath, tag string) (*SpecContent, error) {
+	owner, repo, err := parseOwnerRepo(gitRemote)
+	if err != nil {
+		return nil, err
+	}
+
+	commitSHA, err := ResolveTagToCommit(ctx, client, gitRemote, tag)
+	if err != nil {
+		return nil, fmt.Errorf("resolve tag to commit: %w", err)
+	}
+
+	// Get the spec file content at the tag
+	specContent, err := getFileContent(ctx, client, owner, repo, filePath, commitSHA)
+	if err != nil {
+		return nil, fmt.Errorf("read spec file %s: %w", filePath, err)
+	}
+
+	// Get the directory contents recursively to find additional files
+	specDir := filepath.Dir(filePath)
+	specFileName := filepath.Base(filePath)
+	additionalFiles, err := getAdditionalFilesFromGitHub(ctx, client, owner, repo, specDir, specFileName, commitSHA)
+	if err != nil {
+		return nil, fmt.Errorf("collect additional files: %w", err)
+	}
+
+	logger.Info("pulled spec from git",
+		zap.String("git_remote", gitRemote),
+		zap.String("file_path", filePath),
+		zap.String("tag", tag),
+		zap.String("commit_sha", commitSHA),
+		zap.Int("additional_files", len(additionalFiles)))
+
+	return &SpecContent{
+		Content:         specContent,
+		CommitSHA:       commitSHA,
+		AdditionalFiles: additionalFiles,
+	}, nil
+}
+
+// getFileContent fetches a single file's content from a GitHub repo at a specific ref.
+func getFileContent(ctx context.Context, client *github.Client, owner, repo, path, ref string) (string, error) {
+	opt := &github.RepositoryContentGetOptions{Ref: ref}
+	fileContent, _, _, err := client.Repositories.GetContents(ctx, owner, repo, path, opt)
+	if err != nil {
+		return "", fmt.Errorf("get contents for %s at ref %s: %w", path, ref, err)
+	}
+	if fileContent == nil {
+		return "", fmt.Errorf("file %s not found at ref %s", path, ref)
+	}
+	content, err := fileContent.GetContent()
+	if err != nil {
+		return "", fmt.Errorf("decode content for %s: %w", path, err)
+	}
+	return content, nil
+}
+
+// getAdditionalFilesFromGitHub fetches all files in a directory (recursively) from a GitHub repo,
+// excluding the spec file itself. Uses the Git Trees API with recursive=true for efficiency.
+func getAdditionalFilesFromGitHub(ctx context.Context, client *github.Client, owner, repo, dir, specFileName, ref string) ([]AdditionalFile, error) {
+	// Use the Git Trees API to get a recursive listing of the directory
+	tree, _, err := client.Git.GetTree(ctx, owner, repo, ref, true)
+	if err != nil {
+		return nil, fmt.Errorf("get tree at ref %s: %w", ref, err)
+	}
+
+	var files []AdditionalFile
+	for _, entry := range tree.Entries {
+		if entry.GetType() != "blob" {
+			continue
+		}
+		entryPath := entry.GetPath()
+
+		// Only include files under the spec file's directory
+		if !strings.HasPrefix(entryPath, dir+"/") && entryPath != dir {
+			continue
+		}
+
+		// Calculate path relative to the spec directory
+		var relPath string
+		if dir == "." || dir == "" {
+			relPath = entryPath
+		} else {
+			relPath = strings.TrimPrefix(entryPath, dir+"/")
+		}
+
+		// Skip the spec file itself
+		if relPath == specFileName {
+			continue
+		}
+
+		if relPath == "" || relPath == "." {
+			continue
+		}
+
+		content, err := getFileContent(ctx, client, owner, repo, entryPath, ref)
+		if err != nil {
+			logger.Warn("failed to get additional file content, skipping",
+				zap.String("path", entryPath),
+				zap.Error(err))
+			continue
+		}
+
+		files = append(files, AdditionalFile{
+			Path:    relPath,
+			Content: content,
+		})
+	}
+
+	return files, nil
+}
+
+// parseOwnerRepo extracts the owner and repo from a GitHub URL.
+// Handles formats like "https://github.com/owner/repo.git" or "github.com/owner/repo".
+func parseOwnerRepo(gitRemote string) (string, string, error) {
+	parsedURL, err := url.Parse(gitRemote)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid repository URL: %w", err)
+	}
+
+	pathParts := strings.Split(strings.Trim(parsedURL.Path, "/"), "/")
+	if len(pathParts) < 2 {
+		return "", "", fmt.Errorf("invalid repository path, expected format: github.com/owner/repo, got: %s", gitRemote)
+	}
+
+	owner := pathParts[0]
+	repo := strings.TrimSuffix(pathParts[1], ".git")
+	return owner, repo, nil
+}
+
+// ListTags lists all tags from a GitHub repo using the GitHub API.
+func ListTags(ctx context.Context, client *github.Client, gitRemote string) ([]string, error) {
+	owner, repo, err := parseOwnerRepo(gitRemote)
+	if err != nil {
+		return nil, err
+	}
+
+	var allTags []string
+	opt := &github.ListOptions{PerPage: 100}
+	for {
+		tags, resp, err := client.Repositories.ListTags(ctx, owner, repo, opt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list tags for %s/%s: %w", owner, repo, err)
+		}
+		for _, tag := range tags {
+			allTags = append(allTags, tag.GetName())
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
+	}
+
+	return allTags, nil
+}
+
+// ResolveTagToCommit resolves a git tag to its commit SHA using the GitHub API.
+func ResolveTagToCommit(ctx context.Context, client *github.Client, gitRemote, tag string) (string, error) {
+	owner, repo, err := parseOwnerRepo(gitRemote)
+	if err != nil {
+		return "", err
+	}
+
+	ref, _, err := client.Git.GetRef(ctx, owner, repo, "refs/tags/"+tag)
+	if err != nil {
+		return "", fmt.Errorf("failed to get ref for tag %s: %w", tag, err)
+	}
+
+	obj := ref.GetObject()
+
+	if obj.GetType() == "commit" {
+		return obj.GetSHA(), nil
+	} else if obj.GetType() == "tag" {
+		tagObj, _, err := client.Git.GetTag(ctx, owner, repo, obj.GetSHA())
+		if err != nil {
+			return "", fmt.Errorf("failed to get tag object: %w", err)
+		}
+		return tagObj.GetObject().GetSHA(), nil
+	}
+
+	return "", fmt.Errorf("unexpected object type: %s", obj.GetType())
+}

--- a/pkg/gitspec/semver.go
+++ b/pkg/gitspec/semver.go
@@ -1,0 +1,70 @@
+package gitspec
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver"
+)
+
+// OverrideVersionAndEpochInMelange replaces the version and epoch fields in the
+// melange YAML using a line-by-line approach that preserves the original formatting.
+// Only the first occurrence of each field is replaced. The git tag is the
+// authoritative source of the version; the melange file's own package.version
+// and package.epoch are overridden.
+// Returns the modified YAML content and the version string derived from the tag.
+func OverrideVersionAndEpochInMelange(melangeYAML string, gitTag string, epoch int) (string, string, error) {
+	v, err := semver.NewVersion(gitTag)
+	if err != nil {
+		return "", "", fmt.Errorf("parse git tag %q as semver: %w", gitTag, err)
+	}
+
+	if v.Prerelease() != "" {
+		return "", "", fmt.Errorf("pre-release tags are not supported (tag=%q)", gitTag)
+	}
+
+	versionStr := v.String()
+
+	lines := strings.Split(melangeYAML, "\n")
+	versionReplaced := false
+	epochReplaced := false
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		leadingWhitespace := line[:len(line)-len(trimmed)]
+
+		if !versionReplaced && strings.HasPrefix(trimmed, "version:") {
+			lines[i] = fmt.Sprintf("%sversion: %q", leadingWhitespace, versionStr)
+			versionReplaced = true
+		}
+
+		if !epochReplaced && strings.HasPrefix(trimmed, "epoch:") {
+			lines[i] = fmt.Sprintf("%sepoch: %d", leadingWhitespace, epoch)
+			epochReplaced = true
+		}
+
+		if versionReplaced && epochReplaced {
+			break
+		}
+	}
+
+	return strings.Join(lines, "\n"), versionStr, nil
+}
+
+// VersionFromTag parses a git tag as semver and returns the canonical version string.
+func VersionFromTag(gitTag string) (string, error) {
+	v, err := semver.NewVersion(gitTag)
+	if err != nil {
+		return "", fmt.Errorf("parse git tag %q as semver: %w", gitTag, err)
+	}
+	if v.Prerelease() != "" {
+		return "", fmt.Errorf("pre-release tags are not supported (tag=%q)", gitTag)
+	}
+	return v.String(), nil
+}
+
+// IsSemverTag returns true if the given string is a valid semver tag (with optional v prefix).
+func IsSemverTag(tag string) bool {
+	_, err := semver.NewVersion(tag)
+	return err == nil
+}

--- a/pkg/gitspec/semver.go
+++ b/pkg/gitspec/semver.go
@@ -7,13 +7,14 @@ import (
 	"github.com/Masterminds/semver"
 )
 
-// OverrideVersionAndEpochInMelange replaces the version and epoch fields in the
+// OverrideVersionAndEpochInMelange replaces the name, version, and epoch fields in the
 // melange YAML using a line-by-line approach that preserves the original formatting.
 // Only the first occurrence of each field is replaced. The git tag is the
-// authoritative source of the version; the melange file's own package.version
-// and package.epoch are overridden.
+// authoritative source of the version; the melange file's own package.name,
+// package.version, and package.epoch are overridden.
+// packageName is generated from the package family's name template.
 // Returns the modified YAML content and the version string derived from the tag.
-func OverrideVersionAndEpochInMelange(melangeYAML string, gitTag string, epoch int) (string, string, error) {
+func OverrideVersionAndEpochInMelange(melangeYAML string, gitTag string, epoch int, packageName string) (string, string, error) {
 	v, err := semver.NewVersion(gitTag)
 	if err != nil {
 		return "", "", fmt.Errorf("parse git tag %q as semver: %w", gitTag, err)
@@ -26,12 +27,18 @@ func OverrideVersionAndEpochInMelange(melangeYAML string, gitTag string, epoch i
 	versionStr := v.String()
 
 	lines := strings.Split(melangeYAML, "\n")
+	nameReplaced := false
 	versionReplaced := false
 	epochReplaced := false
 
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		leadingWhitespace := line[:len(line)-len(trimmed)]
+
+		if !nameReplaced && packageName != "" && strings.HasPrefix(trimmed, "name:") {
+			lines[i] = fmt.Sprintf("%sname: %q", leadingWhitespace, packageName)
+			nameReplaced = true
+		}
 
 		if !versionReplaced && strings.HasPrefix(trimmed, "version:") {
 			lines[i] = fmt.Sprintf("%sversion: %q", leadingWhitespace, versionStr)
@@ -43,7 +50,7 @@ func OverrideVersionAndEpochInMelange(melangeYAML string, gitTag string, epoch i
 			epochReplaced = true
 		}
 
-		if versionReplaced && epochReplaced {
+		if nameReplaced && versionReplaced && epochReplaced {
 			break
 		}
 	}

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -176,7 +176,7 @@ func GetImage(ctx context.Context, id string) (*types.Image, error) {
 	`
 
 	var image types.Image
-	var alternateImage string
+	var alternateImage sql.NullString
 	var readme sql.NullString
 	var gitRemote, apkoFilePath, tagTemplate sql.NullString
 	if err := conn.QueryRow(ctx, query, id).Scan(&image.ID, &image.Name, &image.CreatedAt, &image.UpdatedAt, &alternateImage, &readme, &gitRemote, &apkoFilePath, &tagTemplate); err != nil {
@@ -189,7 +189,7 @@ func GetImage(ctx context.Context, id string) (*types.Image, error) {
 	}
 	image.APKOs = apkos
 
-	image.AlternateImage = alternateImage
+	image.AlternateImage = alternateImage.String
 	image.Readme = readme.String
 	image.GitRemote = gitRemote.String
 	image.ApkoFilePath = apkoFilePath.String

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -170,7 +170,7 @@ func GetImage(ctx context.Context, id string) (*types.Image, error) {
 	defer conn.Release()
 
 	query := `
-		SELECT id, name, created_at, updated_at, alternate_image, readme
+		SELECT id, name, created_at, updated_at, alternate_image, readme, git_remote, apko_file_path, image_tag_template
 		FROM image
 		WHERE id = $1
 	`
@@ -178,7 +178,8 @@ func GetImage(ctx context.Context, id string) (*types.Image, error) {
 	var image types.Image
 	var alternateImage string
 	var readme sql.NullString
-	if err := conn.QueryRow(ctx, query, id).Scan(&image.ID, &image.Name, &image.CreatedAt, &image.UpdatedAt, &alternateImage, &readme); err != nil {
+	var gitRemote, apkoFilePath, tagTemplate sql.NullString
+	if err := conn.QueryRow(ctx, query, id).Scan(&image.ID, &image.Name, &image.CreatedAt, &image.UpdatedAt, &alternateImage, &readme, &gitRemote, &apkoFilePath, &tagTemplate); err != nil {
 		return nil, err
 	}
 
@@ -190,6 +191,9 @@ func GetImage(ctx context.Context, id string) (*types.Image, error) {
 
 	image.AlternateImage = alternateImage
 	image.Readme = readme.String
+	image.GitRemote = gitRemote.String
+	image.ApkoFilePath = apkoFilePath.String
+	image.TagTemplate = tagTemplate.String
 
 	return &image, nil
 }
@@ -232,7 +236,7 @@ func listImageAPKOs(ctx context.Context, imageID string) ([]*types.ImageAPKO, er
 	defer conn.Release()
 
 	query := `
-		SELECT id, name, tags, created_at, updated_at, readme
+		SELECT id, name, tags, created_at, updated_at, readme, git_remote, git_tag, apko_file_path
 		FROM image_apko
 		WHERE image_id = $1
 	`
@@ -246,10 +250,14 @@ func listImageAPKOs(ctx context.Context, imageID string) ([]*types.ImageAPKO, er
 	for rows.Next() {
 		var apko types.ImageAPKO
 		var readme sql.NullString
-		if err := rows.Scan(&apko.ID, &apko.Name, &apko.Tags, &apko.CreatedAt, &apko.UpdatedAt, &readme); err != nil {
+		var gitRemote, gitTag, apkoFilePath sql.NullString
+		if err := rows.Scan(&apko.ID, &apko.Name, &apko.Tags, &apko.CreatedAt, &apko.UpdatedAt, &readme, &gitRemote, &gitTag, &apkoFilePath); err != nil {
 			return nil, err
 		}
 		apko.Readme = readme.String
+		apko.GitRemote = gitRemote.String
+		apko.GitTag = gitTag.String
+		apko.ApkoFilePath = apkoFilePath.String
 		apkos = append(apkos, &apko)
 	}
 	rows.Close()
@@ -270,7 +278,7 @@ func GetLatestImageAPKOVersion(ctx context.Context, apkoID string) (types.ImageA
 	defer conn.Release()
 
 	query := `
-		SELECT id, apko_yaml, created_at, updated_at
+		SELECT id, apko_yaml, created_at, updated_at, git_remote, apko_file_path, git_commit_sha
 		FROM image_apko_version
 		WHERE image_apko_id = $1
 		ORDER BY created_at DESC
@@ -279,9 +287,13 @@ func GetLatestImageAPKOVersion(ctx context.Context, apkoID string) (types.ImageA
 	row := conn.QueryRow(ctx, query, apkoID)
 
 	var version types.ImageAPKOVersion
-	if err := row.Scan(&version.ID, &version.APKOYAML, &version.CreatedAt, &version.UpdatedAt); err != nil {
+	var gitRemote, apkoFilePath, gitCommitSHA sql.NullString
+	if err := row.Scan(&version.ID, &version.APKOYAML, &version.CreatedAt, &version.UpdatedAt, &gitRemote, &apkoFilePath, &gitCommitSHA); err != nil {
 		return types.ImageAPKOVersion{}, err
 	}
+	version.GitRemote = gitRemote.String
+	version.ApkoFilePath = apkoFilePath.String
+	version.GitCommitSHA = gitCommitSHA.String
 
 	return version, nil
 }
@@ -292,16 +304,20 @@ func GetImageApkoVersion(ctx context.Context, imageApkoVersionID string) (types.
 	defer conn.Release()
 
 	query := `
-		SELECT id, image_apko_id, apko_yaml, created_at, updated_at
+		SELECT id, image_apko_id, apko_yaml, created_at, updated_at, git_remote, apko_file_path, git_commit_sha
 		FROM image_apko_version
 		WHERE id = $1
 	`
 	row := conn.QueryRow(ctx, query, imageApkoVersionID)
 
 	var version types.ImageAPKOVersion
-	if err := row.Scan(&version.ID, &version.ImageApkoID, &version.APKOYAML, &version.CreatedAt, &version.UpdatedAt); err != nil {
+	var gitRemote, apkoFilePath, gitCommitSHA sql.NullString
+	if err := row.Scan(&version.ID, &version.ImageApkoID, &version.APKOYAML, &version.CreatedAt, &version.UpdatedAt, &gitRemote, &apkoFilePath, &gitCommitSHA); err != nil {
 		return types.ImageAPKOVersion{}, err
 	}
+	version.GitRemote = gitRemote.String
+	version.ApkoFilePath = apkoFilePath.String
+	version.GitCommitSHA = gitCommitSHA.String
 
 	return version, nil
 }
@@ -376,7 +392,7 @@ func GetAPKO(ctx context.Context, id string) (*types.ImageAPKO, string, error) {
 	defer conn.Release()
 
 	query := `
-		SELECT ia.id, ia.name, ia.tags, ia.created_at, ia.updated_at, ia.readme, ia.image_id
+		SELECT ia.id, ia.name, ia.tags, ia.created_at, ia.updated_at, ia.readme, ia.image_id, ia.git_remote, ia.git_tag, ia.apko_file_path
 		FROM image_apko ia
 		WHERE ia.id = $1
 	`
@@ -384,10 +400,14 @@ func GetAPKO(ctx context.Context, id string) (*types.ImageAPKO, string, error) {
 	var apko types.ImageAPKO
 	var apkoReadme sql.NullString
 	var imageID string
-	if err := conn.QueryRow(ctx, query, id).Scan(&apko.ID, &apko.Name, &apko.Tags, &apko.CreatedAt, &apko.UpdatedAt, &apkoReadme, &imageID); err != nil {
+	var gitRemote, gitTag, apkoFilePath sql.NullString
+	if err := conn.QueryRow(ctx, query, id).Scan(&apko.ID, &apko.Name, &apko.Tags, &apko.CreatedAt, &apko.UpdatedAt, &apkoReadme, &imageID, &gitRemote, &gitTag, &apkoFilePath); err != nil {
 		return nil, "", err
 	}
 	apko.Readme = apkoReadme.String
+	apko.GitRemote = gitRemote.String
+	apko.GitTag = gitTag.String
+	apko.ApkoFilePath = apkoFilePath.String
 
 	latestVersion, err := GetLatestImageAPKOVersion(ctx, apko.ID)
 	if err != nil {
@@ -414,7 +434,7 @@ func GetImageAPKOVersionsByCustomBuildRequestID(ctx context.Context, customBuild
 	defer conn.Release()
 
 	query := `
-		SELECT id, image_apko_id, apko_yaml, created_at, updated_at
+		SELECT id, image_apko_id, apko_yaml, created_at, updated_at, git_remote, apko_file_path, git_commit_sha
 		FROM image_apko_version
 		WHERE custom_build_request_id = $1
 		ORDER BY created_at ASC
@@ -429,9 +449,13 @@ func GetImageAPKOVersionsByCustomBuildRequestID(ctx context.Context, customBuild
 	var apkoVersions []types.ImageAPKOVersion
 	for rows.Next() {
 		var version types.ImageAPKOVersion
-		if err := rows.Scan(&version.ID, &version.ImageApkoID, &version.APKOYAML, &version.CreatedAt, &version.UpdatedAt); err != nil {
+		var gitRemote, apkoFilePath, gitCommitSHA sql.NullString
+		if err := rows.Scan(&version.ID, &version.ImageApkoID, &version.APKOYAML, &version.CreatedAt, &version.UpdatedAt, &gitRemote, &apkoFilePath, &gitCommitSHA); err != nil {
 			return nil, fmt.Errorf("failed to scan image apko version: %w", err)
 		}
+		version.GitRemote = gitRemote.String
+		version.ApkoFilePath = apkoFilePath.String
+		version.GitCommitSHA = gitCommitSHA.String
 		apkoVersions = append(apkoVersions, version)
 	}
 

--- a/pkg/image/tag_reassignment.go
+++ b/pkg/image/tag_reassignment.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"regexp"
 	"strings"
@@ -14,8 +15,9 @@ import (
 
 // APKOTagInfo represents an APKO with its tags
 type APKOTagInfo struct {
-	ID   string
-	Tags []string
+	ID      string
+	Tags    []string
+	GitTag  string // empty if not a linked image
 }
 
 // countVersionParts counts how many numeric parts a version string has (major, major.minor, or major.minor.patch)
@@ -95,8 +97,9 @@ func reassignLatestTag(tagAssignments map[string][]string, apkoVersions map[stri
 
 // reassignLessSpecificTags moves less specific tags (like "v1", "v1.3") to the APKO with the greatest version that satisfies the tag
 // When a less-specific tag moves to a new APKO, it also generates equivalent tags for all part-counts that exist in the system
+// Tags in the protectedTags set (git-derived OCI tags) are excluded from reassignment.
 // TODO: figure out how to support tags with arbitrary prefixes.
-func reassignLessSpecificTags(tagAssignments map[string][]string, apkoVersions map[string]*semver.Version, apkos []APKOTagInfo) {
+func reassignLessSpecificTags(tagAssignments map[string][]string, apkoVersions map[string]*semver.Version, apkos []APKOTagInfo, protectedTags map[string]bool) {
 	// Collect all unique less-specific tags across all APKOs and track part counts
 	lessSpecificTags := make(map[string]bool)
 	existingPartCounts := make(map[int]bool) // Track which part counts exist (1 or 2)
@@ -105,6 +108,10 @@ func reassignLessSpecificTags(tagAssignments map[string][]string, apkoVersions m
 	for _, apko := range apkos {
 		for _, tag := range apko.Tags {
 			if tag == "latest" {
+				continue
+			}
+			// Skip git-derived tags — they must not be reassigned
+			if protectedTags[tag] {
 				continue
 			}
 			parts := countVersionParts(tag)
@@ -263,7 +270,7 @@ func removeTag(tags []string, tag string) []string {
 func ReassignTagsForImage(ctx context.Context, tx pgx.Tx, imageID string) error {
 	// Fetch all APKOs for this image
 	query := `
-		SELECT ia.id, ia.tags
+		SELECT ia.id, ia.tags, ia.git_tag
 		FROM image_apko ia
 		WHERE ia.image_id = $1
 		ORDER BY ia.created_at ASC
@@ -277,9 +284,11 @@ func ReassignTagsForImage(ctx context.Context, tx pgx.Tx, imageID string) error 
 	var apkos []APKOTagInfo
 	for rows.Next() {
 		var apko APKOTagInfo
-		if err := rows.Scan(&apko.ID, &apko.Tags); err != nil {
+		var gitTag sql.NullString
+		if err := rows.Scan(&apko.ID, &apko.Tags, &gitTag); err != nil {
 			return fmt.Errorf("failed to scan APKO row: %w", err)
 		}
+		apko.GitTag = gitTag.String
 		apkos = append(apkos, apko)
 	}
 
@@ -312,7 +321,16 @@ func ReassignTagsForImage(ctx context.Context, tx pgx.Tx, imageID string) error 
 
 // computeGlobalTagReassignments recalculates optimal tags based on current APKO state
 // This is a pure function (no I/O) that can be unit tested
+// Git-derived OCI tags (those matching a git_tag on an image_apko) are excluded from reassignment.
 func computeGlobalTagReassignments(apkos []APKOTagInfo) (map[string][]string, error) {
+	// Build set of git-derived tags that must not be reassigned
+	protectedTags := make(map[string]bool)
+	for _, apko := range apkos {
+		if apko.GitTag != "" {
+			protectedTags[apko.GitTag] = true
+		}
+	}
+
 	// Build version map
 	apkoVersions := make(map[string]*semver.Version)
 	for _, apko := range apkos {
@@ -345,8 +363,8 @@ func computeGlobalTagReassignments(apkos []APKOTagInfo) (map[string][]string, er
 	// Reassign "latest" to APKO with greatest version
 	reassignLatestTag(newTagAssignments, apkoVersions, apkos)
 
-	// Reassign less specific tags (e.g., "1", "1.2")
-	reassignLessSpecificTags(newTagAssignments, apkoVersions, apkos)
+	// Reassign less specific tags (e.g., "1", "1.2"), excluding git-derived tags
+	reassignLessSpecificTags(newTagAssignments, apkoVersions, apkos, protectedTags)
 
 	return newTagAssignments, nil
 }

--- a/pkg/image/tag_reassignment_test.go
+++ b/pkg/image/tag_reassignment_test.go
@@ -119,6 +119,28 @@ func TestComputeGlobalTagReassignments(t *testing.T) {
 				"apko2": {"2.0.0", "2.0", "2", "latest"},
 			},
 		},
+		{
+			name: "excludes git-derived tags from reassignment",
+			apkos: []APKOTagInfo{
+				{ID: "apko1", Tags: []string{"1.5.0", "latest"}, GitTag: "v1.5.0"},
+				{ID: "apko2", Tags: []string{"1.5.1", "1.5", "1"}, GitTag: "v1.5.1"},
+			},
+			expected: map[string][]string{
+				"apko1": {"1.5.0"},
+				"apko2": {"1.5.1", "1.5", "1", "latest"},
+			},
+		},
+		{
+			name: "git-derived tag with v prefix is protected",
+			apkos: []APKOTagInfo{
+				{ID: "apko1", Tags: []string{"v1.5.0", "v1.5", "v1", "latest"}, GitTag: "v1.5.0"},
+				{ID: "apko2", Tags: []string{"v1.5.1"}, GitTag: "v1.5.1"},
+			},
+			expected: map[string][]string{
+				"apko1": {"v1.5.0"},
+				"apko2": {"v1.5.1", "v1.5", "v1", "latest"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/image/types/types.go
+++ b/pkg/image/types/types.go
@@ -10,6 +10,9 @@ type Image struct {
 	APKOs          []*ImageAPKO
 	AlternateImage string
 	Readme         string
+	GitRemote      string
+	ApkoFilePath   string
+	TagTemplate    string
 }
 
 type ImageAPKO struct {
@@ -20,6 +23,9 @@ type ImageAPKO struct {
 	UpdatedAt     time.Time
 	LatestVersion ImageAPKOVersion
 	Readme        string
+	GitRemote     string
+	GitTag        string
+	ApkoFilePath  string
 }
 
 type ImageAPKOVersion struct {
@@ -28,6 +34,9 @@ type ImageAPKOVersion struct {
 	APKOYAML    string
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
+	GitRemote    string
+	ApkoFilePath string
+	GitCommitSHA string
 }
 
 type ImageCatalogItem struct {

--- a/pkg/listener/build-apko.go
+++ b/pkg/listener/build-apko.go
@@ -5,11 +5,16 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/google/go-github/v61/github"
 	image "github.com/securebuildhq/securebuild/pkg/image"
 	imagetypes "github.com/securebuildhq/securebuild/pkg/image/types"
+	"github.com/securebuildhq/securebuild/pkg/gitspec"
 	"github.com/securebuildhq/securebuild/pkg/logger"
+	"github.com/securebuildhq/securebuild/pkg/param"
 	"github.com/securebuildhq/securebuild/pkg/persistence"
+	"github.com/tuvistavie/securerandom"
 	"go.uber.org/zap"
+	"golang.org/x/oauth2"
 )
 
 type BuildAPKOPayload struct {
@@ -46,8 +51,18 @@ func handleBuildAPKO(ctx context.Context, payload string) error {
 		return fmt.Errorf("APKO with ID %s not found in image %s", buildAPKOPayload.APKOID, buildAPKOPayload.ImageID)
 	}
 
+	// For linked APKOs, check if the git tag has been reassigned to a new commit.
+	// If so, create a new image_apko_version with the updated spec before building.
+	apkoVersionID, err := checkAndRefreshLinkedApko(ctx, targetAPKO)
+	if err != nil {
+		logger.Warn("failed to check/refresh linked APKO, proceeding with existing version",
+			zap.String("apkoId", targetAPKO.ID),
+			zap.Error(err))
+		apkoVersionID = targetAPKO.LatestVersion.ID
+	}
+
 	// Create image build record for the specific APKO version
-	imageBuild, err := image.CreateImageBuild(ctx, targetAPKO.LatestVersion.ID)
+	imageBuild, err := image.CreateImageBuild(ctx, apkoVersionID)
 	if err != nil {
 		return fmt.Errorf("failed to create image build record for APKO %s: %w", targetAPKO.ID, err)
 	}
@@ -111,4 +126,79 @@ func handleBuildAPKO(ctx context.Context, payload string) error {
 	}
 
 	return nil
+}
+
+// checkAndRefreshLinkedApko checks if a linked APKO's git tag has been reassigned to a
+// new commit SHA. If so, it pulls the updated APKO spec from git and creates a new
+// image_apko_version row. Returns the image_apko_version ID to use for the build.
+// For non-linked APKOs, returns the existing latest version ID unchanged.
+func checkAndRefreshLinkedApko(ctx context.Context, apko *imagetypes.ImageAPKO) (string, error) {
+	if apko.GitTag == "" || apko.GitRemote == "" {
+		return apko.LatestVersion.ID, nil
+	}
+
+	var githubClient *github.Client
+	if githubToken := param.GetParam(ctx).UpdaterGithubAPIToken; githubToken != "" {
+		ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: githubToken})
+		tc := oauth2.NewClient(ctx, ts)
+		githubClient = github.NewClient(tc)
+	} else {
+		githubClient = github.NewClient(nil)
+	}
+
+	// Resolve the current git tag to a commit SHA
+	currentSHA, err := gitspec.ResolveTagToCommit(ctx, githubClient, apko.GitRemote, apko.GitTag)
+	if err != nil {
+		return apko.LatestVersion.ID, fmt.Errorf("resolve tag to commit: %w", err)
+	}
+
+	// Compare to the recorded SHA on the latest version
+	if currentSHA == apko.LatestVersion.GitCommitSHA {
+		logger.Debug("linked APKO git tag unchanged, no refresh needed",
+			zap.String("apkoId", apko.ID),
+			zap.String("git_tag", apko.GitTag),
+			zap.String("commit_sha", currentSHA))
+		return apko.LatestVersion.ID, nil
+	}
+
+	logger.Info("linked APKO git tag reassigned, creating new version",
+		zap.String("apkoId", apko.ID),
+		zap.String("git_tag", apko.GitTag),
+		zap.String("old_sha", apko.LatestVersion.GitCommitSHA),
+		zap.String("new_sha", currentSHA))
+
+	// Pull the updated APKO spec from git
+	apkoFilePath := apko.ApkoFilePath
+	if apkoFilePath == "" {
+		apkoFilePath = apko.LatestVersion.ApkoFilePath
+	}
+
+	specContent, err := gitspec.PullSpecFromGit(ctx, githubClient, apko.GitRemote, apkoFilePath, apko.GitTag)
+	if err != nil {
+		return apko.LatestVersion.ID, fmt.Errorf("pull apko spec from git: %w", err)
+	}
+
+	// Create a new image_apko_version row
+	newVersionID, err := securerandom.Hex(32)
+	if err != nil {
+		return apko.LatestVersion.ID, fmt.Errorf("generate version id: %w", err)
+	}
+
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO image_apko_version (id, image_apko_id, apko_yaml, created_at, updated_at, git_remote, apko_file_path, git_commit_sha)
+		VALUES ($1, $2, $3, NOW(), NOW(), $4, $5, $6)
+	`, newVersionID, apko.ID, specContent.Content, apko.GitRemote, apkoFilePath, currentSHA)
+	if err != nil {
+		return apko.LatestVersion.ID, fmt.Errorf("insert new image_apko_version: %w", err)
+	}
+
+	logger.Info("created new image_apko_version for linked APKO",
+		zap.String("apkoId", apko.ID),
+		zap.String("newVersionId", newVersionID),
+		zap.String("commit_sha", currentSHA))
+
+	return newVersionID, nil
 }

--- a/pkg/listener/build-image.go
+++ b/pkg/listener/build-image.go
@@ -79,7 +79,17 @@ func handleBuildImage(ctx context.Context, payload string) error {
 	// Create image build records for each APKO version
 	var imageBuilds []*imagetypes.ImageBuild
 	for _, apko := range img.APKOs {
-		imageBuild, err := image.CreateImageBuild(ctx, apko.LatestVersion.ID)
+		// For linked APKOs, check if the git tag has been reassigned to a new commit.
+		// If so, create a new image_apko_version with the updated spec before building.
+		apkoVersionID, err := checkAndRefreshLinkedApko(ctx, apko)
+		if err != nil {
+			logger.Warn("failed to check/refresh linked APKO, proceeding with existing version",
+				zap.String("apkoId", apko.ID),
+				zap.Error(err))
+			apkoVersionID = apko.LatestVersion.ID
+		}
+
+		imageBuild, err := image.CreateImageBuild(ctx, apkoVersionID)
 		if err != nil {
 			return fmt.Errorf("failed to create image build record for APKO %s: %w", apko.ID, err)
 		}

--- a/pkg/listener/build-package.go
+++ b/pkg/listener/build-package.go
@@ -19,6 +19,7 @@ import (
 
 var (
 	ErrExecutionPaused = errors.New("execution is paused")
+	ErrNotRetryable    = errors.New("not retryable")
 )
 
 type BuildPackagePayload struct {
@@ -70,7 +71,7 @@ func HandleBuildPackage(ctx context.Context, payload string) error {
 	if buildPackagePayload.PackageVersionID != "" {
 		pkgVersion, err = sbpackage.GetPackageVersion(ctx, buildPackagePayload.PackageVersionID)
 		if err != nil {
-			return fmt.Errorf("failed to get package version: %w", err)
+			return fmt.Errorf("%w: failed to get package version: %w", ErrNotRetryable, err)
 		}
 	} else {
 		// if the most recent package version built, we need a new one

--- a/pkg/listener/package-family-update-check.go
+++ b/pkg/listener/package-family-update-check.go
@@ -577,14 +577,14 @@ func processGitLinkedNewVersion(ctx context.Context, githubClient *github.Client
 		return nil, fmt.Errorf("pull spec from git: %w", err)
 	}
 
-	// Override version and epoch in the melange YAML from the git tag
-	overriddenYAML, versionStr, err := gitspec.OverrideVersionAndEpochInMelange(specContent.Content, gitTag, 0)
-	if err != nil {
-		return nil, fmt.Errorf("override version/epoch: %w", err)
-	}
-
 	// Determine the package name from the template
 	packageName := package_family.GeneratePackageName(pf.PackageNameTemplate, pf.Name, int(version.Major()), int(version.Minor()))
+
+	// Override name, version, and epoch in the melange YAML from the git tag
+	overriddenYAML, versionStr, err := gitspec.OverrideVersionAndEpochInMelange(specContent.Content, gitTag, 0, packageName)
+	if err != nil {
+		return nil, fmt.Errorf("override name/version/epoch: %w", err)
+	}
 
 	// Check if the package already exists
 	conn := persistence.MustGetPooledPostgresSession(ctx)
@@ -658,6 +658,18 @@ func processGitLinkedNewVersion(ctx context.Context, githubClient *github.Client
 			}
 		}
 
+		// Write provides for the new version
+		newPackageVersion := &types.PackageVersion{
+			ID:          newVersionID,
+			PackageID:   newPackageID,
+			Version:     versionStr,
+			MelangeYaml: overriddenYAML,
+			APKRelease:  0,
+		}
+		if err := sbpackage.WritePackageVersionProvides(ctx, tx, newPackageVersion); err != nil {
+			return nil, fmt.Errorf("write package version provides: %w", err)
+		}
+
 		if err := tx.Commit(ctx); err != nil {
 			return nil, fmt.Errorf("commit transaction: %w", err)
 		}
@@ -710,6 +722,37 @@ func processGitLinkedNewVersion(ctx context.Context, githubClient *github.Client
 		if err != nil {
 			return nil, fmt.Errorf("insert additional file %s: %w", af.Path, err)
 		}
+	}
+
+	// Create subpackage version rows (melange_yaml = nil, same version/release as main package)
+	subpackages, err := sbpackage.ListSubpackages(ctx, existingPackageID)
+	if err != nil {
+		return nil, fmt.Errorf("list subpackages: %w", err)
+	}
+	for _, subpackage := range subpackages {
+		newID, err := securerandom.Hex(32)
+		if err != nil {
+			return nil, fmt.Errorf("generate random id for subpackage version: %w", err)
+		}
+		_, err = tx.Exec(ctx, `
+			INSERT INTO package_version (id, package_id, version, melange_yaml, created_at, updated_at, apk_release)
+			VALUES ($1, $2, $3, NULL, $4, $5, 0)
+		`, newID, subpackage.ID, versionStr, now, now)
+		if err != nil {
+			return nil, fmt.Errorf("insert subpackage version %s %s-r0: %w", subpackage.Name, versionStr, err)
+		}
+	}
+
+	// Write provides for the new version
+	newPackageVersion := &types.PackageVersion{
+		ID:          newVersionID,
+		PackageID:   existingPackageID,
+		Version:     versionStr,
+		MelangeYaml: overriddenYAML,
+		APKRelease:  0,
+	}
+	if err := sbpackage.WritePackageVersionProvides(ctx, tx, newPackageVersion); err != nil {
+		return nil, fmt.Errorf("write package version provides: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -765,11 +808,11 @@ func processGitLinkedRetag(ctx context.Context, githubClient *github.Client, pf 
 		newEpoch = int(maxEpoch.Int32) + 1
 	}
 
-	// Override version and epoch in the melange YAML from the git tag
+	// Override name, version, and epoch in the melange YAML from the git tag
 	versionStr := version.String()
-	overriddenYAML, _, err := gitspec.OverrideVersionAndEpochInMelange(specContent.Content, gitTag, newEpoch)
+	overriddenYAML, _, err := gitspec.OverrideVersionAndEpochInMelange(specContent.Content, gitTag, newEpoch, packageName)
 	if err != nil {
-		return nil, fmt.Errorf("override version/epoch: %w", err)
+		return nil, fmt.Errorf("override name/version/epoch: %w", err)
 	}
 
 	now := time.Now()
@@ -807,6 +850,37 @@ func processGitLinkedRetag(ctx context.Context, githubClient *github.Client, pf 
 		}
 	}
 
+	// Create subpackage version rows (melange_yaml = nil, same version/release as main package)
+	subpackages, err := sbpackage.ListSubpackages(ctx, packageID)
+	if err != nil {
+		return nil, fmt.Errorf("list subpackages: %w", err)
+	}
+	for _, subpackage := range subpackages {
+		newID, err := securerandom.Hex(32)
+		if err != nil {
+			return nil, fmt.Errorf("generate random id for subpackage version: %w", err)
+		}
+		_, err = tx.Exec(ctx, `
+			INSERT INTO package_version (id, package_id, version, melange_yaml, created_at, updated_at, apk_release)
+			VALUES ($1, $2, $3, NULL, $4, $5, $6)
+		`, newID, subpackage.ID, versionStr, now, now, newEpoch)
+		if err != nil {
+			return nil, fmt.Errorf("insert subpackage version %s %s-r%d: %w", subpackage.Name, versionStr, newEpoch, err)
+		}
+	}
+
+	// Write provides for the new version
+	newPackageVersion := &types.PackageVersion{
+		ID:          newVersionID,
+		PackageID:   packageID,
+		Version:     versionStr,
+		MelangeYaml: overriddenYAML,
+		APKRelease:  newEpoch,
+	}
+	if err := sbpackage.WritePackageVersionProvides(ctx, tx, newPackageVersion); err != nil {
+		return nil, fmt.Errorf("write package version provides: %w", err)
+	}
+
 	if err := tx.Commit(ctx); err != nil {
 		return nil, fmt.Errorf("commit transaction: %w", err)
 	}
@@ -841,7 +915,29 @@ func generateImageAPKOsForGitLinkedVersion(ctx context.Context, githubClient *gi
 	if err != nil {
 		return nil, fmt.Errorf("query linked images: %w", err)
 	}
-	defer rows.Close()
+
+	type linkedImage struct {
+		ImageID       string
+		GitRemote     string
+		ApkoFilePath  sql.NullString
+		TagTemplate   sql.NullString
+	}
+
+	var linkedImages []linkedImage
+	for rows.Next() {
+		var img linkedImage
+		if err := rows.Scan(&img.ImageID, &img.GitRemote, &img.ApkoFilePath, &img.TagTemplate); err != nil {
+			return nil, fmt.Errorf("failed to scan image row: %w", err)
+		}
+		if !img.ApkoFilePath.Valid || img.ApkoFilePath.String == "" {
+			logger.Warn("skipping linked image with missing apko_file_path",
+				zap.String("image_id", img.ImageID),
+				zap.String("git_remote", img.GitRemote))
+			continue
+		}
+		linkedImages = append(linkedImages, img)
+	}
+	rows.Close()
 
 	// Get the package version ID for the version we just created, to look up provides
 	var packageVersionID string
@@ -879,18 +975,34 @@ func generateImageAPKOsForGitLinkedVersion(ctx context.Context, githubClient *gi
 	}
 
 	var result []*ImageAPKOInfo
-	for rows.Next() {
-		var imageID, apkoFilePath string
-		var tagTemplate sql.NullString
-		if err := rows.Scan(&imageID, &gitRemote, &apkoFilePath, &tagTemplate); err != nil {
-			logger.Warn("Failed to scan image row", zap.Error(err))
+	for _, img := range linkedImages {
+		// Check if an APKO with this git_tag already exists for this image.
+		// If it does, skip creating a duplicate.
+		var existingApkoID string
+		err := conn.QueryRow(ctx,
+			`SELECT id FROM image_apko WHERE image_id = $1 AND git_tag = $2`,
+			img.ImageID, gitTag).Scan(&existingApkoID)
+		if err != nil {
+			if err == pgx.ErrNoRows {
+				// No existing APKO — proceed with creation
+			} else {
+				logger.Error(fmt.Errorf("failed to check for existing APKO: %w", err),
+					zap.String("image_id", img.ImageID),
+					zap.String("git_tag", gitTag))
+				continue
+			}
+		} else {
+			logger.Info("APKO with git tag already exists for image, skipping",
+				zap.String("image_id", img.ImageID),
+				zap.String("git_tag", gitTag),
+				zap.String("existing_apko_id", existingApkoID))
 			continue
 		}
 
 		// Pull the APKO spec from git at the same tag
-		apkoSpec, err := gitspec.PullSpecFromGit(ctx, githubClient, gitRemote, apkoFilePath, gitTag)
+		apkoSpec, err := gitspec.PullSpecFromGit(ctx, githubClient, img.GitRemote, img.ApkoFilePath.String, gitTag)
 		if err != nil {
-			logger.Error(fmt.Errorf("failed to pull APKO spec from git for image %s: %w", imageID, err))
+			logger.Error(fmt.Errorf("failed to pull APKO spec from git for image %s: %w", img.ImageID, err))
 			continue
 		}
 
@@ -898,27 +1010,27 @@ func generateImageAPKOsForGitLinkedVersion(ctx context.Context, githubClient *gi
 		pinnedApkoYAML, err := pinCorePackageInApkoYAML(apkoSpec.Content, possibleNames, versionStr)
 		if err != nil {
 			logger.Warn("failed to pin core package in APKO YAML, using as-is",
-				zap.String("image_id", imageID),
+				zap.String("image_id", img.ImageID),
 				zap.Error(err))
 			pinnedApkoYAML = apkoSpec.Content
 		}
 
 		// Generate the OCI tag from the git tag using the template
-		template := tagTemplate.String
+		template := img.TagTemplate.String
 		if template == "" {
 			template = pf.ImageTagTemplate.String
 		}
 		ociTag := package_family.GenerateImageTag(template, gitTag)
 
 		// Create the image_apko and image_apko_version
-		apkoID, err := createLinkedImageAPKO(ctx, imageID, gitRemote, apkoFilePath, gitTag, apkoSpec.CommitSHA, ociTag, pinnedApkoYAML, packageID, versionStr)
+		apkoID, err := createLinkedImageAPKO(ctx, img.ImageID, img.GitRemote, img.ApkoFilePath.String, gitTag, apkoSpec.CommitSHA, ociTag, pinnedApkoYAML, packageID, versionStr)
 		if err != nil {
-			logger.Error(fmt.Errorf("failed to create linked image APKO for image %s: %w", imageID, err))
+			logger.Error(fmt.Errorf("failed to create linked image APKO for image %s: %w", img.ImageID, err))
 			continue
 		}
 
 		result = append(result, &ImageAPKOInfo{
-			ImageID: imageID,
+			ImageID: img.ImageID,
 			ApkoID:  apkoID,
 		})
 	}

--- a/pkg/listener/package-family-update-check.go
+++ b/pkg/listener/package-family-update-check.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-github/v61/github"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/securebuildhq/securebuild/pkg/gitspec"
 	"github.com/securebuildhq/securebuild/pkg/image"
 	imagetypes "github.com/securebuildhq/securebuild/pkg/image/types"
 	"github.com/securebuildhq/securebuild/pkg/logger"
@@ -38,6 +39,7 @@ import (
 	"github.com/securebuildhq/securebuild/pkg/param"
 	"github.com/securebuildhq/securebuild/pkg/persistence"
 	"github.com/securebuildhq/securebuild/pkg/releasemonitor"
+	"github.com/tuvistavie/securerandom"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v3"
@@ -160,6 +162,21 @@ func performPackageFamilyUpdateCheck(ctx context.Context, p *PackageFamilyUpdate
 	// Log automation mode
 	if packageFamily.DryRunMode {
 		logger.Info("Package family in dry run mode", zap.String("package_family_id", p.PackageFamilyID))
+	}
+
+	// Git-linked package families use a separate flow: detect tags from the git remote,
+	// pull specs from git, and create package versions with git link metadata.
+	if packageFamily.GitRemote.Valid && packageFamily.GitRemote.String != "" {
+		var githubClient *github.Client
+		if githubToken := param.GetParam(ctx).UpdaterGithubAPIToken; githubToken != "" {
+			ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: githubToken})
+			tc := oauth2.NewClient(ctx, ts)
+			githubClient = github.NewClient(tc)
+		} else {
+			githubClient = github.NewClient(nil)
+			logger.Warn("No GitHub API token found, using unauthenticated client")
+		}
+		return performGitLinkedUpdateCheck(ctx, githubClient, packageFamily)
 	}
 
 	// Get the current highest version for this family to extract upstream config
@@ -323,7 +340,683 @@ func performPackageFamilyUpdateCheck(ctx context.Context, p *PackageFamilyUpdate
 	return nil
 }
 
-// processPackageFamilyVersion processes a single detected version for a package family
+// performGitLinkedUpdateCheck handles the update check for git-linked package families.
+// Instead of using the melange YAML's update block, it lists tags from the git remote,
+// filters by semver, and creates package versions by pulling specs from git.
+func performGitLinkedUpdateCheck(ctx context.Context, githubClient *github.Client, pf *package_family.PackageFamily) error {
+	gitRemote := pf.GitRemote.String
+	melangeFilePath := pf.MelangeFilePath.String
+
+	logger.Info("Performing git-linked update check",
+		zap.String("package_family_id", pf.ID),
+		zap.String("git_remote", gitRemote),
+		zap.String("melange_file_path", melangeFilePath))
+
+	// List all tags from the git repo
+	tags, err := gitspec.ListTags(ctx, githubClient, gitRemote)
+	if err != nil {
+		return fmt.Errorf("failed to list tags from %s: %w", gitRemote, err)
+	}
+
+	// Parse and filter tags: only semver, no pre-release
+	var semverTags []*semver.Version
+	for _, tag := range tags {
+		v, err := semver.NewVersion(tag)
+		if err != nil {
+			continue
+		}
+		if v.Prerelease() != "" {
+			continue
+		}
+		semverTags = append(semverTags, v)
+	}
+
+	// Sort descending (newest first)
+	sort.Sort(sort.Reverse(semver.Collection(semverTags)))
+
+	// Get existing versions and their git tags from the database
+	existingVersions, err := getExistingVersionsForFamily(ctx, pf)
+	if err != nil {
+		return fmt.Errorf("failed to get existing versions: %w", err)
+	}
+
+	// Build a map of existing version strings for quick lookup
+	existingVersionSet := make(map[string]bool)
+	for _, v := range existingVersions {
+		existingVersionSet[v.Version] = true
+	}
+
+	// Determine the floor version: the highest existing version in the DB,
+	// or the initial_tag if no versions exist yet.
+	var floorVersion *semver.Version
+	for _, v := range existingVersions {
+		parsed, err := semver.NewVersion(v.Version)
+		if err != nil {
+			continue
+		}
+		if floorVersion == nil || parsed.GreaterThan(floorVersion) {
+			floorVersion = parsed
+		}
+	}
+
+	// If no existing versions, use the initial_tag from the package family as the floor.
+	// The initial_tag is the starting point — tags at or newer than it should be processed.
+	usingInitialTag := false
+	if floorVersion == nil && pf.InitialTag.Valid && pf.InitialTag.String != "" {
+		if parsed, err := semver.NewVersion(pf.InitialTag.String); err == nil {
+			floorVersion = parsed
+			usingInitialTag = true
+		}
+	}
+
+	if floorVersion != nil {
+		logger.Info("Git-linked update check floor",
+			zap.String("package_family_id", pf.ID),
+			zap.String("floor_version", floorVersion.String()),
+			zap.Bool("from_initial_tag", usingInitialTag))
+	}
+
+	// Filter tags: only keep those newer than the floor.
+	// When using initial_tag, include the initial tag itself (>=).
+	// When using existing versions, only newer tags (>).
+	var filteredTags []*semver.Version
+	for _, v := range semverTags {
+		if floorVersion != nil {
+			if usingInitialTag {
+				if v.LessThan(floorVersion) {
+					continue
+				}
+			} else {
+				if !v.GreaterThan(floorVersion) {
+					continue
+				}
+			}
+		}
+		filteredTags = append(filteredTags, v)
+	}
+
+	// Also get existing git tags and their commit SHAs to detect re-tags
+	existingGitTags, err := getExistingGitTagsForFamily(ctx, pf)
+	if err != nil {
+		return fmt.Errorf("failed to get existing git tags: %w", err)
+	}
+
+	// Determine which tags are new or re-tagged
+	var updateResults []*UpdateResult
+	for _, v := range filteredTags {
+		versionStr := v.Original()
+		tagStr := versionStr
+
+		// Skip if version already exists and tag hasn't been re-assigned
+		if existingVersionSet[versionStr] {
+			// Check if the tag has been re-assigned to a new commit
+			existingSHA, exists := existingGitTags[tagStr]
+			if !exists {
+				// Version exists but we don't have a git_tag recorded (non-linked version)
+				// Skip — this version was created before the git link
+				continue
+			}
+
+			// Resolve the current tag to a commit SHA
+			currentSHA, err := gitspec.ResolveTagToCommit(ctx, githubClient, gitRemote, tagStr)
+			if err != nil {
+				logger.Warn("Failed to resolve tag to commit, skipping",
+					zap.String("tag", tagStr),
+					zap.Error(err))
+				continue
+			}
+
+			if currentSHA == existingSHA {
+				// Tag points to the same commit — no change
+				continue
+			}
+
+			// Tag has been re-assigned to a new commit — create a new revision
+			result, err := processGitLinkedRetag(ctx, githubClient, pf, v, tagStr, currentSHA, melangeFilePath)
+			if err != nil {
+				logger.Error(fmt.Errorf("failed to process re-tag for %s: %w", tagStr, err))
+				continue
+			}
+			if result != nil {
+				updateResults = append(updateResults, result)
+			}
+			continue
+		}
+
+		// New version — pull spec from git and create package version
+		result, err := processGitLinkedNewVersion(ctx, githubClient, pf, v, tagStr, melangeFilePath)
+		if err != nil {
+			logger.Error(fmt.Errorf("failed to process new version %s: %w", tagStr, err))
+			continue
+		}
+		if result != nil {
+			updateResults = append(updateResults, result)
+		}
+	}
+
+	if len(updateResults) == 0 {
+		logger.Info("No new versions found for git-linked family", zap.String("package_family_id", pf.ID))
+		return nil
+	}
+
+	// Reassign tags globally before queueing builds
+	if err := reassignTagsGlobally(ctx, pf, updateResults); err != nil {
+		logger.Error(fmt.Errorf("failed to reassign tags globally: %w", err))
+	}
+
+	// Queue builds
+	for _, result := range updateResults {
+		if result.SkipBuild {
+			for _, apkoInfo := range result.ImageAPKOs {
+				if err := queueImageBuildForAPKO(ctx, apkoInfo.ApkoID); err != nil {
+					logger.Error(fmt.Errorf("failed to queue image build for APKO %s: %w", apkoInfo.ApkoID, err))
+				}
+			}
+			continue
+		}
+		if err := queuePackageBuild(ctx, pf, result); err != nil {
+			logger.Error(fmt.Errorf("failed to queue build: %w", err))
+		}
+	}
+
+	return nil
+}
+
+// getExistingGitTagsForFamily returns a map of git_tag -> git_commit_sha for all
+// package versions in a family that have git link metadata.
+func getExistingGitTagsForFamily(ctx context.Context, pf *package_family.PackageFamily) (map[string]string, error) {
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+
+	tmpl := "{name}-{major}.{minor}"
+	if pf.PackageNameTemplate != "" {
+		tmpl = pf.PackageNameTemplate
+	}
+	tmpl = strings.ReplaceAll(tmpl, "{name}", regexp.QuoteMeta(pf.Name))
+	tmpl = strings.ReplaceAll(tmpl, "{major}", "[0-9]+")
+	tmpl = strings.ReplaceAll(tmpl, "{minor}", "[0-9]+")
+	familyPattern := "^" + tmpl + "$"
+
+	query := `
+		SELECT pv.git_tag, pv.git_commit_sha
+		FROM package_version pv
+		INNER JOIN package p ON p.id = pv.package_id
+		WHERE p.parent_id IS NULL
+		  AND p.name ~ $1
+		  AND pv.git_tag IS NOT NULL
+		  AND pv.git_commit_sha IS NOT NULL
+	`
+
+	rows, err := conn.Query(ctx, query, familyPattern)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query existing git tags: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]string)
+	for rows.Next() {
+		var gitTag, gitCommitSHA string
+		if err := rows.Scan(&gitTag, &gitCommitSHA); err != nil {
+			continue
+		}
+		result[gitTag] = gitCommitSHA
+	}
+
+	return result, nil
+}
+
+// processGitLinkedNewVersion creates a new package version from a git tag.
+// It pulls the melange spec from git, overrides version and epoch from the git tag,
+// and creates the DB records.
+func processGitLinkedNewVersion(ctx context.Context, githubClient *github.Client, pf *package_family.PackageFamily, version *semver.Version, gitTag, melangeFilePath string) (*UpdateResult, error) {
+	gitRemote := pf.GitRemote.String
+
+	// Pull the melange spec and additional files from git
+	specContent, err := gitspec.PullSpecFromGit(ctx, githubClient, gitRemote, melangeFilePath, gitTag)
+	if err != nil {
+		return nil, fmt.Errorf("pull spec from git: %w", err)
+	}
+
+	// Override version and epoch in the melange YAML from the git tag
+	overriddenYAML, versionStr, err := gitspec.OverrideVersionAndEpochInMelange(specContent.Content, gitTag, 0)
+	if err != nil {
+		return nil, fmt.Errorf("override version/epoch: %w", err)
+	}
+
+	// Determine the package name from the template
+	packageName := package_family.GeneratePackageName(pf.PackageNameTemplate, pf.Name, int(version.Major()), int(version.Minor()))
+
+	// Check if the package already exists
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+
+	var existingPackageID string
+	err = conn.QueryRow(ctx, `SELECT id FROM package WHERE name = $1 AND parent_id IS NULL`, packageName).Scan(&existingPackageID)
+
+	if err != nil && err != pgx.ErrNoRows {
+		return nil, fmt.Errorf("check existing package: %w", err)
+	}
+
+	now := time.Now()
+
+	if err == pgx.ErrNoRows {
+		// New package — create it
+		newPackageID, err := securerandom.Hex(32)
+		if err != nil {
+			return nil, fmt.Errorf("generate package id: %w", err)
+		}
+
+		tx, err := conn.Begin(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("begin transaction: %w", err)
+		}
+		defer tx.Rollback(ctx)
+
+		_, err = tx.Exec(ctx, `
+			INSERT INTO package (id, name, created_at, updated_at)
+			VALUES ($1, $2, $3, $4)
+		`, newPackageID, packageName, now, now)
+		if err != nil {
+			return nil, fmt.Errorf("insert package: %w", err)
+		}
+
+		// Link package to family
+		_, err = tx.Exec(ctx, `
+			INSERT INTO package_family_package (package_family_id, package_id, created_at)
+			VALUES ($1, $2, $3)
+		`, pf.ID, newPackageID, now)
+		if err != nil {
+			return nil, fmt.Errorf("insert package_family_package: %w", err)
+		}
+
+		// Create the package version with git link metadata
+		newVersionID, err := securerandom.Hex(32)
+		if err != nil {
+			return nil, fmt.Errorf("generate version id: %w", err)
+		}
+
+		_, err = tx.Exec(ctx, `
+			INSERT INTO package_version (id, package_id, version, melange_yaml, created_at, updated_at, apk_release, git_remote, melange_file_path, git_tag, git_commit_sha)
+			VALUES ($1, $2, $3, $4, $5, $6, 0, $7, $8, $9, $10)
+		`, newVersionID, newPackageID, versionStr, overriddenYAML, now, now, gitRemote, melangeFilePath, gitTag, specContent.CommitSHA)
+		if err != nil {
+			return nil, fmt.Errorf("insert package version: %w", err)
+		}
+
+		// Insert additional files
+		for _, af := range specContent.AdditionalFiles {
+			afID, err := securerandom.Hex(32)
+			if err != nil {
+				return nil, fmt.Errorf("generate additional file id: %w", err)
+			}
+			_, err = tx.Exec(ctx, `
+				INSERT INTO package_version_additional_file (id, package_version_id, path, content, created_at, updated_at)
+				VALUES ($1, $2, $3, $4, $5, $6)
+			`, afID, newVersionID, af.Path, af.Content, now, now)
+			if err != nil {
+				return nil, fmt.Errorf("insert additional file %s: %w", af.Path, err)
+			}
+		}
+
+		if err := tx.Commit(ctx); err != nil {
+			return nil, fmt.Errorf("commit transaction: %w", err)
+		}
+
+		// Generate image APKOs if the image is linked to git
+		imageAPKOs, err := generateImageAPKOsForGitLinkedVersion(ctx, githubClient, pf, gitTag, gitRemote, melangeFilePath, newPackageID, packageName, versionStr)
+		if err != nil {
+			logger.Error(fmt.Errorf("failed to generate image APKOs: %w", err))
+		}
+
+		return &UpdateResult{
+			PackageID:        newPackageID,
+			PackageVersionID: newVersionID,
+			CreateNewPackage: true,
+			MelangeYAML:      overriddenYAML,
+			ImageAPKOs:       imageAPKOs,
+		}, nil
+	}
+
+	// Package exists — create a new version (apk_release = 0 for a new version)
+	newVersionID, err := securerandom.Hex(32)
+	if err != nil {
+		return nil, fmt.Errorf("generate version id: %w", err)
+	}
+
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	_, err = tx.Exec(ctx, `
+		INSERT INTO package_version (id, package_id, version, melange_yaml, created_at, updated_at, apk_release, git_remote, melange_file_path, git_tag, git_commit_sha)
+		VALUES ($1, $2, $3, $4, $5, $6, 0, $7, $8, $9, $10)
+	`, newVersionID, existingPackageID, versionStr, overriddenYAML, now, now, gitRemote, melangeFilePath, gitTag, specContent.CommitSHA)
+	if err != nil {
+		return nil, fmt.Errorf("insert package version: %w", err)
+	}
+
+	// Insert additional files
+	for _, af := range specContent.AdditionalFiles {
+		afID, err := securerandom.Hex(32)
+		if err != nil {
+			return nil, fmt.Errorf("generate additional file id: %w", err)
+		}
+		_, err = tx.Exec(ctx, `
+			INSERT INTO package_version_additional_file (id, package_version_id, path, content, created_at, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6)
+		`, afID, newVersionID, af.Path, af.Content, now, now)
+		if err != nil {
+			return nil, fmt.Errorf("insert additional file %s: %w", af.Path, err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit transaction: %w", err)
+	}
+
+	// Generate image APKOs if the image is linked to git
+	imageAPKOs, err := generateImageAPKOsForGitLinkedVersion(ctx, githubClient, pf, gitTag, gitRemote, melangeFilePath, existingPackageID, packageName, versionStr)
+	if err != nil {
+		logger.Error(fmt.Errorf("failed to generate image APKOs: %w", err))
+	}
+
+	return &UpdateResult{
+		PackageID:        existingPackageID,
+		PackageVersionID: newVersionID,
+		ImageAPKOs:       imageAPKOs,
+	}, nil
+}
+
+// processGitLinkedRetag creates a new revision (incremented apk_release) when a git tag
+// has been reassigned to a new commit SHA.
+func processGitLinkedRetag(ctx context.Context, githubClient *github.Client, pf *package_family.PackageFamily, version *semver.Version, gitTag, newCommitSHA, melangeFilePath string) (*UpdateResult, error) {
+	gitRemote := pf.GitRemote.String
+
+	// Pull the melange spec from git at the re-tagged commit
+	specContent, err := gitspec.PullSpecFromGit(ctx, githubClient, gitRemote, melangeFilePath, gitTag)
+	if err != nil {
+		return nil, fmt.Errorf("pull spec from git: %w", err)
+	}
+
+	packageName := package_family.GeneratePackageName(pf.PackageNameTemplate, pf.Name, int(version.Major()), int(version.Minor()))
+
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+
+	// Find the existing package
+	var packageID string
+	err = conn.QueryRow(ctx, `SELECT id FROM package WHERE name = $1 AND parent_id IS NULL`, packageName).Scan(&packageID)
+	if err != nil {
+		return nil, fmt.Errorf("find package %s: %w", packageName, err)
+	}
+
+	// Calculate new apk_release
+	var maxEpoch sql.NullInt32
+	err = conn.QueryRow(ctx,
+		`SELECT MAX(apk_release) FROM package_version WHERE package_id = $1 AND version = $2`,
+		packageID, version.String()).Scan(&maxEpoch)
+	if err != nil {
+		return nil, fmt.Errorf("get max apk_release: %w", err)
+	}
+	newEpoch := 0
+	if maxEpoch.Valid {
+		newEpoch = int(maxEpoch.Int32) + 1
+	}
+
+	// Override version and epoch in the melange YAML from the git tag
+	versionStr := version.String()
+	overriddenYAML, _, err := gitspec.OverrideVersionAndEpochInMelange(specContent.Content, gitTag, newEpoch)
+	if err != nil {
+		return nil, fmt.Errorf("override version/epoch: %w", err)
+	}
+
+	now := time.Now()
+	newVersionID, err := securerandom.Hex(32)
+	if err != nil {
+		return nil, fmt.Errorf("generate version id: %w", err)
+	}
+
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	_, err = tx.Exec(ctx, `
+		INSERT INTO package_version (id, package_id, version, melange_yaml, created_at, updated_at, apk_release, git_remote, melange_file_path, git_tag, git_commit_sha)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+	`, newVersionID, packageID, versionStr, overriddenYAML, now, now, newEpoch, gitRemote, melangeFilePath, gitTag, newCommitSHA)
+	if err != nil {
+		return nil, fmt.Errorf("insert package version: %w", err)
+	}
+
+	// Insert additional files
+	for _, af := range specContent.AdditionalFiles {
+		afID, err := securerandom.Hex(32)
+		if err != nil {
+			return nil, fmt.Errorf("generate additional file id: %w", err)
+		}
+		_, err = tx.Exec(ctx, `
+			INSERT INTO package_version_additional_file (id, package_version_id, path, content, created_at, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6)
+		`, afID, newVersionID, af.Path, af.Content, now, now)
+		if err != nil {
+			return nil, fmt.Errorf("insert additional file %s: %w", af.Path, err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit transaction: %w", err)
+	}
+
+	// Generate image APKOs
+	imageAPKOs, err := generateImageAPKOsForGitLinkedVersion(ctx, githubClient, pf, gitTag, gitRemote, melangeFilePath, packageID, packageName, versionStr)
+	if err != nil {
+		logger.Error(fmt.Errorf("failed to generate image APKOs: %w", err))
+	}
+
+	return &UpdateResult{
+		PackageID:        packageID,
+		PackageVersionID: newVersionID,
+		ImageAPKOs:       imageAPKOs,
+	}, nil
+}
+
+// generateImageAPKOsForGitLinkedVersion generates image APKOs for a git-linked package version.
+// If the image is linked to git, it pulls the APKO spec from the repo. Otherwise, it uses
+// the existing clone logic.
+func generateImageAPKOsForGitLinkedVersion(ctx context.Context, githubClient *github.Client, pf *package_family.PackageFamily, gitTag, gitRemote, melangeFilePath string, packageID, packageName, versionStr string) ([]*ImageAPKOInfo, error) {
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+
+	// Find images linked to git that are associated with this package family
+	// by checking if the image's git_remote matches the package family's git_remote
+	rows, err := conn.Query(ctx, `
+		SELECT i.id, i.git_remote, i.apko_file_path, i.image_tag_template
+		FROM image i
+		WHERE i.git_remote = $1
+	`, gitRemote)
+	if err != nil {
+		return nil, fmt.Errorf("query linked images: %w", err)
+	}
+	defer rows.Close()
+
+	// Get the package version ID for the version we just created, to look up provides
+	var packageVersionID string
+	err = conn.QueryRow(ctx, `
+		SELECT pv.id FROM package_version pv
+		WHERE pv.package_id = $1 AND pv.version = $2 AND pv.apk_release = 0
+		ORDER BY pv.created_at DESC LIMIT 1
+	`, packageID, versionStr).Scan(&packageVersionID)
+	if err != nil {
+		logger.Warn("failed to get package version ID for provides lookup, skipping pinning",
+			zap.String("package_id", packageID),
+			zap.String("version", versionStr),
+			zap.Error(err))
+	}
+
+	// Collect possible package names for core package detection
+	possibleNames := make(map[string]struct{})
+	possibleNames[pf.Name] = struct{}{}
+	possibleNames[packageName] = struct{}{}
+	if packageVersionID != "" {
+		providesRows, err := conn.Query(ctx, `
+			SELECT package_name, provides_name FROM package_version_provides WHERE package_version_id = $1
+		`, packageVersionID)
+		if err == nil {
+			for providesRows.Next() {
+				var pkgName, providesName string
+				if err := providesRows.Scan(&pkgName, &providesName); err != nil {
+					continue
+				}
+				possibleNames[pkgName] = struct{}{}
+				possibleNames[providesName] = struct{}{}
+			}
+			providesRows.Close()
+		}
+	}
+
+	var result []*ImageAPKOInfo
+	for rows.Next() {
+		var imageID, apkoFilePath string
+		var tagTemplate sql.NullString
+		if err := rows.Scan(&imageID, &gitRemote, &apkoFilePath, &tagTemplate); err != nil {
+			logger.Warn("Failed to scan image row", zap.Error(err))
+			continue
+		}
+
+		// Pull the APKO spec from git at the same tag
+		apkoSpec, err := gitspec.PullSpecFromGit(ctx, githubClient, gitRemote, apkoFilePath, gitTag)
+		if err != nil {
+			logger.Error(fmt.Errorf("failed to pull APKO spec from git for image %s: %w", imageID, err))
+			continue
+		}
+
+		// Pin the core package to the correct version in the APKO YAML
+		pinnedApkoYAML, err := pinCorePackageInApkoYAML(apkoSpec.Content, possibleNames, versionStr)
+		if err != nil {
+			logger.Warn("failed to pin core package in APKO YAML, using as-is",
+				zap.String("image_id", imageID),
+				zap.Error(err))
+			pinnedApkoYAML = apkoSpec.Content
+		}
+
+		// Generate the OCI tag from the git tag using the template
+		template := tagTemplate.String
+		if template == "" {
+			template = pf.ImageTagTemplate.String
+		}
+		ociTag := package_family.GenerateImageTag(template, gitTag)
+
+		// Create the image_apko and image_apko_version
+		apkoID, err := createLinkedImageAPKO(ctx, imageID, gitRemote, apkoFilePath, gitTag, apkoSpec.CommitSHA, ociTag, pinnedApkoYAML, packageID, versionStr)
+		if err != nil {
+			logger.Error(fmt.Errorf("failed to create linked image APKO for image %s: %w", imageID, err))
+			continue
+		}
+
+		result = append(result, &ImageAPKOInfo{
+			ImageID: imageID,
+			ApkoID:  apkoID,
+		})
+	}
+
+	return result, nil
+}
+
+// createLinkedImageAPKO creates an image_apko and image_apko_version for a linked image.
+func createLinkedImageAPKO(ctx context.Context, imageID, gitRemote, apkoFilePath, gitTag, commitSHA, ociTag, apkoYAML, packageID, pinnedVersion string) (string, error) {
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+
+	apkoID, err := securerandom.Hex(32)
+	if err != nil {
+		return "", fmt.Errorf("generate apko id: %w", err)
+	}
+
+	apkoVersionID, err := securerandom.Hex(32)
+	if err != nil {
+		return "", fmt.Errorf("generate apko version id: %w", err)
+	}
+
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return "", fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	_, err = tx.Exec(ctx, `
+		INSERT INTO image_apko (id, image_id, name, tags, created_at, updated_at, git_remote, git_tag, apko_file_path)
+		VALUES ($1, $2, $3, $4, NOW(), NOW(), $5, $6, $7)
+	`, apkoID, imageID, ociTag, []string{ociTag}, gitRemote, gitTag, apkoFilePath)
+	if err != nil {
+		return "", fmt.Errorf("insert image_apko: %w", err)
+	}
+
+	_, err = tx.Exec(ctx, `
+		INSERT INTO image_apko_version (id, image_apko_id, apko_yaml, created_at, updated_at, git_remote, apko_file_path, git_commit_sha)
+		VALUES ($1, $2, $3, NOW(), NOW(), $4, $5, $6)
+	`, apkoVersionID, apkoID, apkoYAML, gitRemote, apkoFilePath, commitSHA)
+	if err != nil {
+		return "", fmt.Errorf("insert image_apko_version: %w", err)
+	}
+
+	// Link the package to the image with the pinned version
+	// This ensures that when the package finishes building, the APKO build is triggered
+	if packageID != "" && pinnedVersion != "" {
+		_, err = tx.Exec(ctx, `
+			INSERT INTO image_package (image_id, apko_id, package_id, pinned_version)
+			VALUES ($1, $2, $3, $4)
+			ON CONFLICT (apko_id, package_id) DO UPDATE
+			SET pinned_version = EXCLUDED.pinned_version
+		`, imageID, apkoID, packageID, pinnedVersion)
+		if err != nil {
+			return "", fmt.Errorf("failed to insert into image_package: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return "", fmt.Errorf("commit transaction: %w", err)
+	}
+
+	return apkoID, nil
+}
+// pinCorePackageInApkoYAML finds the core package in the APKO YAML and pins it to the
+// specified version using the ~version syntax. Uses the same package detection logic
+// as IsPackageCoreForAPKO (matching by family name, package name, and provides).
+func pinCorePackageInApkoYAML(apkoYAML string, possibleNames map[string]struct{}, version string) (string, error) {
+	var imageConfig apkotypes.ImageConfiguration
+	if err := yaml.Unmarshal([]byte(apkoYAML), &imageConfig); err != nil {
+		return "", fmt.Errorf("failed to parse APKO YAML: %w", err)
+	}
+
+	// Build a map of replacements
+	replacements := make(map[string]string)
+
+	for _, pkg := range imageConfig.Contents.Packages {
+		parsed := apkopackage.ResolvePackageNameVersionPin(pkg)
+		if parsed.Name == "" {
+			continue
+		}
+
+		if _, exists := possibleNames[parsed.Name]; exists {
+			// Pin this package to the correct version
+			newPkg := fmt.Sprintf("%s~%s", parsed.Name, version)
+			replacements[pkg] = newPkg
+		}
+	}
+
+	// Apply replacements to the YAML string, preserving formatting
+	result := apkoYAML
+	for oldPkg, newPkg := range replacements {
+		result = strings.ReplaceAll(result, oldPkg, newPkg)
+	}
+
+	return result, nil
+}
+
 // Routes to either processMinorVersionUpdate or processPatchVersionUpdate based on version change type
 func processPackageFamilyVersion(ctx context.Context, pf *package_family.PackageFamily, versionUpdate *VersionUpdate) (*UpdateResult, error) {
 	version := versionUpdate.Version

--- a/pkg/package/package.go
+++ b/pkg/package/package.go
@@ -553,7 +553,7 @@ func changeVersionInMelangeYAML(ctx context.Context, melangeYAML string, version
 		zap.String("commit", commit),
 	)
 
-	result, _, err := gitspec.OverrideVersionAndEpochInMelange(melangeYAML, version, 0)
+	result, _, err := gitspec.OverrideVersionAndEpochInMelange(melangeYAML, version, 0, "")
 	if err != nil {
 		return "", fmt.Errorf("override version/epoch: %w", err)
 	}

--- a/pkg/package/package.go
+++ b/pkg/package/package.go
@@ -17,10 +17,12 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/jackc/pgx/v5"
 	"github.com/securebuildhq/securebuild/pkg/builder"
+	"github.com/securebuildhq/securebuild/pkg/gitspec"
 	"github.com/securebuildhq/securebuild/pkg/logger"
 	"github.com/securebuildhq/securebuild/pkg/package/types"
 	"github.com/securebuildhq/securebuild/pkg/persistence"
 	"github.com/securebuildhq/securebuild/pkg/pipeline"
+	"github.com/securebuildhq/securebuild/pkg/util"
 	"github.com/tuvistavie/securerandom"
 	"go.uber.org/zap"
 )
@@ -551,21 +553,17 @@ func changeVersionInMelangeYAML(ctx context.Context, melangeYAML string, version
 		zap.String("commit", commit),
 	)
 
-	lines := strings.Split(melangeYAML, "\n")
+	result, _, err := gitspec.OverrideVersionAndEpochInMelange(melangeYAML, version, 0)
+	if err != nil {
+		return "", fmt.Errorf("override version/epoch: %w", err)
+	}
 
+	lines := strings.Split(result, "\n")
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		leadingWhitespace := line[:len(line)-len(trimmed)]
-		if strings.HasPrefix(trimmed, "version:") {
-			lines[i] = fmt.Sprintf("%sversion: %q", leadingWhitespace, version)
-		}
-
 		if strings.HasPrefix(trimmed, "expected-commit:") {
 			lines[i] = fmt.Sprintf("%sexpected-commit: %s", leadingWhitespace, commit)
-		}
-
-		if strings.HasPrefix(trimmed, "epoch:") {
-			lines[i] = fmt.Sprintf("%sepoch: %d", leadingWhitespace, 0)
 		}
 	}
 
@@ -664,9 +662,9 @@ func CreateNewReleaseForLatestPackageVersion(ctx context.Context, packageID stri
 	}
 
 	_, err = tx.Exec(ctx, `
-		INSERT INTO package_version (id, package_id, version, melange_yaml, created_at, updated_at, apk_release, license, use_root, bootstrap_enabled, bootstrap_apk_repository, bootstrap_keyring_append)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-	`, newVersionID, packageID, newVersion, updatedMelangeYAML, now, now, release, latestVersion.License, latestVersion.UseRoot, latestVersion.BootstrapEnabled, latestVersion.BootstrapApkRepository, latestVersion.BootstrapKeyringAppend)
+		INSERT INTO package_version (id, package_id, version, melange_yaml, created_at, updated_at, apk_release, license, use_root, bootstrap_enabled, bootstrap_apk_repository, bootstrap_keyring_append, git_remote, melange_file_path, git_tag, git_commit_sha)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+	`, newVersionID, packageID, newVersion, updatedMelangeYAML, now, now, release, latestVersion.License, latestVersion.UseRoot, latestVersion.BootstrapEnabled, latestVersion.BootstrapApkRepository, latestVersion.BootstrapKeyringAppend, util.NullIfEmpty(latestVersion.GitRemote), util.NullIfEmpty(latestVersion.MelangeFilePath), util.NullIfEmpty(latestVersion.GitTag), util.NullIfEmpty(latestVersion.GitCommitSHA))
 	if err != nil {
 		return nil, fmt.Errorf("insert new package version: %w", err)
 	}
@@ -791,13 +789,14 @@ func getPackageVersion(ctx context.Context, packageVersionID string) (*types.Pac
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
-	query := `SELECT id, package_id, version, melange_yaml, created_at, apk_release, use_root, bootstrap_enabled, bootstrap_apk_repository, bootstrap_keyring_append, custom_disk_size FROM package_version WHERE id = $1`
+	query := `SELECT id, package_id, version, melange_yaml, created_at, apk_release, use_root, bootstrap_enabled, bootstrap_apk_repository, bootstrap_keyring_append, custom_disk_size, git_remote, melange_file_path, git_tag, git_commit_sha FROM package_version WHERE id = $1`
 	var p types.PackageVersion
 	var melangeYaml sql.NullString
 	var bootstrapApkRepository sql.NullString
 	var bootstrapKeyringAppend sql.NullString
 	var customDiskSize sql.NullInt32
-	err := conn.QueryRow(ctx, query, packageVersionID).Scan(&p.ID, &p.PackageID, &p.Version, &melangeYaml, &p.CreatedAt, &p.APKRelease, &p.UseRoot, &p.BootstrapEnabled, &bootstrapApkRepository, &bootstrapKeyringAppend, &customDiskSize)
+	var gitRemote, melangeFilePath, gitTag, gitCommitSHA sql.NullString
+	err := conn.QueryRow(ctx, query, packageVersionID).Scan(&p.ID, &p.PackageID, &p.Version, &melangeYaml, &p.CreatedAt, &p.APKRelease, &p.UseRoot, &p.BootstrapEnabled, &bootstrapApkRepository, &bootstrapKeyringAppend, &customDiskSize, &gitRemote, &melangeFilePath, &gitTag, &gitCommitSHA)
 	if err != nil {
 		return nil, fmt.Errorf("get package version: %w", err)
 	}
@@ -818,6 +817,11 @@ func getPackageVersion(ctx context.Context, packageVersionID string) (*types.Pac
 		diskSize := int(customDiskSize.Int32)
 		p.CustomDiskSize = &diskSize
 	}
+
+	p.GitRemote = gitRemote.String
+	p.MelangeFilePath = melangeFilePath.String
+	p.GitTag = gitTag.String
+	p.GitCommitSHA = gitCommitSHA.String
 
 	return &p, nil
 }
@@ -846,13 +850,14 @@ func SetCustomDiskSize(ctx context.Context, packageVersionID string, diskSize *i
 }
 
 func getPackageVersionWithTx(ctx context.Context, tx pgx.Tx, packageVersionID string) (*types.PackageVersion, error) {
-	query := `SELECT id, package_id, version, melange_yaml, created_at, apk_release, use_root, bootstrap_enabled, bootstrap_apk_repository, bootstrap_keyring_append, custom_disk_size FROM package_version WHERE id = $1`
+	query := `SELECT id, package_id, version, melange_yaml, created_at, apk_release, use_root, bootstrap_enabled, bootstrap_apk_repository, bootstrap_keyring_append, custom_disk_size, git_remote, melange_file_path, git_tag, git_commit_sha FROM package_version WHERE id = $1`
 	var p types.PackageVersion
 	var melangeYaml sql.NullString
 	var bootstrapApkRepository sql.NullString
 	var bootstrapKeyringAppend sql.NullString
 	var customDiskSize sql.NullInt32
-	err := tx.QueryRow(ctx, query, packageVersionID).Scan(&p.ID, &p.PackageID, &p.Version, &melangeYaml, &p.CreatedAt, &p.APKRelease, &p.UseRoot, &p.BootstrapEnabled, &bootstrapApkRepository, &bootstrapKeyringAppend, &customDiskSize)
+	var gitRemote, melangeFilePath, gitTag, gitCommitSHA sql.NullString
+	err := tx.QueryRow(ctx, query, packageVersionID).Scan(&p.ID, &p.PackageID, &p.Version, &melangeYaml, &p.CreatedAt, &p.APKRelease, &p.UseRoot, &p.BootstrapEnabled, &bootstrapApkRepository, &bootstrapKeyringAppend, &customDiskSize, &gitRemote, &melangeFilePath, &gitTag, &gitCommitSHA)
 	if err != nil {
 		return nil, fmt.Errorf("get package version: %w", err)
 	}
@@ -873,6 +878,11 @@ func getPackageVersionWithTx(ctx context.Context, tx pgx.Tx, packageVersionID st
 		diskSize := int(customDiskSize.Int32)
 		p.CustomDiskSize = &diskSize
 	}
+
+	p.GitRemote = gitRemote.String
+	p.MelangeFilePath = melangeFilePath.String
+	p.GitTag = gitTag.String
+	p.GitCommitSHA = gitCommitSHA.String
 
 	return &p, nil
 }

--- a/pkg/package/types/types.go
+++ b/pkg/package/types/types.go
@@ -104,6 +104,12 @@ type PackageVersion struct {
 
 	// Custom disk size for build VMs (in GB)
 	CustomDiskSize *int `json:"customDiskSize"`
+
+	// Git link fields (set when the package version is from an external git repo)
+	GitRemote       string `json:"gitRemote"`
+	MelangeFilePath string `json:"melangeFilePath"`
+	GitTag          string `json:"gitTag"`
+	GitCommitSHA    string `json:"gitCommitSha"`
 }
 
 type AdditionalFile struct {

--- a/pkg/package_family/package_family.go
+++ b/pkg/package_family/package_family.go
@@ -27,7 +27,7 @@ func GetPackageFamily(ctx context.Context, id string) (*PackageFamily, error) {
 		dry_run_mode, min_version, notify_on_detection,
 		notify_on_build_failure, check_for_updates_at, last_check_at,
 		last_error, consecutive_errors, created_at, updated_at,
-		image_tag_template
+		image_tag_template, git_remote, melange_file_path, initial_tag
 		FROM package_family WHERE id = $1`
 
 	var pf PackageFamily
@@ -38,7 +38,7 @@ func GetPackageFamily(ctx context.Context, id string) (*PackageFamily, error) {
 		&pf.DryRunMode, &pf.MinVersion, &pf.NotifyOnDetection,
 		&pf.NotifyOnBuildFailure, &pf.CheckForUpdatesAt, &pf.LastCheckAt,
 		&pf.LastError, &pf.ConsecutiveErrors, &pf.CreatedAt, &pf.UpdatedAt,
-		&pf.ImageTagTemplate,
+		&pf.ImageTagTemplate, &pf.GitRemote, &pf.MelangeFilePath, &pf.InitialTag,
 	)
 	if err != nil {
 		if err == pgx.ErrNoRows {

--- a/pkg/package_family/types.go
+++ b/pkg/package_family/types.go
@@ -24,4 +24,7 @@ type PackageFamily struct {
 	CreatedAt             time.Time      `json:"created_at" db:"created_at"`
 	UpdatedAt             time.Time      `json:"updated_at" db:"updated_at"`
 	ImageTagTemplate      sql.NullString `json:"image_tag_template" db:"image_tag_template"`
+	GitRemote             sql.NullString `json:"git_remote" db:"git_remote"`
+	MelangeFilePath       sql.NullString `json:"melange_file_path" db:"melange_file_path"`
+	InitialTag            sql.NullString `json:"initial_tag" db:"initial_tag"`
 }

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -427,7 +427,7 @@ func lookupPackageFamilyByPackageID(ctx context.Context, packageID string) (*pac
 		       dry_run_mode, min_version, notify_on_detection,
 		       notify_on_build_failure, check_for_updates_at, last_check_at,
 		       last_error, consecutive_errors, created_at, updated_at,
-		       image_tag_template
+		       image_tag_template, git_remote, melange_file_path, initial_tag
 		FROM package_family
 		WHERE $1 LIKE name || '-%'
 	`
@@ -446,7 +446,7 @@ func lookupPackageFamilyByPackageID(ctx context.Context, packageID string) (*pac
 			&pf.DryRunMode, &pf.MinVersion, &pf.NotifyOnDetection,
 			&pf.NotifyOnBuildFailure, &pf.CheckForUpdatesAt, &pf.LastCheckAt,
 			&pf.LastError, &pf.ConsecutiveErrors, &pf.CreatedAt, &pf.UpdatedAt,
-			&pf.ImageTagTemplate,
+			&pf.ImageTagTemplate, &pf.GitRemote, &pf.MelangeFilePath, &pf.InitialTag,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan family row: %w", err)
 		}

--- a/pkg/util/nullable.go
+++ b/pkg/util/nullable.go
@@ -1,0 +1,11 @@
+package util
+
+// NullIfEmpty returns nil if the string is empty, otherwise returns the string.
+// Use this when inserting into nullable text columns where NULL (not empty string)
+// has semantic meaning (e.g. presence of git_remote indicates a linked package).
+func NullIfEmpty(s string) interface{} {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/securebuild-app/app/(dashboard)/images/[id]/[[...tab]]/image-page-client.tsx
+++ b/securebuild-app/app/(dashboard)/images/[id]/[[...tab]]/image-page-client.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, Calendar, Clock, Package, Tag, Save, Edit3, X, Plus, Trash2, Shield, Download, Play, AlertTriangle, Info, HelpCircle, Eye, EyeOff } from "lucide-react";
+import { ArrowLeft, Calendar, Clock, Package, Tag, Save, Edit3, X, Plus, Trash2, Shield, Download, Play, AlertTriangle, Info, HelpCircle, Eye, EyeOff, GitBranch } from "lucide-react";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import semver from "semver";
@@ -22,6 +22,8 @@ import { getFixableCVEs, FixableCVEsByAPKO } from "@/lib/image/actions/get-fixab
 import { buildImageAction } from "@/lib/image/actions/build-image";
 import { buildImageApkoAction } from "@/lib/image/actions/build-apko";
 import { scanImageApkoAction } from "@/lib/image/actions/scan-apko";
+import { addLinkedImageApkoAction } from "@/lib/image/actions/add-linked-image-apko";
+import { updateImageGitLinkAction } from "@/lib/image/actions/update-image-git-link";
 import { setImagePublic } from "@/lib/image/actions/set-image-public";
 import { getImageAction } from "@/lib/image/actions/get-image";
 import { getImageBuildsAction } from "@/lib/image/actions/get-image-builds";
@@ -169,6 +171,17 @@ export function ImagePageClient({
     setActiveTab(currentTab);
   }, [currentTab]);
 
+  // Sync git link state when image data changes
+  useEffect(() => {
+    setLinkGitRepo(!!image.gitRemote);
+    setGitEditForm({
+      gitRemote: image.gitRemote || "",
+      apkoFilePath: image.apkoFilePath || "",
+      imageTagTemplate: image.imageTagTemplate || "",
+    });
+    setIsEditingGitLink(false);
+  }, [image.gitRemote, image.apkoFilePath, image.imageTagTemplate]);
+
   // Loading states for lazy-loaded tabs
   const [scanResultsLoading, setScanResultsLoading] = useState(false);
   const [buildsLoading, setBuildsLoading] = useState(false);
@@ -237,6 +250,15 @@ export function ImagePageClient({
   // Public/Private state
   const [isPublic, setIsPublic] = useState(image.isPublic || false);
   const [isTogglingPublic, setIsTogglingPublic] = useState(false);
+
+  // Linked repository state
+  const [showAddLinkedApkoForm, setShowAddLinkedApkoForm] = useState(false);
+  const [linkedApkoGitTag, setLinkedApkoGitTag] = useState("");
+  const [isAddingLinkedApko, setIsAddingLinkedApko] = useState(false);
+  const [linkGitRepo, setLinkGitRepo] = useState(false);
+  const [gitEditForm, setGitEditForm] = useState({ gitRemote: "", apkoFilePath: "", imageTagTemplate: "" });
+  const [isSavingGitLink, setIsSavingGitLink] = useState(false);
+  const [isEditingGitLink, setIsEditingGitLink] = useState(false);
 
   // Lazy loading functions for tab data
   const fetchScanResults = async () => {
@@ -440,6 +462,54 @@ const fetchFixableCVEs = async (force = false) => {
       setIsPublic(!checked);
     } finally {
       setIsTogglingPublic(false);
+    }
+  };
+
+  // Linked APKO handler
+  const handleSaveGitLink = async () => {
+    if (!session || !image) return;
+    setIsSavingGitLink(true);
+    try {
+      const updated = await updateImageGitLinkAction(
+        session,
+        image.id,
+        linkGitRepo ? gitEditForm.gitRemote.trim() : "",
+        linkGitRepo ? gitEditForm.apkoFilePath.trim() : "",
+        linkGitRepo ? gitEditForm.imageTagTemplate.trim() : "",
+      );
+      setImage(updated);
+      setIsEditingGitLink(false);
+      toast.success("Repository link updated");
+    } catch (err) {
+      toast.error("Failed to update repository link");
+      console.error(err);
+    } finally {
+      setIsSavingGitLink(false);
+    }
+  };
+
+  const handleAddLinkedApko = async () => {
+    if (!session || !image) return;
+    if (!linkedApkoGitTag.trim()) {
+      toast.error("Git tag is required");
+      return;
+    }
+
+    setIsAddingLinkedApko(true);
+    try {
+      await addLinkedImageApkoAction(session, image.id, linkedApkoGitTag.trim());
+      toast.success("APKO from git tag added successfully");
+      setLinkedApkoGitTag("");
+      setShowAddLinkedApkoForm(false);
+
+      // Refresh the image data
+      const updatedImage = await getImageAction(session, image.id);
+      setImage(updatedImage);
+    } catch (error) {
+      console.error("Failed to add linked APKO:", error);
+      toast.error("Failed to add APKO from git tag");
+    } finally {
+      setIsAddingLinkedApko(false);
     }
   };
 
@@ -1056,6 +1126,158 @@ test:
 
                       </div>
 
+                      {/* Git Repository Link */}
+                      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                        <div>
+                          <div className="flex items-center justify-between mb-2">
+                            <label className="text-sm font-medium">Git Repository</label>
+                            {linkGitRepo && !isEditingGitLink && image.gitRemote && (
+                              <Button size="sm" variant="outline" onClick={() => setIsEditingGitLink(true)}>
+                                <Edit3 className="h-3 w-3 mr-1" />
+                                Edit
+                              </Button>
+                            )}
+                            {isEditingGitLink && (
+                              <div className="flex gap-2">
+                                <Button size="sm" onClick={handleSaveGitLink} disabled={isSavingGitLink}>
+                                  {isSavingGitLink ? <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-primary-foreground mr-1" /> : <Save className="h-3 w-3 mr-1" />}
+                                  Save
+                                </Button>
+                                <Button size="sm" variant="outline" onClick={() => {
+                                  setIsEditingGitLink(false);
+                                  setLinkGitRepo(!!image.gitRemote);
+                                  setGitEditForm({
+                                    gitRemote: image.gitRemote || "",
+                                    apkoFilePath: image.apkoFilePath || "",
+                                    imageTagTemplate: image.imageTagTemplate || "",
+                                  });
+                                }}>
+                                  <X className="h-3 w-3 mr-1" />
+                                  Cancel
+                                </Button>
+                              </div>
+                            )}
+                          </div>
+                          <div className={`px-3 py-2 rounded border ${
+                            linkGitRepo
+                              ? "bg-blue-50 border-blue-200"
+                              : "bg-muted/30"
+                          }`}>
+                            <div className="flex items-center space-x-6">
+                              <Switch
+                                checked={linkGitRepo}
+                                onCheckedChange={(checked) => {
+                                  setLinkGitRepo(checked);
+                                  setIsEditingGitLink(true);
+                                }}
+                                disabled={isSavingGitLink}
+                              />
+                              <label className={`text-sm font-medium leading-none ${
+                                linkGitRepo ? "text-blue-700" : ""
+                              }`}>
+                                {linkGitRepo ? "Linked" : "Not linked"}
+                              </label>
+                              <p className={`text-xs ${
+                                linkGitRepo ? "text-blue-600" : "text-muted-foreground"
+                              }`}>
+                                {linkGitRepo
+                                  ? "Specs pulled from git repository"
+                                  : "Specs managed manually"}
+                              </p>
+                            </div>
+                          </div>
+
+                          {linkGitRepo && (
+                            <div className="space-y-4 mt-4">
+                              {isEditingGitLink || !image.gitRemote ? (
+                                <>
+                                  <div className="space-y-2">
+                                    <label className="text-sm font-medium">Git Origin URL</label>
+                                    <Input
+                                      value={gitEditForm.gitRemote}
+                                      onChange={(e) => setGitEditForm({ ...gitEditForm, gitRemote: e.target.value })}
+                                      placeholder="e.g., https://github.com/owner/repo.git"
+                                      disabled={isSavingGitLink}
+                                    />
+                                  </div>
+                                  <div className="space-y-2">
+                                    <label className="text-sm font-medium">Path to APKO Spec File</label>
+                                    <Input
+                                      value={gitEditForm.apkoFilePath}
+                                      onChange={(e) => setGitEditForm({ ...gitEditForm, apkoFilePath: e.target.value })}
+                                      placeholder="e.g., apko.yaml"
+                                      disabled={isSavingGitLink}
+                                    />
+                                  </div>
+                                  <div className="space-y-2">
+                                    <label className="text-sm font-medium">Image Tag Template</label>
+                                    <Input
+                                      value={gitEditForm.imageTagTemplate}
+                                      onChange={(e) => setGitEditForm({ ...gitEditForm, imageTagTemplate: e.target.value })}
+                                      placeholder="e.g., v{major}.{minor}"
+                                      disabled={isSavingGitLink}
+                                    />
+                                    <p className="text-sm text-muted-foreground">
+                                      Template for OCI tags using {"{major}"}, {"{minor}"}, and {"{patch}"} variables.
+                                    </p>
+                                  </div>
+                                </>
+                              ) : (
+                                <div className="space-y-4">
+                                  <div>
+                                    <label className="text-sm font-medium text-muted-foreground">Git Remote</label>
+                                    <p className="text-sm font-mono bg-muted/30 p-2 rounded border mt-1">{image.gitRemote}</p>
+                                  </div>
+                                  <div>
+                                    <label className="text-sm font-medium text-muted-foreground">APKO File Path</label>
+                                    <p className="text-sm font-mono bg-muted/30 p-2 rounded border mt-1">{image.apkoFilePath || "-"}</p>
+                                  </div>
+                                  <div>
+                                    <label className="text-sm font-medium text-muted-foreground">Image Tag Template</label>
+                                    <p className="text-sm font-mono bg-muted/30 p-2 rounded border mt-1">{image.imageTagTemplate || "-"}</p>
+                                  </div>
+                                </div>
+                              )}
+
+                              {image.gitRemote && (
+                                <div className="border-t pt-4">
+                                  {!showAddLinkedApkoForm ? (
+                                    <Button onClick={() => setShowAddLinkedApkoForm(true)} disabled={isAddingLinkedApko} size="sm">
+                                      <Plus className="mr-2 h-4 w-4" />
+                                      Add APKO from Git Tag
+                                    </Button>
+                                  ) : (
+                                    <div className="space-y-4">
+                                      <h4 className="font-semibold">Add APKO from Git Tag</h4>
+                                      <div className="space-y-2">
+                                        <label className="text-sm font-medium">Git Tag</label>
+                                        <Input
+                                          value={linkedApkoGitTag}
+                                          onChange={(e) => setLinkedApkoGitTag(e.target.value)}
+                                          placeholder="e.g., v1.0.0"
+                                          className="max-w-md"
+                                        />
+                                      </div>
+                                      <div className="flex gap-2">
+                                        <Button onClick={handleAddLinkedApko} disabled={isAddingLinkedApko || !linkedApkoGitTag.trim()} size="sm">
+                                          {isAddingLinkedApko ? <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-primary-foreground mr-1" /> : <Plus className="mr-2 h-4 w-4" />}
+                                          {isAddingLinkedApko ? "Adding..." : "Add APKO"}
+                                        </Button>
+                                        <Button variant="outline" onClick={() => { setShowAddLinkedApkoForm(false); setLinkedApkoGitTag(""); }} disabled={isAddingLinkedApko} size="sm">
+                                          <X className="mr-2 h-4 w-4" />
+                                          Cancel
+                                        </Button>
+                                      </div>
+                                    </div>
+                                  )}
+                                </div>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                        <div></div>
+                      </div>
+
                       {/* Second Row - Image Visibility (Single Column Width) */}
                       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                         <div>
@@ -1170,6 +1392,7 @@ test:
                     </div>
                   </div>
                 </div>
+
               </CardContent>
             </Card>
           </TabsContent>
@@ -1279,6 +1502,26 @@ test:
                               <Clock className="h-3 w-3 text-muted-foreground" />
                               <span className="text-xs text-muted-foreground">Last built {formatDate(apko.lastBuiltAt)}</span>
                             </div>
+                            {apko.gitTag && (
+                              <>
+                                <div className="flex items-center gap-2 mt-1">
+                                  <GitBranch className="h-3 w-3 text-muted-foreground" />
+                                  <span className="text-xs text-muted-foreground">Remote: {image.gitRemote || "-"}</span>
+                                </div>
+                                <div className="flex items-center gap-2 mt-1">
+                                  <GitBranch className="h-3 w-3 text-muted-foreground" />
+                                  <span className="text-xs text-muted-foreground">File: {apko.apkoFilePath || "-"}</span>
+                                </div>
+                                <div className="flex items-center gap-2 mt-1">
+                                  <GitBranch className="h-3 w-3 text-muted-foreground" />
+                                  <span className="text-xs text-muted-foreground">Tag: {apko.gitTag}</span>
+                                </div>
+                                <div className="flex items-center gap-2 mt-1">
+                                  <GitBranch className="h-3 w-3 text-muted-foreground" />
+                                  <span className="text-xs text-muted-foreground">Commit: {apko.gitCommitSha ? apko.gitCommitSha.substring(0, 7) : "-"}</span>
+                                </div>
+                              </>
+                            )}
                           </div>
                           <div className="flex items-center gap-2">
                             <div className="flex flex-wrap gap-1">
@@ -1363,7 +1606,7 @@ test:
                                     Cancel
                                   </Button>
                                 </div>
-                              ) : (
+                              ) : !apko.gitTag ? (
                                 <Button
                                   size="sm"
                                   variant="outline"
@@ -1372,7 +1615,7 @@ test:
                                   <Edit3 className="h-3 w-3 mr-1" />
                                   Edit
                                 </Button>
-                              )}
+                              ) : null}
                             </div>
 
                             {editingApkoId === apko.id ? (

--- a/securebuild-app/app/(dashboard)/images/new/page.tsx
+++ b/securebuild-app/app/(dashboard)/images/new/page.tsx
@@ -11,10 +11,12 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
-import { ArrowLeft, Plus, Trash2, X, HelpCircle } from "lucide-react"
+import { ArrowLeft, Plus, Trash2, X, HelpCircle, GitBranch } from "lucide-react"
 import Link from "next/link"
 import { useSession } from "@/app/hooks/use-session"
 import { createImageAction } from "@/lib/image/actions/create-image"
+import { createLinkedImageAction } from "@/lib/image/actions/create-linked-image"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 // Dynamically import Monaco Editor to avoid SSR issues
 const MonacoEditor = dynamic(() => import("@monaco-editor/react"), {
@@ -42,6 +44,20 @@ export default function NewImagePage() {
   const [tagErrors, setTagErrors] = useState<string[]>([""])
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [imageNameError, setImageNameError] = useState<string | null>(null)
+
+  // Tab state
+  const [activeTab, setActiveTab] = useState("manual")
+
+  // Linked repository form state
+  const [linkedImageName, setLinkedImageName] = useState("")
+  const [linkedGitRemote, setLinkedGitRemote] = useState("")
+  const [linkedApkoFilePath, setLinkedApkoFilePath] = useState("")
+  const [linkedTestFilePath, setLinkedTestFilePath] = useState("")
+  const [linkedImageTagTemplate, setLinkedImageTagTemplate] = useState("")
+  const [linkedGitTag, setLinkedGitTag] = useState("")
+  const [isSubmittingLinked, setIsSubmittingLinked] = useState(false)
+  const [linkedSubmitError, setLinkedSubmitError] = useState<string | null>(null)
+  const [linkedImageNameError, setLinkedImageNameError] = useState<string | null>(null)
 
   // Helper function to validate image names according to Docker/OCI standards
   const validateImageName = (name: string): string | null => {
@@ -125,6 +141,67 @@ export default function NewImagePage() {
       }
       
       setIsSubmitting(false)
+    }
+  }
+
+  const handleLinkedSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsSubmittingLinked(true)
+    setLinkedSubmitError(null)
+
+    try {
+      if (!session) {
+        throw new Error("No session found")
+      }
+
+      const nameError = validateImageName(linkedImageName)
+      if (nameError) {
+        setLinkedImageNameError(nameError)
+        setIsSubmittingLinked(false)
+        return
+      }
+
+      if (!linkedGitRemote.trim()) {
+        setLinkedSubmitError("Git remote is required.")
+        setIsSubmittingLinked(false)
+        return
+      }
+      if (!linkedApkoFilePath.trim()) {
+        setLinkedSubmitError("APKO file path is required.")
+        setIsSubmittingLinked(false)
+        return
+      }
+      if (!linkedImageTagTemplate.trim()) {
+        setLinkedSubmitError("Image tag template is required.")
+        setIsSubmittingLinked(false)
+        return
+      }
+      if (!linkedGitTag.trim()) {
+        setLinkedSubmitError("Initial git tag is required.")
+        setIsSubmittingLinked(false)
+        return
+      }
+
+      const image = await createLinkedImageAction(session, {
+        name: linkedImageName.trim(),
+        gitRemote: linkedGitRemote.trim(),
+        apkoFilePath: linkedApkoFilePath.trim(),
+        testFilePath: linkedTestFilePath.trim() || undefined,
+        imageTagTemplate: linkedImageTagTemplate.trim(),
+        gitTag: linkedGitTag.trim(),
+      })
+      console.log("Linked image created:", image)
+      router.push("/images")
+    } catch (error) {
+      console.error("Failed to create linked image:", error)
+
+      if (error instanceof Error) {
+        setLinkedSubmitError(error.message)
+      } else {
+        setLinkedSubmitError("Failed to create linked image. Please try again.")
+      }
+
+      setIsSubmittingLinked(false)
     }
   }
 
@@ -243,212 +320,355 @@ export default function NewImagePage() {
             </div>
           </div>
 
-          <div>
-            <Card>
-              <CardHeader>
-                <CardTitle>Image Configuration</CardTitle>
-                <CardDescription>
-                  Provide a name for your image and the apko YAML configuration
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <form onSubmit={handleSubmit} className="space-y-6">
-                  <div className="space-y-2">
-                    <Label htmlFor="imageName">Image Name</Label>
-                    <Input
-                      id="imageName"
-                      type="text"
-                      placeholder="my-awesome-image"
-                      value={imageName}
-                      onChange={(e) => {
-                        const value = e.target.value
-                        setImageName(value)
-                        setSubmitError(null) // Clear error when user starts typing
-                        
-                        // Validate image name in real-time
-                        const error = validateImageName(value)
-                        setImageNameError(error)
-                      }}
-                      required
-                      className={`max-w-md ${imageNameError ? 'border-red-500' : ''}`}
-                    />
-                    {imageNameError && (
-                      <p className="text-sm text-red-500 mt-1">{imageNameError}</p>
+          <Tabs value={activeTab} onValueChange={setActiveTab}>
+            <TabsList className="mb-6">
+              <TabsTrigger value="manual">Manual Configuration</TabsTrigger>
+              <TabsTrigger value="link-repository">
+                <GitBranch className="h-4 w-4 mr-2" />
+                Link a repository
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="manual">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Image Configuration</CardTitle>
+                  <CardDescription>
+                    Provide a name for your image and the apko YAML configuration
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <form onSubmit={handleSubmit} className="space-y-6">
+                    <div className="space-y-2">
+                      <Label htmlFor="imageName">Image Name</Label>
+                      <Input
+                        id="imageName"
+                        type="text"
+                        placeholder="my-awesome-image"
+                        value={imageName}
+                        onChange={(e) => {
+                          const value = e.target.value
+                          setImageName(value)
+                          setSubmitError(null) // Clear error when user starts typing
+                          
+                          // Validate image name in real-time
+                          const error = validateImageName(value)
+                          setImageNameError(error)
+                        }}
+                        required
+                        className={`max-w-md ${imageNameError ? 'border-red-500' : ''}`}
+                      />
+                      {imageNameError && (
+                        <p className="text-sm text-red-500 mt-1">{imageNameError}</p>
+                      )}
+                      <p className="text-sm text-muted-foreground">
+                        Choose a descriptive name for your container image. Must start and end with a lowercase letter or number, and can contain lowercase letters, numbers, dots, dashes, and underscores.
+                      </p>
+                    </div>
+
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-2">
+                        <Label htmlFor="alternateImage" className="text-base font-semibold">
+                          Alternate Image (Recommended)
+                        </Label>
+                        <Tooltip>
+                          <TooltipTrigger>
+                            <HelpCircle className="h-4 w-4 text-muted-foreground hover:text-foreground" />
+                          </TooltipTrigger>
+                          <TooltipContent className="max-w-xs">
+                            <p>Configuring this enables vulnerability comparison between your SecureBuild image and the upstream image, highlighting which CVEs are fixed.</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </div>
+                      <Input
+                        id="alternateImage"
+                        type="text"
+                        placeholder="Enter upstream image (e.g., nginx, redis, sonobuoy/sonobuoy)"
+                        value={alternateImage}
+                        onChange={(e) => setAlternateImage(e.target.value)}
+                        className="max-w-md border-2 border-blue-200 focus:border-blue-400"
+                      />
+                      <div className="bg-blue-50 border border-blue-200 rounded-md p-3">
+                        <p className="text-sm text-blue-900 font-medium mb-1">
+                          💡 Recommended: Configure upstream image for vulnerability and image testing comparison
+                        </p>
+                        <p className="text-sm text-blue-800">
+                          This enables SecureBuild to show both which CVEs are fixed and how your image performs in comparison to the original upstream image through vulnerability and image testing comparisons. Uses Docker Hub format — examples: nginx, redis, sonobuoy/sonobuoy, or gcr.io/project/image for other registries.
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="space-y-4">
+                      <div className="flex items-center justify-between">
+                        <Label>Apko Configurations</Label>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={addApko}
+                          disabled={isSubmitting}
+                        >
+                          <Plus className="mr-2 h-4 w-4" />
+                          Add Apko
+                        </Button>
+                      </div>
+
+                      {apkos.map((apko, index) => (
+                        <Card key={index} className="relative">
+                          <CardHeader>
+                            <div className="flex items-center justify-between">
+                              <CardTitle className="text-lg">Apko Configuration {index + 1}</CardTitle>
+                              {apkos.length > 1 && (
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => removeApko(index)}
+                                  disabled={isSubmitting}
+                                >
+                                  <Trash2 className="h-4 w-4" />
+                                </Button>
+                              )}
+                            </div>
+                          </CardHeader>
+                          <CardContent className="space-y-4">
+                            <div className="space-y-2">
+                              <Label htmlFor={`tags-${index}`}>Tags</Label>
+                              <div className="flex gap-2">
+                                <Input
+                                  id={`tags-${index}`}
+                                  type="text"
+                                  placeholder="Enter a tag"
+                                  value={currentTags[index]}
+                                  onChange={(e) => updateCurrentTag(index, e.target.value)}
+                                  onKeyDown={(e) => {
+                                    if (e.key === 'Enter') {
+                                      e.preventDefault()
+                                      addTag(index)
+                                    }
+                                  }}
+                                  className={`max-w-md ${tagErrors[index] ? 'border-red-500' : ''}`}
+                                />
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() => addTag(index)}
+                                  disabled={!currentTags[index].trim() || !!tagErrors[index]}
+                                >
+                                  Add
+                                </Button>
+                              </div>
+                              {tagErrors[index] && (
+                                <p className="text-sm text-red-500 mt-1">{tagErrors[index]}</p>
+                              )}
+                              <div className="flex flex-wrap gap-2 mt-2">
+                                {apko.tags.map((tag, tagIndex) => (
+                                  <Badge key={tagIndex} variant="secondary" className="flex items-center gap-1">
+                                    {tag}
+                                    <Button
+                                      type="button"
+                                      variant="ghost"
+                                      size="sm"
+                                      className="h-4 w-4 p-0 hover:bg-transparent"
+                                      onClick={() => removeTag(index, tagIndex)}
+                                    >
+                                      <X className="h-3 w-3" />
+                                    </Button>
+                                  </Badge>
+                                ))}
+                              </div>
+                            </div>
+
+                            <div className="space-y-2">
+                              <Label htmlFor={`yaml-${index}`}>Apko YAML Configuration</Label>
+                              <div className="border rounded-md overflow-hidden">
+                                <MonacoEditor
+                                  height="400px"
+                                  defaultLanguage="yaml"
+                                  value={apko.yaml}
+                                  onChange={(value) => updateApko(index, 'yaml', value || "")}
+                                  options={{
+                                    minimap: { enabled: false },
+                                    scrollBeyondLastLine: false,
+                                    fontSize: 14,
+                                    lineNumbers: "on",
+                                    roundedSelection: false,
+                                    scrollbar: {
+                                      vertical: "visible",
+                                      horizontal: "visible",
+                                    },
+                                    theme: "vs-dark",
+                                    automaticLayout: true,
+                                    tabSize: 2,
+                                    insertSpaces: true,
+                                    wordWrap: "on",
+                                  }}
+                                  theme="vs-dark"
+                                />
+                              </div>
+                              <p className="text-sm text-muted-foreground">
+                                Provide the complete apko YAML configuration for this image variant.
+                                This defines the packages, entrypoint, and other image settings.
+                              </p>
+                            </div>
+                          </CardContent>
+                        </Card>
+                      ))}
+                    </div>
+
+                    {submitError && (
+                      <div className="p-3 bg-red-50 border border-red-200 rounded-md">
+                        <p className="text-sm text-red-700">{submitError}</p>
+                      </div>
                     )}
-                    <p className="text-sm text-muted-foreground">
-                      Choose a descriptive name for your container image. Must start and end with a lowercase letter or number, and can contain lowercase letters, numbers, dots, dashes, and underscores.
-                    </p>
-                  </div>
 
-                  <div className="space-y-2">
-                    <div className="flex items-center gap-2">
-                      <Label htmlFor="alternateImage" className="text-base font-semibold">
-                        Alternate Image (Recommended)
-                      </Label>
-                      <Tooltip>
-                        <TooltipTrigger>
-                          <HelpCircle className="h-4 w-4 text-muted-foreground hover:text-foreground" />
-                        </TooltipTrigger>
-                        <TooltipContent className="max-w-xs">
-                          <p>Configuring this enables vulnerability comparison between your SecureBuild image and the upstream image, highlighting which CVEs are fixed.</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </div>
-                    <Input
-                      id="alternateImage"
-                      type="text"
-                      placeholder="Enter upstream image (e.g., nginx, redis, sonobuoy/sonobuoy)"
-                      value={alternateImage}
-                      onChange={(e) => setAlternateImage(e.target.value)}
-                      className="max-w-md border-2 border-blue-200 focus:border-blue-400"
-                    />
-                    <div className="bg-blue-50 border border-blue-200 rounded-md p-3">
-                      <p className="text-sm text-blue-900 font-medium mb-1">
-                        💡 Recommended: Configure upstream image for vulnerability and image testing comparison
-                      </p>
-                      <p className="text-sm text-blue-800">
-                        This enables SecureBuild to show both which CVEs are fixed and how your image performs in comparison to the original upstream image through vulnerability and image testing comparisons. Uses Docker Hub format — examples: nginx, redis, sonobuoy/sonobuoy, or gcr.io/project/image for other registries.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <Label>Apko Configurations</Label>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={addApko}
-                        disabled={isSubmitting}
-                      >
-                        <Plus className="mr-2 h-4 w-4" />
-                        Add Apko
+                    <div className="flex gap-4 pt-4">
+                      <Button type="submit" disabled={isSubmitting || !!imageNameError || !imageName.trim() || !apkos.some(apko => apko.yaml.trim() && apko.tags.length > 0)}>
+                        {isSubmitting ? "Creating..." : "Create Image"}
+                      </Button>
+                      <Button type="button" variant="outline" asChild>
+                        <Link href="/images">Cancel</Link>
                       </Button>
                     </div>
+                  </form>
+                </CardContent>
+              </Card>
+            </TabsContent>
 
-                    {apkos.map((apko, index) => (
-                      <Card key={index} className="relative">
-                        <CardHeader>
-                          <div className="flex items-center justify-between">
-                            <CardTitle className="text-lg">Apko Configuration {index + 1}</CardTitle>
-                            {apkos.length > 1 && (
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => removeApko(index)}
-                                disabled={isSubmitting}
-                              >
-                                <Trash2 className="h-4 w-4" />
-                              </Button>
-                            )}
-                          </div>
-                        </CardHeader>
-                        <CardContent className="space-y-4">
-                          <div className="space-y-2">
-                            <Label htmlFor={`tags-${index}`}>Tags</Label>
-                            <div className="flex gap-2">
-                              <Input
-                                id={`tags-${index}`}
-                                type="text"
-                                placeholder="Enter a tag"
-                                value={currentTags[index]}
-                                onChange={(e) => updateCurrentTag(index, e.target.value)}
-                                onKeyDown={(e) => {
-                                  if (e.key === 'Enter') {
-                                    e.preventDefault()
-                                    addTag(index)
-                                  }
-                                }}
-                                className={`max-w-md ${tagErrors[index] ? 'border-red-500' : ''}`}
-                              />
-                              <Button
-                                type="button"
-                                variant="outline"
-                                size="sm"
-                                onClick={() => addTag(index)}
-                                disabled={!currentTags[index].trim() || !!tagErrors[index]}
-                              >
-                                Add
-                              </Button>
-                            </div>
-                            {tagErrors[index] && (
-                              <p className="text-sm text-red-500 mt-1">{tagErrors[index]}</p>
-                            )}
-                            <div className="flex flex-wrap gap-2 mt-2">
-                              {apko.tags.map((tag, tagIndex) => (
-                                <Badge key={tagIndex} variant="secondary" className="flex items-center gap-1">
-                                  {tag}
-                                  <Button
-                                    type="button"
-                                    variant="ghost"
-                                    size="sm"
-                                    className="h-4 w-4 p-0 hover:bg-transparent"
-                                    onClick={() => removeTag(index, tagIndex)}
-                                  >
-                                    <X className="h-3 w-3" />
-                                  </Button>
-                                </Badge>
-                              ))}
-                            </div>
-                          </div>
-
-                          <div className="space-y-2">
-                            <Label htmlFor={`yaml-${index}`}>Apko YAML Configuration</Label>
-                            <div className="border rounded-md overflow-hidden">
-                              <MonacoEditor
-                                height="400px"
-                                defaultLanguage="yaml"
-                                value={apko.yaml}
-                                onChange={(value) => updateApko(index, 'yaml', value || "")}
-                                options={{
-                                  minimap: { enabled: false },
-                                  scrollBeyondLastLine: false,
-                                  fontSize: 14,
-                                  lineNumbers: "on",
-                                  roundedSelection: false,
-                                  scrollbar: {
-                                    vertical: "visible",
-                                    horizontal: "visible",
-                                  },
-                                  theme: "vs-dark",
-                                  automaticLayout: true,
-                                  tabSize: 2,
-                                  insertSpaces: true,
-                                  wordWrap: "on",
-                                }}
-                                theme="vs-dark"
-                              />
-                            </div>
-                            <p className="text-sm text-muted-foreground">
-                              Provide the complete apko YAML configuration for this image variant.
-                              This defines the packages, entrypoint, and other image settings.
-                            </p>
-                          </div>
-                        </CardContent>
-                      </Card>
-                    ))}
-                  </div>
-
-                  {submitError && (
-                    <div className="p-3 bg-red-50 border border-red-200 rounded-md">
-                      <p className="text-sm text-red-700">{submitError}</p>
+            <TabsContent value="link-repository">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Link a Repository</CardTitle>
+                  <CardDescription>
+                    Create an image linked to an external git repository containing an APKO configuration file.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <form onSubmit={handleLinkedSubmit} className="space-y-6">
+                    <div className="space-y-2">
+                      <Label htmlFor="linkedImageName">Image Name</Label>
+                      <Input
+                        id="linkedImageName"
+                        type="text"
+                        placeholder="my-awesome-image"
+                        value={linkedImageName}
+                        onChange={(e) => {
+                          const value = e.target.value
+                          setLinkedImageName(value)
+                          setLinkedSubmitError(null)
+                          const error = validateImageName(value)
+                          setLinkedImageNameError(error)
+                        }}
+                        required
+                        className={`max-w-md ${linkedImageNameError ? 'border-red-500' : ''}`}
+                      />
+                      {linkedImageNameError && (
+                        <p className="text-sm text-red-500 mt-1">{linkedImageNameError}</p>
+                      )}
+                      <p className="text-sm text-muted-foreground">
+                        Choose a descriptive name for your container image. Must start and end with a lowercase letter or number, and can contain lowercase letters, numbers, dots, dashes, and underscores.
+                      </p>
                     </div>
-                  )}
 
-                  <div className="flex gap-4 pt-4">
-                    <Button type="submit" disabled={isSubmitting || !!imageNameError || !imageName.trim() || !apkos.some(apko => apko.yaml.trim() && apko.tags.length > 0)}>
-                      {isSubmitting ? "Creating..." : "Create Image"}
-                    </Button>
-                    <Button type="button" variant="outline" asChild>
-                      <Link href="/images">Cancel</Link>
-                    </Button>
-                  </div>
-                </form>
-              </CardContent>
-            </Card>
-          </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="linkedGitRemote">Git Remote</Label>
+                      <Input
+                        id="linkedGitRemote"
+                        type="text"
+                        placeholder="https://github.com/owner/repo.git"
+                        value={linkedGitRemote}
+                        onChange={(e) => setLinkedGitRemote(e.target.value)}
+                        required
+                        className="max-w-md"
+                      />
+                      <p className="text-sm text-muted-foreground">
+                        The git remote URL to clone.
+                      </p>
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="linkedApkoFilePath">Path to APKO File</Label>
+                      <Input
+                        id="linkedApkoFilePath"
+                        type="text"
+                        placeholder="e.g., apko.yaml"
+                        value={linkedApkoFilePath}
+                        onChange={(e) => setLinkedApkoFilePath(e.target.value)}
+                        required
+                        className="max-w-md"
+                      />
+                      <p className="text-sm text-muted-foreground">
+                        Path to the APKO YAML file relative to the repository root, including filename.
+                      </p>
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="linkedTestFilePath">Path to Test File (Optional)</Label>
+                      <Input
+                        id="linkedTestFilePath"
+                        type="text"
+                        placeholder="e.g., test.yaml"
+                        value={linkedTestFilePath}
+                        onChange={(e) => setLinkedTestFilePath(e.target.value)}
+                        className="max-w-md"
+                      />
+                      <p className="text-sm text-muted-foreground">
+                        Optional path to the test YAML file relative to the repository root.
+                      </p>
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="linkedImageTagTemplate">Image Tag Template</Label>
+                      <Input
+                        id="linkedImageTagTemplate"
+                        type="text"
+                        placeholder="v{major}.{minor}"
+                        value={linkedImageTagTemplate}
+                        onChange={(e) => setLinkedImageTagTemplate(e.target.value)}
+                        required
+                        className="max-w-md"
+                      />
+                      <p className="text-sm text-muted-foreground">
+                        Template for image tags using {"{major}"}, {"{minor}"}, and {"{patch}"} variables.
+                      </p>
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="linkedGitTag">Initial Git Tag</Label>
+                      <Input
+                        id="linkedGitTag"
+                        type="text"
+                        placeholder="e.g., v1.0.0"
+                        value={linkedGitTag}
+                        onChange={(e) => setLinkedGitTag(e.target.value)}
+                        required
+                        className="max-w-md"
+                      />
+                      <p className="text-sm text-muted-foreground">
+                        The git tag to clone initially. Only tags are supported.
+                      </p>
+                    </div>
+
+                    {linkedSubmitError && (
+                      <div className="p-3 bg-red-50 border border-red-200 rounded-md">
+                        <p className="text-sm text-red-700">{linkedSubmitError}</p>
+                      </div>
+                    )}
+
+                    <div className="flex gap-4 pt-4">
+                      <Button type="submit" disabled={isSubmittingLinked || !!linkedImageNameError || !linkedImageName.trim()}>
+                        {isSubmittingLinked ? "Creating..." : "Create Linked Image"}
+                      </Button>
+                      <Button type="button" variant="outline" asChild>
+                        <Link href="/images">Cancel</Link>
+                      </Button>
+                    </div>
+                  </form>
+                </CardContent>
+              </Card>
+            </TabsContent>
+          </Tabs>
       </div>
     </TooltipProvider>
   )

--- a/securebuild-app/app/(dashboard)/package-families/[id]/page.tsx
+++ b/securebuild-app/app/(dashboard)/package-families/[id]/page.tsx
@@ -619,16 +619,8 @@ export default function PackageFamilyDetailsPage() {
                   <p className="text-sm font-mono">{packageFamily.melangeFilePath || "-"}</p>
                 </div>
                 <div>
-                  <Label className="text-sm font-medium">Git Tag (Latest Version)</Label>
-                  <p className="text-sm font-mono">
-                    {packageFamily.packages?.[0]?.gitTag || packageFamily.gitTag || "-"}
-                  </p>
-                </div>
-                <div>
-                  <Label className="text-sm font-medium">Git Commit SHA (Latest Version)</Label>
-                  <p className="text-sm font-mono">
-                    {packageFamily.packages?.[0]?.gitCommitSha || packageFamily.gitCommitSha || "-"}
-                  </p>
+                  <Label className="text-sm font-medium">Initial Tag</Label>
+                  <p className="text-sm font-mono">{packageFamily.initialTag || "-"}</p>
                 </div>
               </CardContent>
             </Card>

--- a/securebuild-app/app/(dashboard)/package-families/[id]/page.tsx
+++ b/securebuild-app/app/(dashboard)/package-families/[id]/page.tsx
@@ -19,7 +19,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
-import { ArrowLeft, Save, Trash2, Loader2, Edit, X, RefreshCw } from "lucide-react"
+import { ArrowLeft, Save, Trash2, Loader2, Edit, X, RefreshCw, GitBranch } from "lucide-react"
+import { Switch } from "@/components/ui/switch"
 import {
   Dialog,
   DialogContent,
@@ -57,7 +58,11 @@ export default function PackageFamilyDetailsPage() {
     dryRunMode: false,
     notifyOnDetection: false,
     notifyOnBuildFailure: true,
+    melangeFilePath: "",
+    gitRemote: "",
+    initialTag: "",
   })
+  const [linkGitRepo, setLinkGitRepo] = useState(false)
 
   // Computed automation mode based on monitoring and dry run fields
   const automationMode: 'disabled' | 'dry-run' | 'enabled' =
@@ -90,7 +95,11 @@ export default function PackageFamilyDetailsPage() {
           dryRunMode: data.dryRunMode,
           notifyOnDetection: data.notifyOnDetection,
           notifyOnBuildFailure: data.notifyOnBuildFailure,
+          melangeFilePath: data.melangeFilePath || "",
+          gitRemote: data.gitRemote || "",
+          initialTag: data.initialTag || "",
         })
+        setLinkGitRepo(!!data.gitRemote)
 
         // Fetch upstream config from latest package version
         try {
@@ -149,6 +158,9 @@ export default function PackageFamilyDetailsPage() {
         dryRunMode: editForm.dryRunMode,
         notifyOnDetection: editForm.notifyOnDetection,
         notifyOnBuildFailure: editForm.notifyOnBuildFailure,
+        gitRemote: linkGitRepo ? editForm.gitRemote.trim() : "",
+        melangeFilePath: linkGitRepo ? editForm.melangeFilePath.trim() : "",
+        initialTag: linkGitRepo ? editForm.initialTag.trim() : "",
       })
 
       if (updated) {
@@ -189,7 +201,11 @@ export default function PackageFamilyDetailsPage() {
         dryRunMode: packageFamily.dryRunMode,
         notifyOnDetection: packageFamily.notifyOnDetection,
         notifyOnBuildFailure: packageFamily.notifyOnBuildFailure,
+        melangeFilePath: packageFamily.melangeFilePath || "",
+        gitRemote: packageFamily.gitRemote || "",
+        initialTag: packageFamily.initialTag || "",
       })
+      setLinkGitRepo(!!packageFamily.gitRemote)
     }
     setIsEditing(false)
     setError(null)
@@ -411,6 +427,55 @@ export default function PackageFamilyDetailsPage() {
                       If not set, uses the full version as the tag.
                     </p>
                   </div>
+                  <div className="space-y-4 border-t pt-4">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <GitBranch className="h-4 w-4 text-blue-500" />
+                        <Label>Link to Git Repository</Label>
+                      </div>
+                      <Switch
+                        checked={linkGitRepo}
+                        onCheckedChange={setLinkGitRepo}
+                      />
+                    </div>
+                    {linkGitRepo && (
+                      <div className="space-y-4 pl-6 border-l-2 border-blue-100 dark:border-blue-900">
+                        <div className="space-y-2">
+                          <Label>Git Origin URL</Label>
+                          <Input
+                            value={editForm.gitRemote}
+                            onChange={(e) => setEditForm({ ...editForm, gitRemote: e.target.value })}
+                            placeholder="e.g., https://github.com/owner/repo.git"
+                          />
+                          <p className="text-sm text-slate-600 dark:text-slate-400">
+                            Public git repository URL where the melange spec is maintained.
+                          </p>
+                        </div>
+                        <div className="space-y-2">
+                          <Label>Path to Spec File</Label>
+                          <Input
+                            value={editForm.melangeFilePath}
+                            onChange={(e) => setEditForm({ ...editForm, melangeFilePath: e.target.value })}
+                            placeholder="e.g., melange.yaml"
+                          />
+                          <p className="text-sm text-slate-600 dark:text-slate-400">
+                            Path to the melange YAML file relative to the repository root.
+                          </p>
+                        </div>
+                        <div className="space-y-2">
+                          <Label>Initial Tag</Label>
+                          <Input
+                            value={editForm.initialTag}
+                            onChange={(e) => setEditForm({ ...editForm, initialTag: e.target.value })}
+                            placeholder="e.g., v1.2.3"
+                          />
+                          <p className="text-sm text-slate-600 dark:text-slate-400">
+                            Git tag to use as the starting point. Only tags at or newer than this will be processed. Must be a valid semver tag.
+                          </p>
+                        </div>
+                      </div>
+                    )}
+                  </div>
                 </>
               ) : (
                 <>
@@ -535,6 +600,39 @@ export default function PackageFamilyDetailsPage() {
               )}
             </CardContent>
           </Card>
+
+          {packageFamily?.gitRemote && (
+            <Card>
+              <CardHeader>
+                <div className="flex items-center gap-2">
+                  <GitBranch className="h-5 w-5 text-blue-500" />
+                  <CardTitle>Git Repository</CardTitle>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div>
+                  <Label className="text-sm font-medium">Git Remote</Label>
+                  <p className="text-sm font-mono">{packageFamily.gitRemote}</p>
+                </div>
+                <div>
+                  <Label className="text-sm font-medium">Melange File Path</Label>
+                  <p className="text-sm font-mono">{packageFamily.melangeFilePath || "-"}</p>
+                </div>
+                <div>
+                  <Label className="text-sm font-medium">Git Tag (Latest Version)</Label>
+                  <p className="text-sm font-mono">
+                    {packageFamily.packages?.[0]?.gitTag || packageFamily.gitTag || "-"}
+                  </p>
+                </div>
+                <div>
+                  <Label className="text-sm font-medium">Git Commit SHA (Latest Version)</Label>
+                  <p className="text-sm font-mono">
+                    {packageFamily.packages?.[0]?.gitCommitSha || packageFamily.gitCommitSha || "-"}
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          )}
         </div>
 
         <div>

--- a/securebuild-app/app/(dashboard)/package-families/new/page.tsx
+++ b/securebuild-app/app/(dashboard)/package-families/new/page.tsx
@@ -10,9 +10,11 @@ import { Label } from "@/components/ui/label"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
-import { ArrowLeft, Loader2, Search } from "lucide-react"
+import { ArrowLeft, Loader2, Search, GitBranch } from "lucide-react"
 import { useSession } from "@/app/hooks/use-session"
 import { createPackageFamilyAction } from "@/lib/packagefamily/actions/create-package-family"
+import { createLinkedPackageFamilyAction } from "@/lib/packagefamily/actions/create-linked-package-family"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { formatVersion, parseVersion } from "@/lib/types/packagefamily"
 import { listAvailablePackagesAction, AvailablePackage } from "@/lib/packagefamily/actions/list-available-packages"
 import { getUpstreamConfigFromPackageAction } from "@/lib/packagefamily/actions/get-upstream-config"
@@ -53,6 +55,17 @@ export default function NewPackageFamilyPage() {
 
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  // Tab state
+  const [activeTab, setActiveTab] = useState("select-packages")
+
+  // Linked repository form state
+  const [linkedName, setLinkedName] = useState("")
+  const [gitRemote, setGitRemote] = useState("")
+  const [melangeFilePath, setMelangeFilePath] = useState("")
+  const [initialTag, setInitialTag] = useState("")
+  const [isSavingLinked, setIsSavingLinked] = useState(false)
+  const [linkedError, setLinkedError] = useState<string | null>(null)
 
   // Load available packages
   useEffect(() => {
@@ -214,6 +227,45 @@ export default function NewPackageFamilyPage() {
     router.push("/package-families")
   }
 
+  const handleLinkedSave = async () => {
+    if (!session) return
+
+    if (!linkedName.trim()) {
+      setLinkedError("Name is required.")
+      return
+    }
+    if (!gitRemote.trim()) {
+      setLinkedError("Git remote is required.")
+      return
+    }
+    if (!melangeFilePath.trim()) {
+      setLinkedError("Melange file path is required.")
+      return
+    }
+    if (!initialTag.trim()) {
+      setLinkedError("Initial tag is required.")
+      return
+    }
+
+    setLinkedError(null)
+    setIsSavingLinked(true)
+
+    try {
+      const newFamily = await createLinkedPackageFamilyAction(session, {
+        name: linkedName.trim(),
+        gitRemote: gitRemote.trim(),
+        melangeFilePath: melangeFilePath.trim(),
+        initialTag: initialTag.trim(),
+      })
+      router.push(`/package-families/${newFamily.id}`)
+    } catch (err) {
+      console.error("Failed to create linked package family:", err)
+      setLinkedError("Failed to create linked package family. Please try again.")
+    } finally {
+      setIsSavingLinked(false)
+    }
+  }
+
   const testRegex = () => {
     if (!versionPattern || !testString) return null
     
@@ -259,393 +311,487 @@ export default function NewPackageFamilyPage() {
         </p>
       </div>
 
-      {error && (
-        <div className="mb-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
-          <p className="text-red-600 dark:text-red-400">{error}</p>
-        </div>
-      )}
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <TabsList className="mb-6">
+          <TabsTrigger value="select-packages">Select Packages</TabsTrigger>
+          <TabsTrigger value="link-repository">
+            <GitBranch className="h-4 w-4 mr-2" />
+            Link a repository
+          </TabsTrigger>
+        </TabsList>
 
-      {upstreamConfig && (
-        <div className="mb-4 flex gap-6 text-sm">
-          <div>
-            <span className="text-slate-600 dark:text-slate-400">
-              {upstreamConfig.upstreamType === 'github' ? 'GitHub: ' : 'Release Monitor: '}
-            </span>
-            {upstreamConfig.upstreamType === 'github' ? (
-              <a
-                href={`https://github.com/${upstreamConfig.upstreamIdentifier}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-mono text-blue-600 dark:text-blue-400 hover:underline"
-              >
-                {upstreamConfig.upstreamIdentifier}
-              </a>
-            ) : (
-              <a
-                href={`https://release-monitoring.org/project/${upstreamConfig.upstreamIdentifier}/`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-mono text-blue-600 dark:text-blue-400 hover:underline"
-              >
-                {upstreamConfig.upstreamIdentifier}
-              </a>
-            )}
-          </div>
-          {upstreamConfig.upstreamType === 'github' && upstreamConfig.useTags !== undefined && (
-            <div>
-              <span className="text-slate-600 dark:text-slate-400">Version Source: </span>
-              <span>{upstreamConfig.useTags ? "Tags" : "Releases"}</span>
+        <TabsContent value="select-packages" className="space-y-6">
+          {error && (
+            <div className="mb-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
+              <p className="text-red-600 dark:text-red-400">{error}</p>
             </div>
           )}
-        </div>
-      )}
 
-      <div className="space-y-6">
-        {/* Package Selection - First */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Select Packages ({selectedPackages.length} selected)</CardTitle>
-            <CardDescription>
-              Choose packages to include in this family. At least one is required. The family name will be suggested based on your first selection.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {packagesLoading ? (
-              <div className="text-center py-8">
-                <p className="text-slate-600 dark:text-slate-400">Loading packages...</p>
-              </div>
-            ) : (
-              <>
-                <div className="space-y-4 mb-4">
-                  <div className="relative">
-                    <Search className="absolute left-3 top-3 h-4 w-4 text-slate-400" />
-                    <Input
-                      placeholder="Search packages..."
-                      value={packageSearchTerm}
-                      onChange={(e) => setPackageSearchTerm(e.target.value)}
-                      className="pl-9"
-                    />
-                  </div>
-                </div>
-
-                {selectedPackages.length > 0 && (
-                  <div className="mb-6">
-                    <div className="flex items-center justify-between mb-2">
-                      <h4 className="text-sm font-medium">Selected Packages:</h4>
-                    </div>
-                    <div className="space-y-2 max-h-48 overflow-y-auto border rounded p-2">
-                      {selectedPackages.map((pkg) => (
-                        <div key={pkg.id} className="flex items-center justify-between p-2 bg-slate-50 dark:bg-slate-800 rounded">
-                          <div className="flex-1">
-                            <div className="flex items-center gap-2">
-                              <span className="font-medium text-sm">{pkg.name}</span>
-                              {pkg.isTemplate && (
-                                <span className="text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-2 py-1 rounded">
-                                  Template
-                                </span>
-                              )}
-                            </div>
-                            <div className="flex items-center gap-2 mt-1">
-                              <Input
-                                type="number"
-                                min={0}
-                                max={99}
-                                value={pkg.versionMajor}
-                                onChange={(e) => updatePackageVersion(pkg.id, 'versionMajor', parseInt(e.target.value) || 0)}
-                                className="w-16 h-7 text-xs"
-                              />
-                              <span className="text-xs">.</span>
-                              <Input
-                                type="number"
-                                min={0}
-                                max={99}
-                                value={pkg.versionMinor}
-                                onChange={(e) => updatePackageVersion(pkg.id, 'versionMinor', parseInt(e.target.value) || 0)}
-                                className="w-16 h-7 text-xs"
-                              />
-                              {!pkg.isTemplate && (
-                                <Button
-                                  size="sm"
-                                  variant="outline"
-                                  onClick={() => setAsTemplate(pkg.id)}
-                                  className="h-7 text-xs"
-                                >
-                                  Set as Template
-                                </Button>
-                              )}
-                            </div>
-                          </div>
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            onClick={() => removePackage(pkg.id)}
-                            className="h-7 w-7 p-0"
-                          >
-                            ×
-                          </Button>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                <div className="max-h-64 overflow-y-auto border rounded">
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead>Package Name</TableHead>
-                        <TableHead>Version</TableHead>
-                        <TableHead />
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {filteredPackages.length === 0 ? (
-                        <TableRow>
-                          <TableCell colSpan={3} className="text-center py-4 text-slate-600 dark:text-slate-400">
-                            {packageSearchTerm ? "No packages found matching search" : "No packages available"}
-                          </TableCell>
-                        </TableRow>
-                      ) : (
-                        filteredPackages.slice(0, 20).map((pkg) => (
-                          <TableRow key={pkg.id}>
-                            <TableCell className="font-medium">{pkg.name}</TableCell>
-                            <TableCell className="text-sm text-slate-600 dark:text-slate-400">
-                              {pkg.lastVersion}
-                            </TableCell>
-                            <TableCell>
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                onClick={() => addPackage(pkg)}
-                              >
-                                Add
-                              </Button>
-                            </TableCell>
-                          </TableRow>
-                        ))
-                      )}
-                    </TableBody>
-                  </Table>
-                </div>
-              </>
-            )}
-          </CardContent>
-        </Card>
-
-        {/* Basic Information - Now Second */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>Basic Information</CardTitle>
-              <CardDescription>
-                Configure the basic details of your package family
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="name">Name</Label>
-                <Input
-                  id="name"
-                  placeholder="e.g., replicated"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                />
-                <p className="text-sm text-slate-600 dark:text-slate-400">
-                  A unique identifier for this package family (auto-suggested from first package)
-                </p>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="packageNameTemplate">Package Name Template</Label>
-                <Input
-                  id="packageNameTemplate"
-                  placeholder="{name}-{major}.{minor}"
-                  value={packageNameTemplate}
-                  onChange={(e) => setPackageNameTemplate(e.target.value)}
-                />
-                <p className="text-sm text-slate-600 dark:text-slate-400">
-                  Template for package names using {"{name}"}, {"{major}"}, and {"{minor}"} variables.
-                </p>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="imageTagTemplate">Image Tag Template</Label>
-                <Input
-                  id="imageTagTemplate"
-                  placeholder="{major}.{minor}.{patch}"
-                  value={imageTagTemplate}
-                  onChange={(e) => setImageTagTemplate(e.target.value)}
-                />
-                <p className="text-sm text-slate-600 dark:text-slate-400">
-                  Optional template for image tags using {"{major}"}, {"{minor}"}, and {"{patch}"} variables.
-                  If not set, uses the full version as the tag.
-                </p>
-              </div>
-              
-              <p className="text-sm text-slate-600 dark:text-slate-400">
-                Upstream repository configuration will be read from the template package's melange YAML.
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Version Detection</CardTitle>
-              <CardDescription>
-                Configure how to detect and extract version numbers from upstream
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <p className="text-sm text-slate-600 dark:text-slate-400">
-                Version source (Tags vs Releases) will be read from the template package's melange YAML.
-              </p>
-
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="versionPattern">Version Pattern</Label>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setShowRegexTest(!showRegexTest)}
+          {upstreamConfig && (
+            <div className="mb-4 flex gap-6 text-sm">
+              <div>
+                <span className="text-slate-600 dark:text-slate-400">
+                  {upstreamConfig.upstreamType === 'github' ? 'GitHub: ' : 'Release Monitor: '}
+                </span>
+                {upstreamConfig.upstreamType === 'github' ? (
+                  <a
+                    href={`https://github.com/${upstreamConfig.upstreamIdentifier}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-mono text-blue-600 dark:text-blue-400 hover:underline"
                   >
-                    {showRegexTest ? "Hide Tester" : "Test Pattern"}
-                  </Button>
+                    {upstreamConfig.upstreamIdentifier}
+                  </a>
+                ) : (
+                  <a
+                    href={`https://release-monitoring.org/project/${upstreamConfig.upstreamIdentifier}/`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-mono text-blue-600 dark:text-blue-400 hover:underline"
+                  >
+                    {upstreamConfig.upstreamIdentifier}
+                  </a>
+                )}
+              </div>
+              {upstreamConfig.upstreamType === 'github' && upstreamConfig.useTags !== undefined && (
+                <div>
+                  <span className="text-slate-600 dark:text-slate-400">Version Source: </span>
+                  <span>{upstreamConfig.useTags ? "Tags" : "Releases"}</span>
                 </div>
-                <Input
-                  id="versionPattern"
-                  value={versionPattern}
-                  onChange={(e) => setVersionPattern(e.target.value)}
-                  placeholder="^(\d+)\.(\d+)(?:\.(\d+))?$"
-                />
-                <p className="text-sm text-slate-600 dark:text-slate-400">
-                  Regex pattern to extract version numbers. Must have at least 2 capture groups for major and minor versions. Patch version is optional.
-                </p>
+              )}
+            </div>
+          )}
 
-                {showRegexTest && (
-                  <div className="border rounded p-3 bg-slate-50 dark:bg-slate-800">
-                    <Label htmlFor="testString" className="text-sm font-medium">Test your pattern</Label>
-                    <Input
-                      id="testString"
-                      value={testString}
-                      onChange={(e) => setTestString(e.target.value)}
-                      placeholder="Enter a version like 'v1.2.3'"
-                      className="mt-2"
-                    />
-                    {testString && (
-                      <div className="mt-3 text-sm">
-                        {(() => {
-                          const result = testRegex()
-                          if (!result) return null
-                          
-                          if (result.error) {
-                            return (
-                              <div className="text-red-600 dark:text-red-400">
-                                <strong>Error:</strong> {result.error}
-                              </div>
-                            )
-                          }
-                          
-                          if (result.matches) {
-                            return (
-                              <div className="text-green-600 dark:text-green-400">
-                                <div><strong>✓ Match:</strong> "{result.fullMatch}"</div>
-                                <div className="mt-1">
-                                  <strong>Capture groups:</strong> 
-                                  {result.groups.length > 0 ? (
-                                    <span className="ml-2">
-                                      Major: <code>{result.groups[0]}</code>, 
-                                      Minor: <code>{result.groups[1] || 'missing'}</code>, 
-                                      Patch: <code>{result.groups[2] || 'missing'}</code>
+          <div className="space-y-6">
+            {/* Package Selection - First */}
+            <Card>
+              <CardHeader>
+                <CardTitle>Select Packages ({selectedPackages.length} selected)</CardTitle>
+                <CardDescription>
+                  Choose packages to include in this family. At least one is required. The family name will be suggested based on your first selection.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {packagesLoading ? (
+                  <div className="text-center py-8">
+                    <p className="text-slate-600 dark:text-slate-400">Loading packages...</p>
+                  </div>
+                ) : (
+                  <>
+                    <div className="space-y-4 mb-4">
+                      <div className="relative">
+                        <Search className="absolute left-3 top-3 h-4 w-4 text-slate-400" />
+                        <Input
+                          placeholder="Search packages..."
+                          value={packageSearchTerm}
+                          onChange={(e) => setPackageSearchTerm(e.target.value)}
+                          className="pl-9"
+                        />
+                      </div>
+                    </div>
+
+                    {selectedPackages.length > 0 && (
+                      <div className="mb-6">
+                        <div className="flex items-center justify-between mb-2">
+                          <h4 className="text-sm font-medium">Selected Packages:</h4>
+                        </div>
+                        <div className="space-y-2 max-h-48 overflow-y-auto border rounded p-2">
+                          {selectedPackages.map((pkg) => (
+                            <div key={pkg.id} className="flex items-center justify-between p-2 bg-slate-50 dark:bg-slate-800 rounded">
+                              <div className="flex-1">
+                                <div className="flex items-center gap-2">
+                                  <span className="font-medium text-sm">{pkg.name}</span>
+                                  {pkg.isTemplate && (
+                                    <span className="text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-2 py-1 rounded">
+                                      Template
                                     </span>
-                                  ) : (
-                                    <span className="ml-2 text-orange-600 dark:text-orange-400">No capture groups found!</span>
+                                  )}
+                                </div>
+                                <div className="flex items-center gap-2 mt-1">
+                                  <Input
+                                    type="number"
+                                    min={0}
+                                    max={99}
+                                    value={pkg.versionMajor}
+                                    onChange={(e) => updatePackageVersion(pkg.id, 'versionMajor', parseInt(e.target.value) || 0)}
+                                    className="w-16 h-7 text-xs"
+                                  />
+                                  <span className="text-xs">.</span>
+                                  <Input
+                                    type="number"
+                                    min={0}
+                                    max={99}
+                                    value={pkg.versionMinor}
+                                    onChange={(e) => updatePackageVersion(pkg.id, 'versionMinor', parseInt(e.target.value) || 0)}
+                                    className="w-16 h-7 text-xs"
+                                  />
+                                  {!pkg.isTemplate && (
+                                    <Button
+                                      size="sm"
+                                      variant="outline"
+                                      onClick={() => setAsTemplate(pkg.id)}
+                                      className="h-7 text-xs"
+                                    >
+                                      Set as Template
+                                    </Button>
                                   )}
                                 </div>
                               </div>
-                            )
-                          } else {
-                            return (
-                              <div className="text-red-600 dark:text-red-400">
-                                <strong>✗ No match</strong> - The pattern doesn't match this version
-                              </div>
-                            )
-                          }
-                        })()}
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                onClick={() => removePackage(pkg.id)}
+                                className="h-7 w-7 p-0"
+                              >
+                                ×
+                              </Button>
+                            </div>
+                          ))}
+                        </div>
                       </div>
                     )}
-                  </div>
+
+                    <div className="max-h-64 overflow-y-auto border rounded">
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead>Package Name</TableHead>
+                            <TableHead>Version</TableHead>
+                            <TableHead />
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {filteredPackages.length === 0 ? (
+                            <TableRow>
+                              <TableCell colSpan={3} className="text-center py-4 text-slate-600 dark:text-slate-400">
+                                {packageSearchTerm ? "No packages found matching search" : "No packages available"}
+                              </TableCell>
+                            </TableRow>
+                          ) : (
+                            filteredPackages.slice(0, 20).map((pkg) => (
+                              <TableRow key={pkg.id}>
+                                <TableCell className="font-medium">{pkg.name}</TableCell>
+                                <TableCell className="text-sm text-slate-600 dark:text-slate-400">
+                                  {pkg.lastVersion}
+                                </TableCell>
+                                <TableCell>
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => addPackage(pkg)}
+                                  >
+                                    Add
+                                  </Button>
+                                </TableCell>
+                              </TableRow>
+                            ))
+                          )}
+                        </TableBody>
+                      </Table>
+                    </div>
+                  </>
                 )}
-                
-                <div className="text-xs text-slate-500 dark:text-slate-500 bg-slate-50 dark:bg-slate-800 p-2 rounded">
-                  <p><strong>Examples:</strong></p>
-                  <p>• <code>^v(\d+)\.(\d+)\.(\d+)$</code> matches v1.2.3</p>
-                  <p>• <code>^(\d+)\.(\d+)\.(\d+)$</code> matches 1.2.3</p>
-                  <p>• <code>^release-(\d+)\.(\d+)\.(\d+)$</code> matches release-1.2.3</p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+              </CardContent>
+            </Card>
 
-          <Card>
-            <CardHeader>
-              <CardTitle>Automation Settings</CardTitle>
-              <CardDescription>
-                Configure how the package family monitors and creates new package versions
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label>Automation Mode</Label>
-                <Select value={automationMode} onValueChange={(value) => setAutomationMode(value as 'disabled' | 'dry-run' | 'enabled')}>
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="disabled">Disabled</SelectItem>
-                    <SelectItem value="dry-run">Dry Run</SelectItem>
-                    <SelectItem value="enabled">Enabled</SelectItem>
-                  </SelectContent>
-                </Select>
-                <div className="text-sm text-slate-600 dark:text-slate-400">
-                  {automationMode === 'disabled' && "No monitoring - family is inactive"}
-                  {automationMode === 'dry-run' && "Monitor and log detected versions but don't create packages"}
-                  {automationMode === 'enabled' && "Monitor and automatically create packages for new versions"}
-                </div>
-              </div>
+            {/* Basic Information - Now Second */}
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Basic Information</CardTitle>
+                  <CardDescription>
+                    Configure the basic details of your package family
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="name">Name</Label>
+                    <Input
+                      id="name"
+                      placeholder="e.g., replicated"
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                    />
+                    <p className="text-sm text-slate-600 dark:text-slate-400">
+                      A unique identifier for this package family (auto-suggested from first package)
+                    </p>
+                  </div>
 
-              {automationMode !== 'disabled' && (
+                  <div className="space-y-2">
+                    <Label htmlFor="packageNameTemplate">Package Name Template</Label>
+                    <Input
+                      id="packageNameTemplate"
+                      placeholder="{name}-{major}.{minor}"
+                      value={packageNameTemplate}
+                      onChange={(e) => setPackageNameTemplate(e.target.value)}
+                    />
+                    <p className="text-sm text-slate-600 dark:text-slate-400">
+                      Template for package names using {"{name}"}, {"{major}"}, and {"{minor}"} variables.
+                    </p>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="imageTagTemplate">Image Tag Template</Label>
+                    <Input
+                      id="imageTagTemplate"
+                      placeholder="{major}.{minor}.{patch}"
+                      value={imageTagTemplate}
+                      onChange={(e) => setImageTagTemplate(e.target.value)}
+                    />
+                    <p className="text-sm text-slate-600 dark:text-slate-400">
+                      Optional template for image tags using {"{major}"}, {"{minor}"}, and {"{patch}"} variables.
+                      If not set, uses the full version as the tag.
+                    </p>
+                  </div>
+                  
+                  <p className="text-sm text-slate-600 dark:text-slate-400">
+                    Upstream repository configuration will be read from the template package's melange YAML.
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle>Version Detection</CardTitle>
+                  <CardDescription>
+                    Configure how to detect and extract version numbers from upstream
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <p className="text-sm text-slate-600 dark:text-slate-400">
+                    Version source (Tags vs Releases) will be read from the template package's melange YAML.
+                  </p>
+
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <Label htmlFor="versionPattern">Version Pattern</Label>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setShowRegexTest(!showRegexTest)}
+                      >
+                        {showRegexTest ? "Hide Tester" : "Test Pattern"}
+                      </Button>
+                    </div>
+                    <Input
+                      id="versionPattern"
+                      value={versionPattern}
+                      onChange={(e) => setVersionPattern(e.target.value)}
+                      placeholder="^(\d+)\.(\d+)(?:\.(\d+))?$"
+                    />
+                    <p className="text-sm text-slate-600 dark:text-slate-400">
+                      Regex pattern to extract version numbers. Must have at least 2 capture groups for major and minor versions. Patch version is optional.
+                    </p>
+
+                    {showRegexTest && (
+                      <div className="border rounded p-3 bg-slate-50 dark:bg-slate-800">
+                        <Label htmlFor="testString" className="text-sm font-medium">Test your pattern</Label>
+                        <Input
+                          id="testString"
+                          value={testString}
+                          onChange={(e) => setTestString(e.target.value)}
+                          placeholder="Enter a version like 'v1.2.3'"
+                          className="mt-2"
+                        />
+                        {testString && (
+                          <div className="mt-3 text-sm">
+                            {(() => {
+                              const result = testRegex()
+                              if (!result) return null
+                              
+                              if (result.error) {
+                                return (
+                                  <div className="text-red-600 dark:text-red-400">
+                                    <strong>Error:</strong> {result.error}
+                                  </div>
+                                )
+                              }
+                              
+                              if (result.matches) {
+                                return (
+                                  <div className="text-green-600 dark:text-green-400">
+                                    <div><strong>✓ Match:</strong> "{result.fullMatch}"</div>
+                                    <div className="mt-1">
+                                      <strong>Capture groups:</strong> 
+                                      {result.groups.length > 0 ? (
+                                        <span className="ml-2">
+                                          Major: <code>{result.groups[0]}</code>, 
+                                          Minor: <code>{result.groups[1] || 'missing'}</code>, 
+                                          Patch: <code>{result.groups[2] || 'missing'}</code>
+                                        </span>
+                                      ) : (
+                                        <span className="ml-2 text-orange-600 dark:text-orange-400">No capture groups found!</span>
+                                      )}
+                                    </div>
+                                  </div>
+                                )
+                              } else {
+                                return (
+                                  <div className="text-red-600 dark:text-red-400">
+                                    <strong>✗ No match</strong> - The pattern doesn't match this version
+                                  </div>
+                                )
+                              }
+                            })()}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                    
+                    <div className="text-xs text-slate-500 dark:text-slate-500 bg-slate-50 dark:bg-slate-800 p-2 rounded">
+                      <p><strong>Examples:</strong></p>
+                      <p>• <code>^v(\d+)\.(\d+)\.(\d+)$</code> matches v1.2.3</p>
+                      <p>• <code>^(\d+)\.(\d+)\.(\d+)$</code> matches 1.2.3</p>
+                      <p>• <code>^release-(\d+)\.(\d+)\.(\d+)$</code> matches release-1.2.3</p>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle>Automation Settings</CardTitle>
+                  <CardDescription>
+                    Configure how the package family monitors and creates new package versions
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="space-y-2">
+                    <Label>Automation Mode</Label>
+                    <Select value={automationMode} onValueChange={(value) => setAutomationMode(value as 'disabled' | 'dry-run' | 'enabled')}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="disabled">Disabled</SelectItem>
+                        <SelectItem value="dry-run">Dry Run</SelectItem>
+                        <SelectItem value="enabled">Enabled</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <div className="text-sm text-slate-600 dark:text-slate-400">
+                      {automationMode === 'disabled' && "No monitoring - family is inactive"}
+                      {automationMode === 'dry-run' && "Monitor and log detected versions but don't create packages"}
+                      {automationMode === 'enabled' && "Monitor and automatically create packages for new versions"}
+                    </div>
+                  </div>
+
+                  {automationMode !== 'disabled' && (
+                    <div className="space-y-2">
+                      <Label>Check Frequency</Label>
+                      <Select value={checkFrequencyMinutes.toString()} onValueChange={(value) => setCheckFrequencyMinutes(parseInt(value))}>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="60">1 hour</SelectItem>
+                          <SelectItem value="180">3 hours</SelectItem>
+                          <SelectItem value="360">6 hours</SelectItem>
+                          <SelectItem value="720">12 hours</SelectItem>
+                          <SelectItem value="1440">24 hours</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
+
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+
+          <div className="flex justify-end space-x-4 pt-6">
+            <Button variant="outline" onClick={handleCancel} disabled={isSaving}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={isSaving || selectedPackages.length === 0}>
+              {isSaving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              Create Package Family
+            </Button>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="link-repository" className="space-y-6">
+          {linkedError && (
+            <div className="mb-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
+              <p className="text-red-600 dark:text-red-400">{linkedError}</p>
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Link a Repository</CardTitle>
+                <CardDescription>
+                  Create a package family linked to an external git repository containing melange YAML files.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
                 <div className="space-y-2">
-                  <Label>Check Frequency</Label>
-                  <Select value={checkFrequencyMinutes.toString()} onValueChange={(value) => setCheckFrequencyMinutes(parseInt(value))}>
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="60">1 hour</SelectItem>
-                      <SelectItem value="180">3 hours</SelectItem>
-                      <SelectItem value="360">6 hours</SelectItem>
-                      <SelectItem value="720">12 hours</SelectItem>
-                      <SelectItem value="1440">24 hours</SelectItem>
-                    </SelectContent>
-                  </Select>
+                  <Label htmlFor="linked-name">Name</Label>
+                  <Input
+                    id="linked-name"
+                    placeholder="e.g., replicated"
+                    value={linkedName}
+                    onChange={(e) => setLinkedName(e.target.value)}
+                  />
+                  <p className="text-sm text-slate-600 dark:text-slate-400">
+                    A unique identifier for this package family.
+                  </p>
                 </div>
-              )}
 
-            </CardContent>
-          </Card>
-        </div>
-      </div>
+                <div className="space-y-2">
+                  <Label htmlFor="git-remote">Git Remote</Label>
+                  <Input
+                    id="git-remote"
+                    placeholder="https://github.com/owner/repo.git"
+                    value={gitRemote}
+                    onChange={(e) => setGitRemote(e.target.value)}
+                  />
+                  <p className="text-sm text-slate-600 dark:text-slate-400">
+                    The git remote URL to clone.
+                  </p>
+                </div>
 
-      <div className="flex justify-end space-x-4 pt-6">
-        <Button variant="outline" onClick={handleCancel} disabled={isSaving}>
-          Cancel
-        </Button>
-        <Button onClick={handleSave} disabled={isSaving || selectedPackages.length === 0}>
-          {isSaving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
-          Create Package Family
-        </Button>
-      </div>
+                <div className="space-y-2">
+                  <Label htmlFor="melange-file-path">Path to Melange File</Label>
+                  <Input
+                    id="melange-file-path"
+                    placeholder="e.g., melange.yaml"
+                    value={melangeFilePath}
+                    onChange={(e) => setMelangeFilePath(e.target.value)}
+                  />
+                  <p className="text-sm text-slate-600 dark:text-slate-400">
+                    Path to the melange YAML file relative to the repository root, including filename.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="initial-tag">Initial Tag</Label>
+                  <Input
+                    id="initial-tag"
+                    placeholder="e.g., v1.0.0"
+                    value={initialTag}
+                    onChange={(e) => setInitialTag(e.target.value)}
+                  />
+                  <p className="text-sm text-slate-600 dark:text-slate-400">
+                    The git tag to clone initially. Only tags are supported.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="flex justify-end space-x-4 pt-6">
+            <Button variant="outline" onClick={handleCancel} disabled={isSavingLinked}>
+              Cancel
+            </Button>
+            <Button onClick={handleLinkedSave} disabled={isSavingLinked}>
+              {isSavingLinked && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              Create Linked Package Family
+            </Button>
+          </div>
+        </TabsContent>
+      </Tabs>
     </div>
   )
 }

--- a/securebuild-app/app/(dashboard)/packages/[id]/[[...tab]]/page.tsx
+++ b/securebuild-app/app/(dashboard)/packages/[id]/[[...tab]]/page.tsx
@@ -12,7 +12,7 @@ import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
-import { AlertCircle, AlertTriangle, Triangle } from "lucide-react"
+import { AlertCircle, AlertTriangle, Triangle, GitBranch } from "lucide-react"
 import { PackageStatusIndicator } from "@/components/package-status-indicator"
 import * as yaml from "js-yaml"
 
@@ -27,6 +27,10 @@ export default function PackageDetailPage() {
     parseVersionKey, selectedVersion, session, activeTab, handleSetDeleteProtection, getLastSuccessfulBuildDuration,
     isLastBuildTimedOut, getLastSuccessfulBuildSettings, isSelectedRevisionImmutable
   } = usePackageContext()
+
+  const isLinkedRevision = !!selectedVersionData?.gitRemote
+  const isEditorReadOnly = isLinkedRevision || isSelectedRevisionImmutable()
+  const areSaveButtonsDisabled = isLinkedRevision || isSelectedRevisionImmutable()
 
   // Helper function to check if a setting differed from defaults in last successful build
   const getDeltaIcon = (currentValue: any, defaultValue: any, successfulValue: any) => {
@@ -339,6 +343,32 @@ export default function PackageDetailPage() {
             </CardHeader>
           <CardContent>
             {renderVersionSelector()}
+            {selectedVersionData?.gitRemote && (
+              <div className="mb-4 border rounded-lg p-4 bg-muted/30">
+                <div className="flex items-center gap-2 mb-3">
+                  <GitBranch className="h-4 w-4 text-blue-500" />
+                  <span className="text-sm font-semibold">Git Repository</span>
+                </div>
+                <div className="grid grid-cols-2 gap-4 text-sm">
+                  <div>
+                    <span className="text-muted-foreground">Remote</span>
+                    <p className="font-mono">{selectedVersionData.gitRemote}</p>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">File</span>
+                    <p className="font-mono">{selectedVersionData.melangeFilePath || "-"}</p>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Tag</span>
+                    <p className="font-mono">{selectedVersionData.gitTag || "-"}</p>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Commit SHA</span>
+                    <p className="font-mono">{selectedVersionData.gitCommitSha || "-"}</p>
+                  </div>
+                </div>
+              </div>
+            )}
             <div className="space-y-2 mb-4">
               <div className="font-semibold mb-1">Melange YAML</div>
               {epochMismatch && (
@@ -350,7 +380,20 @@ export default function PackageDetailPage() {
                   </AlertDescription>
                 </Alert>
               )}
-              <CodeEditor value={selectedVersionData ? selectedVersionData.melangeYaml : melangeYaml} onChange={setMelangeYaml} language="yaml" height="420px" />
+              <div>
+                <CodeEditor
+                  value={selectedVersionData ? selectedVersionData.melangeYaml : melangeYaml}
+                  onChange={setMelangeYaml}
+                  language="yaml"
+                  height="420px"
+                  readOnly={isEditorReadOnly}
+                />
+                {isLinkedRevision && (
+                  <p className="text-xs text-muted-foreground mt-1">
+                    This melange file is linked to a git repository and cannot be edited.
+                  </p>
+                )}
+              </div>
             </div>
             
             {/* Build Settings Section */}
@@ -482,7 +525,7 @@ export default function PackageDetailPage() {
                         !!bootstrapRepoError ||
                         !!bootstrapKeyringError ||
                         !!customDiskSizeError ||
-                        isSelectedRevisionImmutable()
+                        areSaveButtonsDisabled
                       }
                     >
                       {isSavingConfig ? "Saving..." : "Save Configuration"}
@@ -507,7 +550,7 @@ export default function PackageDetailPage() {
                         !!bootstrapRepoError ||
                         !!bootstrapKeyringError ||
                         !!customDiskSizeError ||
-                        isSelectedRevisionImmutable()
+                        areSaveButtonsDisabled
                       }
                     >
                       {isSavingAndBuilding ? "Saving & Building..." : "Save & Build"}

--- a/securebuild-app/app/(dashboard)/packages/[id]/[[...tab]]/page.tsx
+++ b/securebuild-app/app/(dashboard)/packages/[id]/[[...tab]]/page.tsx
@@ -23,7 +23,7 @@ export default function PackageDetailPage() {
     useRoot, setUseRoot, bootstrapEnabled, setBootstrapEnabled,
     bootstrapApkRepository, setBootstrapApkRepository, bootstrapKeyringAppend, setBootstrapKeyringAppend,
     customDiskSize, setCustomDiskSize, dependencies,
-    dependenciesLoading, handleSaveConfiguration, handleSaveAndBuild, isSavingAndBuilding, renderVersionSelector,
+    dependenciesLoading, handleSaveConfiguration, handleSaveAndBuild, handleBuildLinked, isSavingAndBuilding, renderVersionSelector,
     parseVersionKey, selectedVersion, session, activeTab, handleSetDeleteProtection, getLastSuccessfulBuildDuration,
     isLastBuildTimedOut, getLastSuccessfulBuildSettings, isSelectedRevisionImmutable
   } = usePackageContext()
@@ -512,6 +512,15 @@ export default function PackageDetailPage() {
             </div>
             {/* Save Configuration Buttons */}
             <div className="mt-4 flex justify-end gap-2">
+              {isLinkedRevision ? (
+                <Button
+                  onClick={handleBuildLinked}
+                  disabled={isSavingAndBuilding || isSelectedRevisionImmutable()}
+                >
+                  {isSavingAndBuilding ? "Building..." : "Build"}
+                </Button>
+              ) : (
+                <>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span>
@@ -563,6 +572,8 @@ export default function PackageDetailPage() {
                   </TooltipContent>
                 )}
               </Tooltip>
+                </>
+              )}
             </div>
               </TooltipProvider>
             </div>

--- a/securebuild-app/app/(dashboard)/packages/[id]/package-context.tsx
+++ b/securebuild-app/app/(dashboard)/packages/[id]/package-context.tsx
@@ -387,6 +387,59 @@ export function PackageProvider({ children }: { children: React.ReactNode }) {
     }
   }
 
+  const handleBuildLinked = async () => {
+    if (!session || !pkg) return
+    setIsSavingAndBuilding(true)
+    try {
+      if (!selectedVersion) {
+        setErrorMessage("Please select a version to build.")
+        setErrorModalOpen(true)
+        return
+      }
+
+      const versionInfo = parseVersionKey(selectedVersion)
+      if (!versionInfo) {
+        setErrorMessage("Invalid version format.")
+        setErrorModalOpen(true)
+        return
+      }
+
+      // Trigger the build without saving (linked versions are read-only)
+      await buildPackageVersionAction(session, pkg.id, versionInfo.version, versionInfo.apkRelease)
+
+      setSuccessMessage("Build triggered successfully!")
+      setSuccessModalOpen(true)
+
+      // Refresh executions to show the new build
+      const refreshExecutions = async (retries = 5, delay = 1000) => {
+        const filters: ExecutionFilters = {
+          packageId: pkg.id,
+          limit: 20
+        }
+
+        try {
+          const { executions: packageExecutions } = await listExecutionsAction(session, filters)
+          const transformedExecutions: Execution[] = transformExecutions(packageExecutions)
+          setExecutions(transformedExecutions)
+        } catch (error) {
+          console.error("Failed to refresh executions after build:", error)
+          if (retries > 0) {
+            setTimeout(() => refreshExecutions(retries - 1, delay), delay)
+          }
+        }
+      }
+
+      setTimeout(() => refreshExecutions(), 1000)
+
+    } catch (error) {
+      console.error("Error building linked package:", error)
+      setErrorMessage(`Error: ${error instanceof Error ? error.message : "An unknown error occurred"}`)
+      setErrorModalOpen(true)
+    } finally {
+      setIsSavingAndBuilding(false)
+    }
+  }
+
   const handleSetDeleteProtection = async (isDeleteProtectionEnabled: boolean) => {
     if (!session || !pkg) return
     try {
@@ -777,7 +830,7 @@ export function PackageProvider({ children }: { children: React.ReactNode }) {
     setTriggerModalOpen, isSavingConfig, isCreatingVersion, isCreatingRelease,
     originalMelangeYaml, useRoot, setUseRoot, bootstrapEnabled, setBootstrapEnabled,
     bootstrapApkRepository, setBootstrapApkRepository, bootstrapKeyringAppend, setBootstrapKeyringAppend,
-    customDiskSize, setCustomDiskSize, handleSaveConfiguration, handleSaveAndBuild, isSavingAndBuilding, handleCreateVersion, handleCreateRelease,
+    customDiskSize, setCustomDiskSize, handleSaveConfiguration, handleSaveAndBuild, handleBuildLinked, isSavingAndBuilding, handleCreateVersion, handleCreateRelease,
     handleExecuteTrigger, renderVersionSelector, createVersionKey,
     parseVersionKey, session, user, isSessionLoading, id, activeTab,
     handleSetDeleteProtection, handleBuildPackageChain, isBuildingPackageChain,

--- a/securebuild-app/lib/gitspec/pull.ts
+++ b/securebuild-app/lib/gitspec/pull.ts
@@ -1,0 +1,151 @@
+import { execSync } from "child_process";
+import { existsSync, readFileSync, readdirSync, statSync, mkdirSync, rmSync } from "fs";
+import { join, relative, dirname, basename } from "path";
+import { tmpdir } from "os";
+import * as semver from "semver";
+
+export interface AdditionalFile {
+  path: string;
+  content: string;
+}
+
+export interface SpecContent {
+  content: string;
+  commitSha: string;
+  additionalFiles: AdditionalFile[];
+}
+
+export function pullSpecFromGit(
+  gitRemote: string,
+  filePath: string,
+  tag: string
+): SpecContent {
+  const repoDir = mkdtempSync();
+
+  try {
+    cloneRepoAtTag(repoDir, gitRemote, tag);
+
+    const commitSha = resolveHead(repoDir);
+    const fullPath = join(repoDir, filePath);
+    const content = readFileSync(fullPath, "utf-8");
+
+    const specDir = dirname(fullPath);
+    const specFileName = basename(fullPath);
+    const additionalFiles = collectAdditionalFiles(specDir, specFileName);
+
+    return { content, commitSha, additionalFiles };
+  } finally {
+    rmSync(repoDir, { recursive: true, force: true });
+  }
+}
+
+export function resolveTagToCommit(gitRemote: string, tag: string): string {
+  const repoDir = mkdtempSync();
+
+  try {
+    cloneRepoAtTag(repoDir, gitRemote, tag);
+    return resolveHead(repoDir);
+  } finally {
+    rmSync(repoDir, { recursive: true, force: true });
+  }
+}
+
+export function listTags(gitRemote: string): string[] {
+  const repoDir = mkdtempSync();
+
+  try {
+    execSync(
+      `git clone --bare --filter=blob-none "${gitRemote}" "${repoDir}"`,
+      { stdio: "pipe", timeout: 60000 }
+    );
+
+    const output = execSync(`git -C "${repoDir}" tag --list`, {
+      stdio: "pipe",
+      timeout: 30000,
+    }).toString();
+
+    return output
+      .split("\n")
+      .map((t) => t.trim())
+      .filter((t) => t !== "");
+  } finally {
+    rmSync(repoDir, { recursive: true, force: true });
+  }
+}
+
+export function generateOCITagFromTemplate(
+  template: string,
+  gitTag: string
+): string {
+  if (!template) {
+    return gitTag;
+  }
+
+  const parsed = semver.coerce(gitTag);
+  if (!parsed) {
+    return gitTag;
+  }
+
+  let result = template;
+  result = result.replace(/\{major\}/g, String(parsed.major));
+  result = result.replace(/\{minor\}/g, String(parsed.minor));
+  result = result.replace(/\{patch\}/g, String(parsed.patch));
+  return result;
+}
+
+function mkdtempSync(): string {
+  return join(tmpdir(), `gitspec-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+}
+
+function cloneRepoAtTag(dir: string, gitRemote: string, tag: string): void {
+  mkdirSync(dirname(dir), { recursive: true });
+  execSync(
+    `git clone --depth 1 --branch "${tag}" "${gitRemote}" "${dir}"`,
+    { stdio: "pipe", timeout: 120000 }
+  );
+}
+
+function resolveHead(repoDir: string): string {
+  return execSync(`git -C "${repoDir}" rev-parse HEAD`, {
+    stdio: "pipe",
+    timeout: 10000,
+  })
+    .toString()
+    .trim();
+}
+
+function collectAdditionalFiles(
+  specDir: string,
+  specFileName: string
+): AdditionalFile[] {
+  const files: AdditionalFile[] = [];
+
+  function walk(dir: string) {
+    const entries = readdirSync(dir);
+    for (const entry of entries) {
+      if (entry === ".git") continue;
+
+      const fullPath = join(dir, entry);
+      const stat = statSync(fullPath);
+
+      if (stat.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+
+      if (entry === specFileName && dir === specDir) continue;
+
+      const relPath = relative(specDir, fullPath);
+      if (relPath === "." || relPath === "") continue;
+
+      const content = readFileSync(fullPath, "utf-8");
+      files.push({ path: relPath, content });
+    }
+  }
+
+  if (existsSync(specDir)) {
+    walk(specDir);
+  }
+
+  return files;
+}

--- a/securebuild-app/lib/gitspec/pull.ts
+++ b/securebuild-app/lib/gitspec/pull.ts
@@ -1,5 +1,5 @@
 import { execSync } from "child_process";
-import { existsSync, readFileSync, readdirSync, statSync, mkdirSync, rmSync } from "fs";
+import { existsSync, readFileSync, readdirSync, lstatSync, mkdirSync, rmSync } from "fs";
 import { join, relative, dirname, basename } from "path";
 import { tmpdir } from "os";
 import * as semver from "semver";
@@ -126,7 +126,10 @@ function collectAdditionalFiles(
       if (entry === ".git") continue;
 
       const fullPath = join(dir, entry);
-      const stat = statSync(fullPath);
+      const stat = lstatSync(fullPath);
+
+      // Skip symlinks entirely — do not follow them
+      if (stat.isSymbolicLink()) continue;
 
       if (stat.isDirectory()) {
         walk(fullPath);

--- a/securebuild-app/lib/image/actions/add-linked-image-apko.ts
+++ b/securebuild-app/lib/image/actions/add-linked-image-apko.ts
@@ -1,0 +1,21 @@
+"use server"
+
+import { Image } from "@/lib/types/image";
+import { Session } from "@/lib/types/session";
+import { addLinkedImageApko } from "../image";
+
+export async function addLinkedImageApkoAction(session: Session, imageId: string, gitTag: string): Promise<Image> {
+  if (!session?.user) {
+    throw new Error("Unauthorized: Valid session required");
+  }
+
+  if (!imageId?.trim()) {
+    throw new Error("Image ID is required");
+  }
+
+  if (!gitTag?.trim()) {
+    throw new Error("Git tag is required");
+  }
+
+  return await addLinkedImageApko(imageId, gitTag.trim());
+}

--- a/securebuild-app/lib/image/actions/create-linked-image.ts
+++ b/securebuild-app/lib/image/actions/create-linked-image.ts
@@ -1,0 +1,41 @@
+"use server"
+
+import { Image } from "@/lib/types/image";
+import { Session } from "@/lib/types/session";
+import { ValidationError } from "@/lib/types/errors";
+import { createLinkedImage } from "../image";
+
+export interface CreateLinkedImageRequest {
+  name: string;
+  gitRemote: string;
+  apkoFilePath: string;
+  testFilePath?: string;
+  imageTagTemplate: string;
+  gitTag: string;
+}
+
+async function createLinkedImageActionImpl(session: Session, req: CreateLinkedImageRequest): Promise<Image> {
+  if (!session?.user) {
+    throw new Error("Unauthorized: Valid session required");
+  }
+
+  if (!req.name?.trim()) {
+    throw new ValidationError("Image name is required");
+  }
+  if (!req.gitRemote?.trim()) {
+    throw new ValidationError("Git remote is required");
+  }
+  if (!req.apkoFilePath?.trim()) {
+    throw new ValidationError("APKO file path is required");
+  }
+  if (!req.imageTagTemplate?.trim()) {
+    throw new ValidationError("Image tag template is required");
+  }
+  if (!req.gitTag?.trim()) {
+    throw new ValidationError("Git tag is required");
+  }
+
+  return await createLinkedImage(req);
+}
+
+export const createLinkedImageAction = createLinkedImageActionImpl;

--- a/securebuild-app/lib/image/actions/update-image-git-link.ts
+++ b/securebuild-app/lib/image/actions/update-image-git-link.ts
@@ -1,0 +1,23 @@
+"use server"
+
+import { Image } from "@/lib/types/image";
+import { Session } from "@/lib/types/session";
+import { updateImageGitLink } from "../image";
+
+export async function updateImageGitLinkAction(
+  session: Session,
+  imageId: string,
+  gitRemote: string,
+  apkoFilePath: string,
+  imageTagTemplate: string,
+): Promise<Image> {
+  if (!session?.user) {
+    throw new Error("Unauthorized: Valid session required");
+  }
+  return await updateImageGitLink(
+    imageId,
+    gitRemote || null,
+    apkoFilePath || null,
+    imageTagTemplate || null,
+  );
+}

--- a/securebuild-app/lib/image/image.ts
+++ b/securebuild-app/lib/image/image.ts
@@ -7,6 +7,7 @@ import * as srs from "secure-random-string";
 import { getImageTestForLatestVersion, createOrUpdateImageTest } from "./image-test";
 import { sortTagsForDisplay } from "../utils/tag-sort";
 import * as semver from "semver";
+import { pullSpecFromGit, generateOCITagFromTemplate } from "@/lib/gitspec/pull";
 
 function countVersionParts(version: string): number {
   const clean = version.replace(/^[vV]/, "");
@@ -434,6 +435,25 @@ export async function updateAlternateImage(imageId: string, alternateImage: stri
   }
 }
 
+export async function updateImageGitLink(
+  imageId: string,
+  gitRemote: string | null,
+  apkoFilePath: string | null,
+  imageTagTemplate: string | null,
+): Promise<Image> {
+  try {
+    const db = getDB(await getParam("DB_URI"))
+    await db.query(
+      `update image set git_remote = $1, apko_file_path = $2, image_tag_template = $3, updated_at = now() where id = $4`,
+      [gitRemote, apkoFilePath, imageTagTemplate, imageId],
+    );
+    return getImage(imageId);
+  } catch (err) {
+    console.error(err);
+    throw err;
+  }
+}
+
 export async function createImage(name: string, alternateImage: string, apkos: CreateImageAPKO[]): Promise<Image> {
   try {
     const db = getDB(await getParam("DB_URI"))
@@ -503,7 +523,7 @@ export async function getImageByName(name: string): Promise<Image | null> {
 export async function getImage(id: string): Promise<Image> {
   try {
     const db = getDB(await getParam("DB_URI"));
-    const query = `select id, name, created_at, updated_at, alternate_image, readme, is_public from image where id = $1`;
+    const query = `select id, name, created_at, updated_at, alternate_image, readme, is_public, git_remote, apko_file_path, image_tag_template from image where id = $1`;
     const result = await db.query(query, [id]);
 
     const image: Image = {
@@ -514,6 +534,9 @@ export async function getImage(id: string): Promise<Image> {
       alternateImage: result.rows[0].alternate_image,
       readme: result.rows[0].readme,
       isPublic: result.rows[0].is_public,
+      gitRemote: result.rows[0].git_remote || undefined,
+      apkoFilePath: result.rows[0].apko_file_path || undefined,
+      imageTagTemplate: result.rows[0].image_tag_template || undefined,
       apkos: await listImageAPKOs(id),
       catalogItems: [],
       currentTags: [],
@@ -644,11 +667,18 @@ export async function getImage(id: string): Promise<Image> {
 
 export async function updateImageAPKOYaml(id: string, apkoId: string, yaml: string): Promise<void> {
   try {
+    const db = getDB(await getParam("DB_URI"));
+
+    // Block editing of linked APKOs (pulled from git)
+    const apkoResult = await db.query(`SELECT git_tag FROM image_apko WHERE id = $1`, [apkoId]);
+    if (apkoResult.rows.length > 0 && apkoResult.rows[0].git_tag) {
+      throw new Error("Cannot edit APKO YAML for a linked image. The APKO is pulled from a git repository.");
+    }
+
     // Get existing test from the latest version before creating new version
     const existingTest = await getImageTestForLatestVersion(apkoId);
 
     const versionId = 'av' + srs.default({ length: 32, alphanumeric: true });
-    const db = getDB(await getParam("DB_URI"));
     const query = `insert into image_apko_version (id, image_apko_id, apko_yaml, created_at, updated_at) values ($1, $2, $3, now(), now())`;
     await db.query(query, [versionId, apkoId, yaml]);
 
@@ -749,7 +779,7 @@ export async function getImageAPKO(id: string): Promise<ImageAPKO> {
 export async function listImageAPKOs(id: string): Promise<ImageAPKO[]> {
   try {
     const db = getDB(await getParam("DB_URI"));
-    const query = `select id, name, tags, created_at, updated_at, readme, last_built_at from image_apko where image_id = $1`;
+    const query = `select id, name, tags, created_at, updated_at, readme, last_built_at, git_remote, git_tag, apko_file_path from image_apko where image_id = $1`;
     const result = await db.query(query, [id]);
 
     const apkos: ImageAPKO[] = [];
@@ -775,6 +805,9 @@ export async function listImageAPKOs(id: string): Promise<ImageAPKO[]> {
         readme: row.readme,
         lastBuiltAt: row.last_built_at,
         testYaml: testYaml,
+        gitTag: row.git_tag || undefined,
+        gitCommitSha: latestVersion.gitCommitSha,
+        apkoFilePath: row.apko_file_path || undefined,
       });
     }
 
@@ -788,7 +821,7 @@ export async function listImageAPKOs(id: string): Promise<ImageAPKO[]> {
 export async function getLatestImageAPKOVersion(id: string): Promise<ImageAPKOVersion> {
   try {
     const db = getDB(await getParam("DB_URI"));
-    const query = `select id, apko_yaml, created_at, updated_at from image_apko_version where image_apko_id = $1 order by created_at desc limit 1`;
+    const query = `select id, apko_yaml, created_at, updated_at, git_remote, apko_file_path, git_commit_sha from image_apko_version where image_apko_id = $1 order by created_at desc limit 1`;
     const result = await db.query(query, [id]);
 
     const apkoVersion: ImageAPKOVersion = {
@@ -796,6 +829,9 @@ export async function getLatestImageAPKOVersion(id: string): Promise<ImageAPKOVe
       apkoYaml: result.rows[0].apko_yaml,
       createdAt: result.rows[0].created_at,
       updatedAt: result.rows[0].updated_at,
+      gitRemote: result.rows[0].git_remote || undefined,
+      apkoFilePath: result.rows[0].apko_file_path || undefined,
+      gitCommitSha: result.rows[0].git_commit_sha || undefined,
     }
 
     return apkoVersion;
@@ -1060,4 +1096,107 @@ export async function listAllImageBuilds(): Promise<ImageBuild[]> {
     console.error(err);
     throw err;
   }
+}
+
+export interface CreateLinkedImageRequest {
+  name: string;
+  gitRemote: string;
+  apkoFilePath: string;
+  testFilePath?: string;
+  imageTagTemplate: string;
+  gitTag: string;
+}
+
+export async function createLinkedImage(req: CreateLinkedImageRequest): Promise<Image> {
+  const { name, gitRemote, apkoFilePath, testFilePath, imageTagTemplate, gitTag } = req;
+
+  const specContent = pullSpecFromGit(gitRemote, apkoFilePath, gitTag);
+  const ociTag = generateOCITagFromTemplate(imageTagTemplate, gitTag);
+
+  let testYaml: string | undefined;
+  if (testFilePath) {
+    try {
+      const testSpec = pullSpecFromGit(gitRemote, testFilePath, gitTag);
+      testYaml = testSpec.content;
+    } catch (err) {
+      console.warn(`Failed to pull test file from git: ${err}`);
+    }
+  }
+
+  const db = getDB(await getParam("DB_URI"));
+  const imageId = 'i' + srs.default({ length: 32, alphanumeric: true });
+
+  await withTransaction(db, async (client) => {
+    await client.query(
+      `insert into image (id, name, created_at, updated_at, git_remote, apko_file_path, image_tag_template) values ($1, $2, now(), now(), $3, $4, $5)`,
+      [imageId, name, gitRemote, apkoFilePath, imageTagTemplate]
+    );
+
+    const apkoId = 'a' + srs.default({ length: 32, alphanumeric: true });
+    await client.query(
+      `insert into image_apko (id, image_id, name, tags, created_at, updated_at, git_remote, git_tag, apko_file_path) values ($1, $2, $3, $4, now(), now(), $5, $6, $7)`,
+      [apkoId, imageId, ociTag, [ociTag], gitRemote, gitTag, apkoFilePath]
+    );
+
+    const apkoVersionId = 'av' + srs.default({ length: 32, alphanumeric: true });
+    await client.query(
+      `insert into image_apko_version (id, image_apko_id, apko_yaml, created_at, updated_at, git_remote, apko_file_path, git_commit_sha) values ($1, $2, $3, now(), now(), $4, $5, $6)`,
+      [apkoVersionId, apkoId, specContent.content, gitRemote, apkoFilePath, specContent.commitSha]
+    );
+
+    if (testYaml) {
+      await client.query(
+        `insert into image_test (apko_id, apko_version_id, yaml_content, created_at, updated_at) values ($1, $2, $3, now(), now())`,
+        [apkoId, apkoVersionId, testYaml]
+      );
+    }
+  });
+
+  return getImage(imageId);
+}
+
+export async function addLinkedImageApko(imageId: string, gitTag: string): Promise<Image> {
+  const db = getDB(await getParam("DB_URI"));
+
+  const imageResult = await db.query(
+    `select git_remote, apko_file_path, image_tag_template from image where id = $1`,
+    [imageId]
+  );
+
+  if (imageResult.rows.length === 0) {
+    throw new Error(`Image ${imageId} not found`);
+  }
+
+  const { git_remote, apko_file_path, image_tag_template } = imageResult.rows[0];
+  if (!git_remote || !apko_file_path) {
+    throw new Error(`Image ${imageId} is not linked to a git repository`);
+  }
+
+  const existingResult = await db.query(
+    `select id from image_apko where image_id = $1 and git_tag = $2`,
+    [imageId, gitTag]
+  );
+  if (existingResult.rows.length > 0) {
+    throw new Error(`An APKO with git tag "${gitTag}" already exists for this image`);
+  }
+
+  const specContent = pullSpecFromGit(git_remote, apko_file_path, gitTag);
+  const ociTag = generateOCITagFromTemplate(image_tag_template, gitTag);
+
+  const apkoId = 'a' + srs.default({ length: 32, alphanumeric: true });
+  const apkoVersionId = 'av' + srs.default({ length: 32, alphanumeric: true });
+
+  await withTransaction(db, async (client) => {
+    await client.query(
+      `insert into image_apko (id, image_id, name, tags, created_at, updated_at, git_remote, git_tag, apko_file_path) values ($1, $2, $3, $4, now(), now(), $5, $6, $7)`,
+      [apkoId, imageId, ociTag, [ociTag], git_remote, gitTag, apko_file_path]
+    );
+
+    await client.query(
+      `insert into image_apko_version (id, image_apko_id, apko_yaml, created_at, updated_at, git_remote, apko_file_path, git_commit_sha) values ($1, $2, $3, now(), now(), $4, $5, $6)`,
+      [apkoVersionId, apkoId, specContent.content, git_remote, apko_file_path, specContent.commitSha]
+    );
+  });
+
+  return getImage(imageId);
 }

--- a/securebuild-app/lib/package/actions/update-package.ts
+++ b/securebuild-app/lib/package/actions/update-package.ts
@@ -78,6 +78,14 @@ export async function updatePackageAction(sess: Session, id: string, version: st
   const hasMelangeYamlChanged = opts.melangeYaml && (opts.melangeYaml !== pkgVersion.melangeYaml);
   const hasCustomDiskSizeChanged = opts.customDiskSize !== undefined && opts.customDiskSize !== pkgVersion.customDiskSize;
 
+  // Linked package versions cannot be edited — specs are pulled from git
+  if (pkgVersion.gitRemote && hasMelangeYamlChanged) {
+    return {
+      isFailed: true,
+      message: "Cannot edit melange yaml for a linked package version. Create a new release instead."
+    }
+  }
+
   // we cannot update the melage yaml or custom disk size if the package version has been built successfully
   const lastExecution = await getLastExecutionForPackageVersion(pkgVersion.id);
   if (lastExecution) {

--- a/securebuild-app/lib/package/package.ts
+++ b/securebuild-app/lib/package/package.ts
@@ -525,7 +525,7 @@ export async function getPackageVersionById(id: string): Promise<PackageVersion>
   try {
     const db = getDB(await getParam("DB_URI"));
 
-    const query = `select id, package_id, created_at, updated_at, version, melange_yaml, apk_release, use_root, bootstrap_enabled, bootstrap_apk_repository, bootstrap_keyring_append, custom_disk_size from package_version where id = $1`;
+    const query = `select id, package_id, created_at, updated_at, version, melange_yaml, apk_release, use_root, bootstrap_enabled, bootstrap_apk_repository, bootstrap_keyring_append, custom_disk_size, git_remote, melange_file_path, git_tag, git_commit_sha from package_version where id = $1`;
     const result = await db.query(query, [id]);
 
     return {
@@ -541,6 +541,10 @@ export async function getPackageVersionById(id: string): Promise<PackageVersion>
       bootstrapApkRepository: result.rows[0].bootstrap_apk_repository,
       bootstrapKeyringAppend: result.rows[0].bootstrap_keyring_append,
       customDiskSize: result.rows[0].custom_disk_size,
+      gitRemote: result.rows[0].git_remote || undefined,
+      melangeFilePath: result.rows[0].melange_file_path || undefined,
+      gitTag: result.rows[0].git_tag || undefined,
+      gitCommitSha: result.rows[0].git_commit_sha || undefined,
     }
   } catch (error) {
     console.error(error);
@@ -551,7 +555,7 @@ export async function getPackageVersion(pkgId: string, versionLabel: string, apk
   try {
     const db = getDB(await getParam("DB_URI"));
 
-    const query = `select id, package_id, created_at, updated_at, version, melange_yaml, apk_release, use_root, bootstrap_enabled, bootstrap_apk_repository, bootstrap_keyring_append, custom_disk_size from package_version where package_id = $1 and version = $2 and apk_release = $3`;
+    const query = `select id, package_id, created_at, updated_at, version, melange_yaml, apk_release, use_root, bootstrap_enabled, bootstrap_apk_repository, bootstrap_keyring_append, custom_disk_size, git_remote, melange_file_path, git_tag, git_commit_sha from package_version where package_id = $1 and version = $2 and apk_release = $3`;
     const result = await db.query(query, [pkgId, versionLabel, apkRelease]);
 
     return {
@@ -567,18 +571,21 @@ export async function getPackageVersion(pkgId: string, versionLabel: string, apk
       bootstrapApkRepository: result.rows[0].bootstrap_apk_repository,
       bootstrapKeyringAppend: result.rows[0].bootstrap_keyring_append,
       customDiskSize: result.rows[0].custom_disk_size,
+      gitRemote: result.rows[0].git_remote || undefined,
+      melangeFilePath: result.rows[0].melange_file_path || undefined,
+      gitTag: result.rows[0].git_tag || undefined,
+      gitCommitSha: result.rows[0].git_commit_sha || undefined,
     }
   } catch (error) {
     console.error(error);
     throw error;
   }
 }
-
 export async function getPackageVersionByVersionAndRelease(pkgId: string, versionLabel: string, apkRelease: number): Promise<PackageVersion> {
   try {
     const db = getDB(await getParam("DB_URI"));
 
-    const query = `select id, package_id, created_at, updated_at, version, melange_yaml, apk_release, use_root, bootstrap_enabled, bootstrap_apk_repository, bootstrap_keyring_append, custom_disk_size from package_version where package_id = $1 and version = $2 and apk_release = $3`;
+    const query = `select id, package_id, created_at, updated_at, version, melange_yaml, apk_release, use_root, bootstrap_enabled, bootstrap_apk_repository, bootstrap_keyring_append, custom_disk_size, git_remote, melange_file_path, git_tag, git_commit_sha from package_version where package_id = $1 and version = $2 and apk_release = $3`;
     const result = await db.query(query, [pkgId, versionLabel, apkRelease]);
 
     if (result.rows.length === 0) {
@@ -598,6 +605,10 @@ export async function getPackageVersionByVersionAndRelease(pkgId: string, versio
       bootstrapApkRepository: result.rows[0].bootstrap_apk_repository,
       bootstrapKeyringAppend: result.rows[0].bootstrap_keyring_append,
       customDiskSize: result.rows[0].custom_disk_size,
+      gitRemote: result.rows[0].git_remote || undefined,
+      melangeFilePath: result.rows[0].melange_file_path || undefined,
+      gitTag: result.rows[0].git_tag || undefined,
+      gitCommitSha: result.rows[0].git_commit_sha || undefined,
     }
   } catch (error) {
     console.error(error);

--- a/securebuild-app/lib/package/package.ts
+++ b/securebuild-app/lib/package/package.ts
@@ -983,7 +983,11 @@ export async function getLatestRevisionByVersion(pkgId: string, version: string)
         bootstrap_enabled,
         bootstrap_apk_repository,
         bootstrap_keyring_append,
-        custom_disk_size
+        custom_disk_size,
+        git_remote,
+        melange_file_path,
+        git_tag,
+        git_commit_sha
       FROM package_version
       WHERE package_id = $1 AND version = $2
       ORDER BY apk_release DESC
@@ -1008,7 +1012,11 @@ export async function getLatestRevisionByVersion(pkgId: string, version: string)
       bootstrapEnabled: row.bootstrap_enabled,
       bootstrapApkRepository: row.bootstrap_apk_repository,
       bootstrapKeyringAppend: row.bootstrap_keyring_append,
-      customDiskSize: row.custom_disk_size
+      customDiskSize: row.custom_disk_size,
+      gitRemote: row.git_remote || undefined,
+      melangeFilePath: row.melange_file_path || undefined,
+      gitTag: row.git_tag || undefined,
+      gitCommitSha: row.git_commit_sha || undefined,
     };
   } catch (err) {
     console.error(err);
@@ -1041,9 +1049,9 @@ export async function createPackageRelease(
     await withTransaction(db, async (client) => {
       // Get current subpackages from database
       const currentSubpackages = await listSubpackages(client, pkgId);
-      // Insert new package version
-      const query = `insert into package_version (id, package_id, version, melange_yaml, created_at, updated_at, apk_release, use_root) values ($1, $2, $3, $4, now(), now(), $5, $6)`;
-      await client.query(query, [id, pkgId, version, melangeYaml, newRelease, currentVersion.useRoot]);
+      // Insert new package version, copying git link fields from the previous version
+      const query = `insert into package_version (id, package_id, version, melange_yaml, created_at, updated_at, apk_release, use_root, git_remote, melange_file_path, git_tag, git_commit_sha) values ($1, $2, $3, $4, now(), now(), $5, $6, $7, $8, $9, $10)`;
+      await client.query(query, [id, pkgId, version, melangeYaml, newRelease, currentVersion.useRoot, currentVersion.gitRemote || null, currentVersion.melangeFilePath || null, currentVersion.gitTag || null, currentVersion.gitCommitSha || null]);
 
       // Update provides data
       const { writePackageVersionProvides } = await import('./provides');

--- a/securebuild-app/lib/packagefamily/actions/create-linked-package-family.ts
+++ b/securebuild-app/lib/packagefamily/actions/create-linked-package-family.ts
@@ -1,0 +1,29 @@
+"use server"
+
+import { Session } from "@/lib/types/session";
+import { PackageFamily } from "@/lib/types/packagefamily";
+import { createLinkedPackageFamily } from "../packagefamily";
+
+export async function createLinkedPackageFamilyAction(
+  session: Session,
+  request: { name: string; gitRemote: string; melangeFilePath: string; initialTag: string }
+): Promise<PackageFamily> {
+  if (!session?.user) {
+    throw new Error("Unauthorized: Valid session required");
+  }
+
+  if (!request.name?.trim()) {
+    throw new Error("Name is required");
+  }
+  if (!request.gitRemote?.trim()) {
+    throw new Error("Git remote is required");
+  }
+  if (!request.melangeFilePath?.trim()) {
+    throw new Error("Melange file path is required");
+  }
+  if (!request.initialTag?.trim()) {
+    throw new Error("Initial tag is required");
+  }
+
+  return await createLinkedPackageFamily(request);
+}

--- a/securebuild-app/lib/packagefamily/packagefamily.ts
+++ b/securebuild-app/lib/packagefamily/packagefamily.ts
@@ -4,6 +4,7 @@ import { PackageFamily, PackageFamilyWithPackages, PackageFamilyPackage, CreateP
 import { randomBytes } from "crypto";
 import semver from "semver";
 import * as yaml from "js-yaml";
+import { enqueueWork } from "@/lib/utils/queue";
 
 export async function listPackageFamilies(): Promise<PackageFamily[]> {
   const pool = getDB(process.env.DB_URI!);
@@ -59,7 +60,7 @@ export async function getPackageFamily(id: string): Promise<PackageFamily | null
              dry_run_mode, min_version, notify_on_detection,
              notify_on_build_failure, check_for_updates_at, last_check_at,
              last_error, consecutive_errors, created_at, updated_at,
-             image_tag_template
+             image_tag_template, git_remote, melange_file_path, initial_tag
       FROM package_family
       WHERE id = $1`;
 
@@ -88,6 +89,9 @@ export async function getPackageFamily(id: string): Promise<PackageFamily | null
       createdAt: new Date(row.created_at),
       updatedAt: new Date(row.updated_at),
       imageTagTemplate: row.image_tag_template,
+      gitRemote: row.git_remote || undefined,
+      melangeFilePath: row.melange_file_path || undefined,
+      initialTag: row.initial_tag || undefined,
     };
   } finally {
     client.release();
@@ -257,9 +261,9 @@ export async function createPackageFamily(req: CreatePackageFamilyRequest): Prom
         major_version_filter, package_name_template,
         dry_run_mode, min_version, notify_on_detection,
         notify_on_build_failure, check_for_updates_at, consecutive_errors,
-        created_at, updated_at, image_tag_template
+        created_at, updated_at, image_tag_template, git_remote, melange_file_path, initial_tag
       ) VALUES (
-        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
+        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19
       )`;
 
     await client.query(query, [
@@ -269,6 +273,9 @@ export async function createPackageFamily(req: CreatePackageFamilyRequest): Prom
       req.dryRunMode, req.minVersion, req.notifyOnDetection,
       req.notifyOnBuildFailure, checkAt, 0, now, now,
       req.imageTagTemplate || null,
+      req.gitRemote || null,
+      req.melangeFilePath || null,
+      req.initialTag || null,
     ]);
 
     // Note: Packages are now dynamically discovered based on naming pattern
@@ -356,6 +363,21 @@ export async function updatePackageFamily(id: string, req: UpdatePackageFamilyRe
     if (req.imageTagTemplate !== undefined) {
       setParts.push(`image_tag_template = $${paramIndex}`);
       values.push(req.imageTagTemplate || null);
+      paramIndex++;
+    }
+    if (req.melangeFilePath !== undefined) {
+      setParts.push(`melange_file_path = $${paramIndex}`);
+      values.push(req.melangeFilePath || null);
+      paramIndex++;
+    }
+    if (req.gitRemote !== undefined) {
+      setParts.push(`git_remote = $${paramIndex}`);
+      values.push(req.gitRemote || null);
+      paramIndex++;
+    }
+    if (req.initialTag !== undefined) {
+      setParts.push(`initial_tag = $${paramIndex}`);
+      values.push(req.initialTag || null);
       paramIndex++;
     }
     
@@ -525,6 +547,62 @@ export async function getUpstreamConfigFromLatestPackage(packageFamilyId: string
     const latestPackage = familyPackages[0];
 
     return await getUpstreamConfigFromPackage(latestPackage.packageId);
+  } finally {
+    client.release();
+  }
+}
+
+export interface CreateLinkedPackageFamilyRequest {
+  name: string;
+  gitRemote: string;
+  melangeFilePath: string;
+  initialTag: string;
+}
+
+export async function createLinkedPackageFamily(req: CreateLinkedPackageFamilyRequest): Promise<PackageFamily> {
+  const { name, gitRemote, melangeFilePath, initialTag } = req;
+
+  const pool = getDB(process.env.DB_URI!);
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    const familyId = randomBytes(16).toString('hex');
+    const now = new Date();
+    const randomHours = Math.random() * 12;
+    const checkAt = new Date(now.getTime() + randomHours * 60 * 60 * 1000);
+
+    await client.query(`
+      INSERT INTO package_family (
+        id, name, monitoring_enabled,
+        check_frequency_minutes, version_pattern,
+        major_version_filter, package_name_template,
+        dry_run_mode, min_version, notify_on_detection,
+        notify_on_build_failure, check_for_updates_at, consecutive_errors,
+        created_at, updated_at, git_remote, melange_file_path, initial_tag
+      ) VALUES (
+        $1, $2, true, 360, null, null, null,
+        false, null, false, true, $3, 0,
+        $4, $5, $6, $7, $8
+      )
+    `, [familyId, name, checkAt, now, now, gitRemote, melangeFilePath, initialTag]);
+
+    await client.query('COMMIT');
+
+    const created = await getPackageFamily(familyId);
+    if (!created) {
+      throw new Error('Failed to create linked package family');
+    }
+
+    await enqueueWork('package_family_update_check', { packageFamilyId: familyId }).catch(err => {
+      console.warn('Failed to enqueue update check:', err);
+    });
+
+    return created;
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
   } finally {
     client.release();
   }

--- a/securebuild-app/lib/types/image.ts
+++ b/securebuild-app/lib/types/image.ts
@@ -37,6 +37,10 @@ export interface Image {
   currentTags: ImageTag[];
 
   externalRegistries: ImageExternalRegistry[];
+
+  gitRemote?: string;
+  apkoFilePath?: string;
+  imageTagTemplate?: string;
 }
 
 export interface ImageExternalRegistry {
@@ -71,6 +75,9 @@ export interface ImageAPKO {
   testYaml: string | null;
 
   latestVersion: ImageAPKOVersion;
+  gitTag?: string;
+  gitCommitSha?: string;
+  apkoFilePath?: string;
 }
 
 export interface ImageAPKOVersion {
@@ -78,6 +85,9 @@ export interface ImageAPKOVersion {
   apkoYaml: string;
   createdAt: Date;
   updatedAt: Date;
+  gitRemote?: string;
+  apkoFilePath?: string;
+  gitCommitSha?: string;
 }
 
 export interface ImageBuild {

--- a/securebuild-app/lib/types/package.ts
+++ b/securebuild-app/lib/types/package.ts
@@ -33,6 +33,10 @@ export interface PackageVersion {
   bootstrapApkRepository?: string | null;
   bootstrapKeyringAppend?: string | null;
   customDiskSize?: number | null;
+  gitRemote?: string;
+  melangeFilePath?: string;
+  gitTag?: string;
+  gitCommitSha?: string;
 }
 
 export enum PackageBuildStatus {

--- a/securebuild-app/lib/types/packagefamily.ts
+++ b/securebuild-app/lib/types/packagefamily.ts
@@ -17,6 +17,11 @@ export interface PackageFamily {
   consecutiveErrors: number;
   createdAt: Date;
   updatedAt: Date;
+  gitRemote?: string;
+  melangeFilePath?: string;
+  initialTag?: string;
+  gitTag?: string;
+  gitCommitSha?: string;
 }
 
 export interface PackageFamilyPackage {
@@ -29,6 +34,8 @@ export interface PackageFamilyPackage {
   lastExecutionId?: string | null;
   lastExecutionStatus?: string | null;
   lastExecutionCreatedAt?: Date | null;
+  gitTag?: string;
+  gitCommitSha?: string;
 }
 
 export interface PackageFamilyWithPackages extends PackageFamily {
@@ -47,6 +54,9 @@ export interface CreatePackageFamilyRequest {
   minVersion?: string;
   notifyOnDetection: boolean;
   notifyOnBuildFailure: boolean;
+  gitRemote?: string;
+  melangeFilePath?: string;
+  initialTag?: string;
 }
 
 export interface UpdatePackageFamilyRequest {
@@ -61,6 +71,9 @@ export interface UpdatePackageFamilyRequest {
   minVersion?: string;
   notifyOnDetection?: boolean;
   notifyOnBuildFailure?: boolean;
+  melangeFilePath?: string;
+  gitRemote?: string;
+  initialTag?: string;
 }
 
 // Helper functions for version parsing

--- a/securebuild-app/package-lock.json
+++ b/securebuild-app/package-lock.json
@@ -139,7 +139,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -153,7 +153,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -168,7 +168,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
       "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -178,7 +178,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -209,7 +209,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -219,7 +219,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
       "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.0",
@@ -236,7 +236,7 @@
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
       "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.27.2",
@@ -253,7 +253,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -263,7 +263,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -273,14 +273,14 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -290,7 +290,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
       "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.27.1",
@@ -304,7 +304,7 @@
       "version": "7.27.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
       "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
@@ -332,7 +332,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -342,7 +342,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -352,7 +352,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -362,7 +362,7 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
       "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
@@ -376,7 +376,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
       "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.0"
@@ -631,7 +631,7 @@
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
       "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -646,7 +646,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
       "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -665,7 +665,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
       "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -1941,7 +1941,7 @@
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
       "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1963,7 +1963,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1972,14 +1972,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.29",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
       "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -8094,7 +8094,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -8104,7 +8104,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -9477,7 +9477,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/core-util-is": {
@@ -9556,7 +9556,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cytoscape": {
@@ -10443,7 +10443,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -11549,7 +11549,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -11567,7 +11567,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -11596,7 +11596,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -13001,7 +13001,8 @@
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",

--- a/securebuild-app/package-lock.json
+++ b/securebuild-app/package-lock.json
@@ -139,7 +139,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -153,7 +153,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -168,7 +168,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
       "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -178,7 +178,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -209,7 +209,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -219,7 +219,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
       "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.0",
@@ -236,7 +236,7 @@
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
       "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.27.2",
@@ -253,7 +253,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -263,7 +263,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -273,14 +273,14 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -290,7 +290,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
       "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.27.1",
@@ -304,7 +304,7 @@
       "version": "7.27.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
       "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
@@ -332,7 +332,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -342,7 +342,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -352,7 +352,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -362,7 +362,7 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
       "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
@@ -376,7 +376,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
       "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.0"
@@ -631,7 +631,7 @@
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
       "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -646,7 +646,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
       "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -665,7 +665,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
       "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -1941,7 +1941,7 @@
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
       "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1963,7 +1963,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1972,14 +1972,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.29",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
       "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -7650,9 +7650,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
-      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.2.tgz",
+      "integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
       "cpu": [
         "x64"
       ],
@@ -7741,6 +7741,23 @@
       "optional": true,
       "os": [
         "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide/node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">= 20"
@@ -8094,7 +8111,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -8104,7 +8121,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -9477,7 +9494,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/core-util-is": {
@@ -9556,7 +9573,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cytoscape": {
@@ -10443,7 +10460,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -11549,7 +11566,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -11567,7 +11584,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -11596,7 +11613,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -13001,8 +13018,7 @@
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/react-redux": {
       "version": "9.2.0",


### PR DESCRIPTION
https://www.loom.com/share/675e4b7d4b8641ab8544f7cef806eb00

# Requirements

1. All packages must be created by SecureBuild  
2. All images must be created by SecureBuild. An image tag cannot be pushed by a maintainer and then overwritten by SecureBuild or vice versa.  
3. There must be only one copy of Melange and APKO files for each package and image.  
4. The maintainers need to be able to control APKO file contents ***before*** making the release.  
   1. For example, if `replicated-sdk` needs to have a special directory in the image with specific permissions, `replicated-sdk` maintainers must be able to make this change.  
5. The release process, which involves producing a package from a Melange file and an image from an APKO file, must be trivial from the maintainer's perspective, like pushing a tag.  
   1. \- securbuild is a CLI, wraps around an API at this time.  
   2. \- api is public, auth is a token. Token can be created in admin in this iteration.  
   3. Long term, plan making CLI a standalone tool that can build a package and publish it to APK repo   
6. Changes to source code dependencies (like `go.mod` files) must be made by the project maintainers and released as a new version.  
7. Changes to build-time or runtime dependencies, like Go compiler version (build time) or busybox version (runtime), must be released by SecureBuild by overwriting existing image tag (not as a new package or image version)

# Support for external Melange and APKO specs

Today SecureBuild only supports melange and APKO specs that are stored in the SecureBuild database. We want to add support for externally maintained specs.

1. Only git based URLs will be supported.  
2. Only public git repos will be supported.  
3. The specs will still be stored in the SecureBuild database, but they will be read-only.  
4. Only git tags will be supported (not releases), and tags have to be semvers.  
5. The existing `package githubsync` implementation is for persisting specs from the database in github for archival purposes and is unrelated to the proposed synching from git into the database. Though linked specs should still be synced with the `githubsync` package to SecureBuild’s internal `securebuild-specs` repo. This archival sync allows seeing all specs and diffs in one place. The `githubsync` logic will not be otherwise modified in this iteration, except for fixing the additional files in subdirectories bug called out earlier (preserving full relative paths instead of flattening to base filenames). The fact that linked specs exist in both the external maintainer repo and the internal `securebuild-specs` repo is acceptable: the internal copy is archival and read-only, while the external repo is the authoritative source.

## Package and image generation from tags

When a package family check detects a new tag, the behavior depends on whether the repo contains a melange file only, or both a melange file and an APKO file:

1. **Repo with both melange and APKO specs:** Tagging the repo produces both an APK package and an OCI image, triggered by the package family check. The package is built from the melange spec pulled from git. When the package is built, the image is built from the APKO spec pulled from the same git repo (at the same tag). The image's APKO spec is **not** cloned from an existing image APKO (as the existing package family image-auto-create logic does today); instead it is the APKO file from the repo. This only applies when the image is linked to git. For example, `replicated-sdk` is not useful on its own; the `replicated-sdk` git repo hosts both a melange and an APKO file. Tagging `replicated-sdk` produces a package and, when built, produces an image from the repo's APKO spec.

2. **Repo with melange only:** Tagging the repo produces an APK package, triggered by the package family check. The existing logic that finds an existing image APKO and clones it to produce a corresponding image is still executed, **unless** the target image is linked to git — in which case item 1 applies instead (the image is built from the repo's APKO spec, not cloned from an existing image).


# Melange specs

## Admin UI

Linked packages can be created by creating a new Package Family. When creating a package family, there will be two tabs: “Select Packages” (the current one) and “Link a repository” (the new one)

1. “Select Packages” should work the same way it works now.  
2. “Link a repository” should allow entering:  
   1. git remote  
   2. The path to the melange file relative to the root of the repo (the file should be part of the path so it does not have to be named “melange.yaml”; it can be named anything).  
   3. Initial tag to clone. Only tags are supported.

## Database

1. When a new package family is created, the initial new package will be created using the provided tag as version.  
   1. Git remote and the path to the melange file will be stored in the `package_family` table, since new packages (versions) are created from this information. These fields are the authoritative source of the link and are kept around for creating new package versions and for detecting new tags.  
   2. The `package` table does not store any git-specific information. It remains a version line (e.g. `git-2.50`) shared by multiple revisions, exactly as in the existing implementation.  
   3. Currently implemented logic for generating package versions from tags should be used, where applicable (see "Adaptation of existing logic" below).  
2. The upstream melange file should be stored in the `package_version` table along with git tag and commit sha corresponding to that tag.  
   1. The following new columns will be added to the `package_version` table: `git_remote`, `melange_file_path`, `git_tag`, `git_commit_sha`.  
   2. The `melange_yaml` column should contain the spec downloaded from the repo at the recorded tag/commit.  
   3. All files located in the same directory as the melange file will be added as additional files for the package version. This includes files in the same directory as well as files in any subdirectories, which are traversed recursively. Each additional file is stored with its path relative to the melange file's directory, preserving the directory structure (e.g. a file at `subdir/keyring.pub` relative to the melange directory is stored with path `subdir/keyring.pub`).  
      1. The `package_version_additional_file.content` column is `type: text` and cannot store binary data. Only text files (including files with Unicode content) are supported as additional files. Binary files (keyrings, tarballs, etc.) must not be placed in the melange file's directory.  
      2. No binary/text validation will be performed in the initial iteration. The list of linked repos will be manually curated by an internal team, who is responsible for ensuring that only text files are present in the melange directory. When the list of linked repos is no longer manually curated, proper binary file detection should be added, and the `content` column should be changed to `bytea` to support binary files.  
      3. The `githubsync` package currently flattens additional file paths to just the base filename (`filepath.Base`), losing subdirectory structure. This is a bug that needs to be fixed: `githubsync` must preserve the full relative path when writing additional files to the `securebuild-specs` repo, so that same-named files in different subdirectories do not collide.  
   4. During the `package_version` record creation, the `version` and `epoch` fields in the melange YAML are overridden with values derived from the git tag. The melange file's own `package.version` and `package.epoch` are ignored — the git tag is the authoritative source of the version. This allows maintainers to keep any version/epoch in their melange file without affecting the released version.  
      1. All semver parsing uses permissive parsing that allows a `v` prefix on tags (e.g. `v1.2.3` and `1.2.3` are equivalent).  
      2. Pre-release versions are ignored. Melange packages cannot have pre-release versions, so this is an acceptable restriction. Pre-release tags are not supported in this iteration.  
      3. All semver comparisons are performed using parsed semver objects, never string comparisons. This ensures `v1.2.3` matches `1.2.3` and that version ordering is correct.  
3. Presence of `git_remote` in the `package_version` table indicates that this package version is external and cannot be modified in admin. New versions can be added by checking for new tags in the repo. Some fields will be editable per version:  
   1. Path in the repo must be editable (updates `melange_file_path`; the next sync/pull will use it).  
   2. If the tag in the repo no longer matches the recorded commit SHA (i.e. the tag was reassigned to a different commit), a new revision should be created (a new row in `package_version` with incremented `apk_release` value). The new revision copies `git_remote`, `melange_file_path`, and `git_tag` from the previous revision, but `git_commit_sha` is always freshly resolved from the repo.  
   3. Changes to the upstream spec that are not associated with a tag (uncommitted branch changes, new commits on a non-tagged ref, etc.) are ignored. Only tagged states are ever imported: a new tag creates a new version, and an existing tag pointing to a different commit creates a new revision.  
   4. A `package_version` at a specific revision is immutable once it has been built and published to the APK repo. Mutation of a linked package only ever happens by adding a new revision row, never by overwriting an existing built one. A `package_version` is also treated as immutable while a build is in progress. The scenario where a git tag is reassigned to a new commit SHA between creating a `package_version` and its first build completing is highly unlikely. Handling this edge case (e.g. by canceling the in-progress build or waiting for it to finish before creating a new revision) is a nice-to-have and should only be implemented if the solution is simple; otherwise it can be deferred.  
5. Subpackages do not get their own git-specific columns (`git_remote`, `melange_file_path`, `git_tag`, `git_commit_sha`). A subpackage does not have a separate spec from its parent — it is defined within the parent's melange file. The git link information is stored only on the parent `package_version` row. Subpackage version rows continue to store `melange_yaml = nil` as they do today.

## Restrictions

1. Once built and published to the APK repo, a `package_version` revision becomes immutable (revision 0: \-r0). A revision is also treated as immutable while a build is in progress.  
2. If the tag is no longer associated with the original commit SHA, a new build can be triggered, and it will result in a new revision (-r1) by adding a new `package_version` row. Note that this technically allows older SHAs to be released as newer revisions if the tag is moved to an older commit.  
3. Untracked/un-tagged changes to the upstream spec are never imported. Only tagged commits are considered.

## Backwards compatibility

Existing packages can be converted to linked packages. However, there are some conditions that must be met:

1. Only a new version can be changed to linked  
2. Package versions created prior to this feature, can still be updated by creating new revisions.

# APKO specs

## Admin UI

Same changes as for Melange UI. There should be two tabs: one for current implementation and one for new. On the linked APKO tab, there should be the following options:

1. Git remote  
2. Path relative to the root of the repo to the apko file, including the file name itself  
3. Path to the test file  
4. Image tag template. Values will be based on the git tag being built. For example `v{major}.{minor}`. Following template fields will be supported  
   1. {major}  
   2. {minor}  
   3. {patch}

   This tag template is stored on the `image` table (new column) and applies **only to linked images**. The existing `image_tag_template` column on `package_family` continues to be used **only for generated APKOs** (the existing image-auto-create flow). This provides clear separation: `package_family.image_tag_template` for non-linked (generated) images, `image.image_tag_template` for linked images.

In addition to creating the linked image, users can create new `image_apko` rows in admin as they do today. For linked images, the user must specify a git tag. The specified git tag must be one that does not yet have an `image_apko` record for this image (no duplicates). The OCI tag is generated from the git tag using the image tag template.

On existing `image_apko` rows for linked images, users can click the "Build" button, which triggers a git check first: the system resolves the git tag to a commit SHA and compares it to the `git_commit_sha` recorded on the latest `image_apko_version`. If the SHA has changed, a new `image_apko_version` row is created with the freshly downloaded spec before the build proceeds. Clicking the "Build All" button triggers the same behavior for all `image_apko` rows of the linked image.

## Database

1. The `image` table has no git-link columns today (only columns relevant to the design are mentioned here). The following new columns will be added: `git_remote`, `apko_file_path` (path relative to the root of the repo to the apko file, including the file name), and `image_tag_template` (the tag template used to generate OCI tags from git tags for linked images). The `git_remote` and `apko_file_path` are the authoritative source of the link and are used to create new image versions and to discover new tags, analogous to `git_remote`/`melange_file_path` on `package_family`. The `image_tag_template` applies only to linked images; the existing `package_family.image_tag_template` continues to apply only to generated (non-linked) images.  
2. The `image_apko` table has no git-link columns today (only columns relevant to the design are mentioned here). The following new columns will be added: `git_remote`, `git_tag`, and `apko_file_path`. The existing `tags` array continues to store the generated OCI image tag(s) (produced from the git tag using the image tag template, e.g. `v{major}.{minor}`). The new `git_tag` column stores the original upstream git tag. The `apko_file_path` is carried down from the `image` table because it can change on re-tag in the source repo. Only a single git tag is supported for linked images (and therefore a single OCI tag).  
3. The `image_apko_version` table contains the actual `apko_yaml` (the APKO content). The following new columns will be added: `git_remote`, `apko_file_path`, and `git_commit_sha`. The `apko_file_path` is carried down from `image_apko` (which carries it from `image`) so that each version row records the exact path used to fetch it. When the image is a link, the spec is read-only in admin: a user cannot edit a linked APKO in admin because its source is an upstream git repo. However, the database-level behavior is unchanged from today: every change results in a new `image_apko_version` row rather than modifying an existing one.  
4. `image_apko` record should be created to link `apko_version` to `image` records.  
5. Before building a linked image, the system checks whether the git tag (stored in `image_apko.git_tag`) has been reassigned to a new commit SHA. If the current commit SHA in the repo no longer matches the `git_commit_sha` recorded on the latest `image_apko_version`, a new `image_apko_version` row is created with the freshly downloaded `apko_yaml`, the new `git_commit_sha`, and the current `apko_file_path` (which may have changed since the previous version). The existing row is not modified.  
6. Only single git tag per linked image is supported.  

## Backwards compatibility

Existing images will continue to work as they do now. However, existing images can be changed to linked images and rebuilding these versions will pull the APKO spec from the repo. This creates a new `image_apko_version` row with the upstream spec (the existing row is not modified), consistent with the existing append-only behavior of `image_apko_version`. The spec in the database will not be editable via admin UI.

When converting an existing non-linked image to a linked image, the existing `image_apko` rows have OCI tags but no `git_tag`. The user must supply the git tag manually for each `image_apko` during conversion. The OCI tag is then generated from the supplied git tag using the image tag template, and `git_tag` is populated on the `image_apko` row.

The same notion of immutability applies to packages: a user cannot edit a melange spec in admin if its source is an external git repo. New revisions are created by adding new `package_version` rows, never by modifying existing built ones.

## Tag reassignment

The existing tag reassignment logic (`ReassignTagsForImage`) moves OCI tags such as `latest`, `v{major}`, or `v{major}.{minor}` to the semantically greatest version among all `image_apko` rows for an image. For example, if `latest` is on `v1.5.3` and a new `v1.5.4` `image_apko` is created, `latest` moves to `v1.5.4`. Similarly, a less specific tag like `v1.5` moves to the greatest patch version under `v1.5`.

Tag reassignment should still run on linked images:
- It covers the case when an image is converted to a linked image and already has a `latest` tag (or other less-specific tags) from its pre-linked state.
- It allows users to manually add a `latest` tag (or other less-specific tags) to a linked image at a later time, and have it reassigned to the greatest version automatically.

However, the OCI tags that are generated from git tags (via the image tag template) must not be moved by tag reassignment. These tags are tied to a specific git tag and `image_apko` row, and moving them would decouple the OCI tag from the git tag it was generated from. The tag reassignment logic should explicitly exclude any OCI tag that matches a git tag stored on an `image_apko` from being reassigned. Only non-git-derived tags (e.g. `latest`, manually-added less-specific tags) are eligible for reassignment on linked images.

## Spec control vs build control

There is a clear separation between who controls the spec and who controls the build:

- **Maintainer controls the spec (requirement #&#8203;4):** The APKO spec content (which packages are included, whether they are pinned or unpinned) is pulled from the maintainer's git repo and is read-only in admin. The maintainer decides what goes into the image definition.
- **SecureBuild controls the build (requirement #&#8203;7):** SecureBuild decides which versions of those packages are actually built into the image. When a dependency (e.g. busybox) is updated, SecureBuild rebuilds the image and overwrites the existing OCI tag with a new image containing the updated dependency. This happens without any change to the upstream git repo.

For example, an upstream APKO file may contain an unpinned `busybox` dependency and the image tag is `v1.5.4`. When the image is first built, the OCI tag `v1.5.4` is pushed with `busybox-1.36`. When `busybox-1.37` becomes available, SecureBuild rebuilds the `v1.5.4` image — using the same APKO spec, same git tag, same commit SHA — and overwrites the `v1.5.4` tag in the OCI registry. The new image has `busybox-1.37`. This also applies to pinned dependencies: if a new Go version becomes available, all Go packages are rebuilt, and those updates propagate to images that depend on them, overwriting their existing OCI tags.

This is the core job of SecureBuild and applies to linked images the same way it applies to non-linked images. The link only affects where the spec comes from, not how the image is rebuilt when dependencies change.