### PR TITLE
New securebuild-api service migrated from securebuild-www

### DIFF
--- a/.github/actions/check-changes/action.yml
+++ b/.github/actions/check-changes/action.yml
@@ -4,6 +4,9 @@ outputs:
   run-app:
     description: 'Whether to run securebuild-app jobs'
     value: ${{ steps.changes.outputs.run-app }}
+  run-api:
+    description: 'Whether to run securebuild-api jobs'
+    value: ${{ steps.changes.outputs.run-api }}
   run-go:
     description: 'Whether to run Go jobs'
     value: ${{ steps.changes.outputs.run-go }}
@@ -28,6 +31,7 @@ runs:
           echo "Workflow, Makefile, or schema changed - running all jobs"
           echo "run-all=true" >> $GITHUB_OUTPUT
           echo "run-app=true" >> $GITHUB_OUTPUT
+          echo "run-api=true" >> $GITHUB_OUTPUT
           echo "run-go=true" >> $GITHUB_OUTPUT
           exit 0
         fi
@@ -37,6 +41,13 @@ runs:
           echo "run-app=true" >> $GITHUB_OUTPUT
         else
           echo "run-app=false" >> $GITHUB_OUTPUT
+        fi
+
+        # Check for securebuild-api changes
+        if echo "$CHANGED_FILES" | grep -q '^securebuild-api/'; then
+          echo "run-api=true" >> $GITHUB_OUTPUT
+        else
+          echo "run-api=false" >> $GITHUB_OUTPUT
         fi
 
         # Check for Go changes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run-app: ${{ steps.check.outputs.run-app }}
+      run-api: ${{ steps.check.outputs.run-api }}
       run-go: ${{ steps.check.outputs.run-go }}
       run-all: ${{ steps.check.outputs.run-all }}
     steps:
@@ -54,6 +55,42 @@ jobs:
     - name: Build
       run: |
         cd securebuild-app
+        npm run build
+      env:
+        CI: true
+
+  securebuild-api-build:
+    needs: check-changes
+    if: needs.check-changes.outputs.run-api == 'true'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '24'
+
+    - name: Cache Node.js modules
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.npm
+          securebuild-api/node_modules
+          securebuild-api/.next/cache
+        key: ${{ runner.os }}-node-api-${{ hashFiles('securebuild-api/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-api-
+
+    - name: Install Node.js dependencies
+      uses: ./.github/actions/install-npm-dependencies
+      with:
+        working-directory: securebuild-api
+
+    - name: Build
+      run: |
+        cd securebuild-api
         npm run build
       env:
         CI: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run-app: ${{ steps.check.outputs.run-app }}
+      run-api: ${{ steps.check.outputs.run-api }}
       run-go: ${{ steps.check.outputs.run-go }}
       run-all: ${{ steps.check.outputs.run-all }}
     steps:
@@ -58,6 +59,47 @@ jobs:
     - name: Run securebuild-app integration tests
       run: |
         cd securebuild-app
+        npm run test:integration
+      env:
+        CI: true
+        NODE_OPTIONS: --enable-source-maps
+
+  securebuild-api-integration:
+    needs: check-changes
+    if: needs.check-changes.outputs.run-api == 'true' || needs.check-changes.outputs.run-all == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '24'
+
+    - name: Cache Node.js modules
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.npm
+          securebuild-api/node_modules
+          securebuild-api/.next/cache
+        key: ${{ runner.os }}-node-api-${{ hashFiles('securebuild-api/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-api-
+
+    - name: Install SchemaHero
+      uses: ./.github/actions/install-schemahero
+
+    - name: Install Node.js dependencies
+      uses: ./.github/actions/install-npm-dependencies
+      with:
+        working-directory: securebuild-api
+
+    - name: Run securebuild-api integration tests
+      run: |
+        cd securebuild-api
         npm run test:integration
       env:
         CI: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,8 +83,44 @@ jobs:
           name: securebuild-app
           path: securebuild-app/securebuild-app.tar.gz
 
+  build-api:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: securebuild-api/package-lock.json
+
+      - name: Install dependencies
+        run: cd securebuild-api && npm ci
+
+      - name: Build
+        run: cd securebuild-api && npm run build
+        env:
+          CI: true
+
+      - name: Package api bundle
+        run: |
+          cd securebuild-api
+          mkdir -p release
+          cp -r .next/standalone release/
+          mkdir -p release/.next
+          cp -r .next/static release/.next/ 2>/dev/null || true
+          tar -czvf securebuild-api.tar.gz -C release .
+
+      - name: Upload api bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: securebuild-api
+          path: securebuild-api/securebuild-api.tar.gz
+
   release:
-    needs: [build-worker, build-app]
+    needs: [build-worker, build-app, build-api]
     runs-on: ubuntu-latest
     steps:
       - name: Download worker artifacts
@@ -102,6 +138,11 @@ jobs:
         with:
           name: securebuild-app
 
+      - name: Download api artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: securebuild-api
+
       - name: Prepare release assets
         run: |
           mkdir -p release-assets
@@ -109,6 +150,8 @@ jobs:
           mv securebuild-worker-linux-amd64 securebuild-worker-linux-arm64 release-assets/
           # App from download-artifact (single file at workspace root)
           mv securebuild-app.tar.gz release-assets/
+          # API from download-artifact (single file at workspace root)
+          mv securebuild-api.tar.gz release-assets/
           ls -la release-assets/
 
       - name: Create Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run-app: ${{ steps.check.outputs.run-app }}
+      run-api: ${{ steps.check.outputs.run-api }}
       run-go: ${{ steps.check.outputs.run-go }}
       run-all: ${{ steps.check.outputs.run-all }}
     steps:
@@ -54,6 +55,41 @@ jobs:
     - name: Run unit tests
       run: |
         cd securebuild-app
+        npm test
+      env:
+        CI: true
+
+  securebuild-api-tests:
+    needs: check-changes
+    if: needs.check-changes.outputs.run-api == 'true'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '24'
+
+    - name: Cache Node.js modules
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.npm
+          securebuild-api/node_modules
+        key: ${{ runner.os }}-node-api-${{ hashFiles('securebuild-api/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-api-
+
+    - name: Install Node.js dependencies
+      uses: ./.github/actions/install-npm-dependencies
+      with:
+        working-directory: securebuild-api
+
+    - name: Run unit tests
+      run: |
+        cd securebuild-api
         npm test
       env:
         CI: true

--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,7 @@ build-dev-images: pkg/builder/builder-linux-amd64 pkg/builder/builder-linux-arm6
 		--build-arg "NEXT_PUBLIC_CENTRIFUGO_ADDRESS=$${NEXT_PUBLIC_CENTRIFUGO_ADDRESS}" \
 		--build-arg "NEXT_PUBLIC_APK_REPOSITORY=$${NEXT_PUBLIC_APK_REPOSITORY}" \
 		-f securebuild-app/Dockerfile.repldev -t securebuild-app:latest securebuild-app/
+	docker build -f securebuild-api/Dockerfile.repldev -t securebuild-api:latest securebuild-api/
 	docker build -f Dockerfile.repldev-migrations -t securebuild-migrations:latest .
 
 # Dev stack targets (Docker Compose)

--- a/db/schema/tables/securebuild-team.yaml
+++ b/db/schema/tables/securebuild-team.yaml
@@ -1,5 +1,6 @@
 database: securebuild
 name: securebuild_team
+requires: []
 schema:
   postgres:
     primaryKey:
@@ -38,3 +39,24 @@ schema:
       constraints:
         notNull: true
       default: "{}"
+seedData:
+  rows:
+    - columns:
+        - column: id
+          value:
+            str: "dev-team"
+        - column: name
+          value:
+            str: "Dev Team"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: registry_username
+          value:
+            str: "dev-team"
+        - column: full_catalog_access
+          value:
+            str: "true"
+        - column: feature_flags
+          value:
+            str: "{custom-melange-upload,custom-apko-upload}"

--- a/db/schema/tables/securebuild-user.yaml
+++ b/db/schema/tables/securebuild-user.yaml
@@ -1,5 +1,6 @@
 database: securebuild
 name: securebuild_user
+requires: []
 schema:
   postgres:
     primaryKey:
@@ -41,3 +42,30 @@ schema:
       constraints:
         notNull: true
       default: false
+seedData:
+  rows:
+    - columns:
+        - column: id
+          value:
+            str: "dev-user"
+        - column: email
+          value:
+            str: "dev@securebuild.com"
+        - column: first_name
+          value:
+            str: "Dev"
+        - column: last_name
+          value:
+            str: "User"
+        - column: picture
+          value:
+            str: "https://securebuild.com/img/avatar-dev.png"
+        - column: hosted_domain
+          value:
+            str: "securebuild.com"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: role
+          value:
+            str: "admin"

--- a/db/schema/tables/service-account.yaml
+++ b/db/schema/tables/service-account.yaml
@@ -1,5 +1,7 @@
 database: securebuild
 name: service_account
+requires:
+  - securebuild-team
 schema:
   postgres:
     primaryKey:
@@ -40,3 +42,31 @@ schema:
       default: bcrypt
       constraints:
         notNull: true
+seedData:
+  # Bearer token: Q9f2Kp7Rm4Xs8Wz3Yv6Bn1Cd5Fh8Jk3Lm0Pq4Rs7Tu
+  rows:
+    - columns:
+        - column: id
+          value:
+            str: "dev-service-account"
+        - column: name
+          value:
+            str: "Dev Service Account"
+        - column: partial_value
+          value:
+            str: "Q9f2"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: bcrypt_hash
+          value:
+            str: "Fq+YxF9qTVhTYNOpQmHsfHEGDTB3wGh0KPQwdqmtoSI="
+        - column: team_id
+          value:
+            str: "dev-team"
+        - column: expires_in
+          value:
+            str: "never"
+        - column: hash_algorithm
+          value:
+            str: "sha256"

--- a/db/schema/tables/user-team.yaml
+++ b/db/schema/tables/user-team.yaml
@@ -1,5 +1,8 @@
 database: securebuild
 name: user_team
+requires:
+  - securebuild-user
+  - securebuild-team
 schema:
   postgres:
     primaryKey:
@@ -14,3 +17,12 @@ schema:
       type: text
       constraints:
         notNull: true
+seedData:
+  rows:
+    - columns:
+        - column: user_id
+          value:
+            str: "dev-user"
+        - column: team_id
+          value:
+            str: "dev-team"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,25 @@ services:
     depends_on:
       - postgres
 
+  api:
+    image: securebuild-api:latest
+    env_file:
+      - ./securebuild-app/.env.local
+    environment:
+      # Override DB_URI to point at the compose postgres (env_file has localhost:15432)
+      DB_URI: postgres://postgres:password@postgres:5432/securebuild?sslmode=disable
+      HOSTNAME: "0.0.0.0"
+      TELEMETRY_BACKEND: ${TELEMETRY_BACKEND:-none}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://host.docker.internal:4318}
+      OTEL_SERVICE_NAME: securebuild-api
+      OTEL_RESOURCE_ATTRIBUTES: ${OTEL_RESOURCE_ATTRIBUTES:-deployment.environment=development}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - "3002:3002"
+    depends_on:
+      - postgres
+
   apk-proxy:
     image: securebuild-worker:latest
     command: ["apk-proxy"]

--- a/securebuild-api/.gitignore
+++ b/securebuild-api/.gitignore
@@ -1,0 +1,27 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files
+.env*
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/securebuild-api/Dockerfile.repldev
+++ b/securebuild-api/Dockerfile.repldev
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1.4
+# Dockerfile for repldev - Next.js standalone build for securebuild-api (linux/amd64)
+FROM node:24-slim AS builder
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies with npm cache mount for faster rebuilds
+# On ARM64, delete package-lock.json to force fresh install with correct binaries
+RUN --mount=type=cache,target=/root/.npm \
+    npm install
+
+# Copy source
+COPY . .
+
+# Optimization: Disable telemetry, source maps, and increase Node memory
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_DISABLE_SOURCEMAPS=1
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+
+# Build with Turbopack and cache mounts for incremental builds (5-10x faster)
+RUN --mount=type=cache,target=/root/.npm \
+    --mount=type=cache,target=/app/.next/cache \
+    npm run build
+
+# Production image
+FROM node:24-slim
+
+WORKDIR /app
+
+# Copy standalone output
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+
+# Expose port
+EXPOSE 3002
+
+ENV NODE_ENV=production
+ENV PORT=3002
+
+CMD ["node", "server.js"]

--- a/securebuild-api/__mocks__/server-only.js
+++ b/securebuild-api/__mocks__/server-only.js
@@ -1,0 +1,4 @@
+// Mock for server-only module used in Jest tests
+// This module is used by Next.js to ensure code only runs on the server
+// For tests, we just provide an empty mock since we're running in Node.js environment
+module.exports = {};

--- a/securebuild-api/app/api/v1/external-image/route.ts
+++ b/securebuild-api/app/api/v1/external-image/route.ts
@@ -1,0 +1,232 @@
+import { upsertExternalImage } from '@/lib/externalimage/externalimage'
+import { getImageDigest, parseImageRef } from '@/lib/externalimage/registry'
+import { enqueueWork, hasExistingSBOM } from '@/lib/utils/queue'
+import { NextRequest, NextResponse } from 'next/server'
+import { findServiceAccountWithValue } from '@/lib/team/service-account'
+import { getExternalImageDigestForTag, getExternalImageLastScannedAt, getExternalImagePlatforms, getExternalImageScan, getSBOMStatus, teamOwnsDigest } from '@/lib/externalimage/externalimage'
+
+export async function POST(request: NextRequest) {
+  try {
+    // Check for Authorization header
+    const authHeader = request.headers.get('Authorization')
+    if (!authHeader) {
+      return NextResponse.json(
+        { error: 'Authorization header required' },
+        { status: 401 }
+      )
+    }
+
+    // Extract Bearer token
+    const tokenMatch = authHeader.match(/^Bearer\s+(.+)$/i)
+    if (!tokenMatch) {
+      return NextResponse.json(
+        { error: 'Invalid authorization header format. Expected: Bearer <token>' },
+        { status: 401 }
+      )
+    }
+
+    const token = tokenMatch[1]
+
+    // Authenticate the service account
+    const authResult = await findServiceAccountWithValue(token)
+    if (!authResult) {
+      return NextResponse.json(
+        { error: 'Invalid or expired service account token' },
+        { status: 401 }
+      )
+    }
+
+    const { teamId } = authResult
+
+    const body = await request.json()
+
+    const { image_url, credentials } = body
+
+    const parsed = parseImageRef(image_url)
+    console.log("parsed", parsed)
+
+    const digest = await getImageDigest(parsed, credentials)
+
+    await upsertExternalImage(parsed.registry, parsed.repository, parsed.tag, digest, credentials?.username, credentials?.password, teamId)
+
+    // Only enqueue SBOM work if needed (no existing SBOM)
+    // This prevents duplicate work items and unnecessary processing
+    // Note: scan_attempted_at will be set when the scan starts (SetScanStatusRunning in Go)
+    const shouldSkipSBOM = await hasExistingSBOM(digest)
+    if (!shouldSkipSBOM) {
+      await enqueueWork('external_image_sbom', {
+        digest: digest,
+      })
+    }
+
+    return NextResponse.json(
+      {
+        status: 201,
+        digest: digest,
+        image_url: image_url,
+      },
+      {
+        status: 201,
+      }
+    )
+  } catch (error) {
+    console.error('Error creating image:', error)
+    return NextResponse.json(
+      { error: 'Failed to create image' },
+      { status: 500 }
+    )
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    // Check for Authorization header
+    const authHeader = request.headers.get('Authorization')
+    if (!authHeader) {
+      return NextResponse.json(
+        { error: 'Authorization header required' },
+        { status: 401 }
+      )
+    }
+
+    // Extract Bearer token
+    const tokenMatch = authHeader.match(/^Bearer\s+(.+)$/i)
+    if (!tokenMatch) {
+      return NextResponse.json(
+        { error: 'Invalid authorization header format. Expected: Bearer <token>' },
+        { status: 401 }
+      )
+    }
+
+    const token = tokenMatch[1]
+
+    // Authenticate the service account
+    const authResult = await findServiceAccountWithValue(token)
+    if (!authResult) {
+      return NextResponse.json(
+        { error: 'Invalid or expired service account token' },
+        { status: 401 }
+      )
+    }
+
+    const { teamId } = authResult
+
+    const { searchParams } = new URL(request.url)
+
+    const sha = searchParams.get('sha')
+    const imageURL = searchParams.get('image_url')
+
+    if (!sha && !imageURL) {
+      return NextResponse.json({ error: 'Missing sha or image_url parameter' }, { status: 400 })
+    }
+
+    let currentDigest: string = ''
+
+    if (sha) {
+      // Validate that the team has access to this digest
+      const hasAccess = await teamOwnsDigest(teamId, sha)
+      if (!hasAccess) {
+        return NextResponse.json(
+          { error: 'Digest not found or access denied' },
+          { status: 404 }
+        )
+      }
+      currentDigest = sha
+    } else if (imageURL) {
+      // Get external image by name/tag
+      const imageUrlParsed = parseImageRef(imageURL)
+      try {
+        const digest = await getExternalImageDigestForTag(teamId, imageUrlParsed.registry, imageUrlParsed.repository, imageUrlParsed.tag)
+        if (!digest) {
+          return NextResponse.json(
+            { error: 'Tag not found for this external image' },
+            { status: 404 }
+          )
+        }
+        currentDigest = digest
+      } catch {
+        return NextResponse.json(
+          { error: 'External image not found or access denied' },
+          { status: 404 }
+        )
+      }
+    }
+
+    // Get last scanned time, platforms, scan status, and SBOM status
+    const [lastScannedAt, platforms, amd64Scan, arm64Scan, sbomStatusResult] = await Promise.all([
+      getExternalImageLastScannedAt(currentDigest),
+      getExternalImagePlatforms(currentDigest),
+      getExternalImageScan(currentDigest, 'x86_64', 'parsed'),
+      getExternalImageScan(currentDigest, 'aarch64', 'parsed'),
+      getSBOMStatus(currentDigest),
+    ])
+    const sbomStatus = sbomStatusResult ?? null
+
+    // Build scan statuses array from individual architecture results
+    const scanStatuses = []
+    if (amd64Scan) {
+      scanStatuses.push({
+        status: amd64Scan.status,
+        scanStatusMessage: amd64Scan.scanStatusMessage,
+        scanStatusUpdatedAt: amd64Scan.scanStatusUpdatedAt,
+      })
+    }
+    if (arm64Scan) {
+      scanStatuses.push({
+        status: arm64Scan.status,
+        scanStatusMessage: arm64Scan.scanStatusMessage,
+        scanStatusUpdatedAt: arm64Scan.scanStatusUpdatedAt,
+      })
+    }
+
+    // Determine overall scan status (priority: failed > running > queued > succeeded)
+    // Note: SBOM generation status is tracked separately in external_image_sbom_status
+    let scanStatus: string | null = null
+    let scanStatusMessage: string | null = null
+    let scanStatusUpdatedAt: Date | null = null
+
+    if (scanStatuses.length > 0) {
+      // Find the most relevant status based on priority
+      const failed = scanStatuses.find(s => s.status === 'failed')
+      const running = scanStatuses.find(s => s.status === 'running')
+      const queued = scanStatuses.find(s => s.status === 'queued')
+      const succeeded = scanStatuses.find(s => s.status === 'succeeded')
+
+      if (failed) {
+        scanStatus = 'failed'
+        scanStatusMessage = failed.scanStatusMessage
+        scanStatusUpdatedAt = failed.scanStatusUpdatedAt
+      } else if (running) {
+        scanStatus = 'running'
+        scanStatusMessage = null
+        scanStatusUpdatedAt = running.scanStatusUpdatedAt
+      } else if (queued) {
+        scanStatus = 'queued'
+        scanStatusMessage = null
+        scanStatusUpdatedAt = queued.scanStatusUpdatedAt
+      } else if (succeeded) {
+        scanStatus = 'succeeded'
+        scanStatusMessage = null
+        scanStatusUpdatedAt = succeeded.scanStatusUpdatedAt
+      }
+    }
+
+    return NextResponse.json({
+      digest: currentDigest,
+      last_scanned_at: lastScannedAt,
+      platforms: platforms,
+      scan_status: scanStatus,
+      scan_status_message: scanStatusMessage,
+      scan_status_updated_at: scanStatusUpdatedAt,
+      sbom_status: sbomStatus?.status ?? null,
+      sbom_status_message: sbomStatus?.statusMessage ?? null,
+      sbom_status_updated_at: sbomStatus?.statusUpdatedAt ?? null,
+    })
+  } catch (error) {
+    console.error('Error retrieving external image:', error)
+    return NextResponse.json(
+      { error: 'Failed to retrieve external image' },
+      { status: 500 }
+    )
+  }
+}

--- a/securebuild-api/app/api/v1/external-image/sbom/route.ts
+++ b/securebuild-api/app/api/v1/external-image/sbom/route.ts
@@ -1,0 +1,272 @@
+import { getExternalImageDigestForTag, getExternalImageSBOM, getBatchExternalSboms, getBatchDigestsForTags, teamOwnsDigest, type ImageRefTag, BatchSbomResult } from "@/lib/externalimage/externalimage"
+import { parseImageRef } from "@/lib/externalimage/registry"
+import { NextRequest, NextResponse } from "next/server"
+import { findServiceAccountWithValue } from "@/lib/team/service-account"
+import { mergeSBOMs } from "@/lib/sbom/merger"
+import { traceFunction, withTrace } from "@/lib/observability/tracing"
+
+
+export async function GET(request: NextRequest) {
+  return withTrace('api.external_image.sbom', async (span) => {
+    try {
+      // Check for Authorization header
+      const authHeader = request.headers.get('Authorization')
+      if (!authHeader) {
+        return NextResponse.json(
+          { error: 'Authorization header required' },
+          { status: 401 }
+        )
+      }
+
+      // Extract Bearer token
+      const tokenMatch = authHeader.match(/^Bearer\s+(.+)$/i)
+      if (!tokenMatch) {
+        return NextResponse.json(
+          { error: 'Invalid authorization header format. Expected: Bearer <token>' },
+          { status: 401 }
+        )
+      }
+
+      const token = tokenMatch[1]
+
+      // Authenticate the service account
+      const authResult = await findServiceAccountWithValue(token)
+      if (!authResult) {
+        return NextResponse.json(
+          { error: 'Invalid or expired service account token' },
+          { status: 401 }
+        )
+      }
+
+      const { teamId } = authResult
+
+      span?.setTag('context.team_id', teamId)
+
+      const { searchParams } = new URL(request.url)
+
+      // Support single and multiple images using same parameter names
+      const digests = searchParams.getAll('digest') // Single or multiple digests
+      const imageURLs = searchParams.getAll('image_url') // Single or multiple image URLs
+
+      span?.setTag('context.digests.length', digests.length)
+      span?.setTag('context.image_urls.length', imageURLs.length)
+
+      // Validate parameters
+      const hasInputs = digests.length > 0 || imageURLs.length > 0
+
+      if (!hasInputs) {
+        return NextResponse.json({
+          error: 'Missing required parameters. Provide digest and/or image_url parameters'
+        }, { status: 400 })
+      }
+
+      // Handle single image (backwards compatibility)
+      if (digests.length + imageURLs.length === 1) {
+        return await handleSingleImage(teamId, digests[0] || null, imageURLs[0] || null)
+      }
+
+      // Handle multiple images
+      return await handleMultipleImages(teamId, digests, imageURLs)
+    } catch (error) {
+      console.error('Error retrieving SBOM:', error)
+      span?.setTag('error', error as Error)
+      return NextResponse.json(
+        { error: 'Failed to retrieve SBOM' },
+        { status: 500 }
+      )
+    }
+  })
+}
+
+const handleSingleImage = traceFunction('api.external_image.sbom.handleSingleImage', async (teamId: string, digestParam: string | null, imageURL: string | null): Promise<NextResponse> => {
+  let digest = digestParam
+  // If we have an image URL, validate access and get digest
+  if (imageURL) {
+    const imageUrlParsed = parseImageRef(imageURL)
+
+    try {
+      digest = await getExternalImageDigestForTag(teamId, imageUrlParsed.registry, imageUrlParsed.repository, imageUrlParsed.tag)
+      if (!digest) {
+        return NextResponse.json(
+          { error: 'Tag not found for this external image' },
+          { status: 404 }
+        )
+      }
+    } catch {
+      return NextResponse.json(
+        { error: 'External image not found or access denied' },
+        { status: 404 }
+      )
+    }
+  }
+
+  if (!digest) {
+    return NextResponse.json({ error: 'Digest not found' }, { status: 404 })
+  }
+
+  // Validate that the team owns this digest
+  const hasAccess = await teamOwnsDigest(teamId, digest)
+  if (!hasAccess) {
+    return NextResponse.json({ error: 'SBOM not found' }, { status: 404 })
+  }
+
+  const { sbom, source } = (await getExternalImageSBOM(digest)) || { sbom: null, source: null }
+
+  if (!sbom) {
+    return NextResponse.json({ error: 'SBOM not found' }, { status: 404 })
+  }
+
+  const response = NextResponse.json(JSON.parse(sbom))
+
+  if (source) {
+    response.headers.set('X-SecureBuild-SBOM_Source', source)
+  }
+
+  response.headers.set('X-SecureBuild-Image_Digest', digest)
+
+  return response
+},
+  {
+    getTags: (teamId: string, digestParam: string | null, imageURL: string | null) => ({
+      'args.team_id': teamId,
+      'args.digest': digestParam,
+      'args.image_url': imageURL,
+    })
+  })
+
+const handleMultipleImages = traceFunction('api.external_image.sbom.handleMultipleImages', async (teamId: string, inputDigests: string[], inputImages: string[]): Promise<NextResponse> => {
+  const results = await batchListSboms(teamId, inputDigests, inputImages);
+
+  const sbomStrings: string[] = []
+  const sbomSources: string[] = []
+  const allDigests = new Set<string>()
+
+  for (const result of results) {
+    if (!result.digest || !result.result) {
+      continue
+    }
+    if (result.result.sbom) {
+      sbomStrings.push(result.result.sbom)
+      if (result.result.source) {
+        sbomSources.push(result.result.source)
+      }
+      allDigests.add(result.digest)
+    }
+  }
+
+  if (sbomStrings.length === 0) {
+    return NextResponse.json({ error: 'No SBOMs found for the requested images' }, { status: 404 })
+  }
+
+  // Merge SBOMs
+  let mergedSbom: string
+  try {
+    mergedSbom = mergeSBOMs(sbomStrings)
+  } catch (error) {
+    console.error('Failed to merge SBOMs:', error)
+    return NextResponse.json({ error: 'Failed to merge SBOMs' }, { status: 500 })
+  }
+
+  const response = NextResponse.json(JSON.parse(mergedSbom))
+
+  // Set headers for multiple images
+  if (sbomSources.length > 0) {
+    response.headers.set('X-SecureBuild-SBOM_Source', sbomSources.join(','))
+  }
+  response.headers.set('X-SecureBuild-Image_Count', allDigests.size.toString())
+  response.headers.set('X-SecureBuild-Image_Digest', Array.from(allDigests).join(','))
+
+  return response
+},
+  {
+    getTags: (teamId: string, inputDigests: string[], inputImages: string[]) => ({
+      'args.team_id': teamId,
+      'args.digests.length': inputDigests.length,
+      'args.images.length': inputImages.length,
+    })
+  })
+
+type ResultEntry = {
+  input: string
+  digest: string | null
+  result: BatchSbomResult | null
+  not_found: boolean
+}
+
+const batchListSboms = traceFunction('api.external_image.sbom.batchListSboms', async (teamId: string, inputDigests: string[], inputImages: string[], arch: string = 'x86_64'): Promise<ResultEntry[]> => {
+  const results: ResultEntry[] = []
+
+  if (inputDigests.length === 0 && inputImages.length === 0) {
+    return results
+  }
+
+  // Step 1: Parse image URLs into ImageRefTag objects
+  const imageRefTags: ImageRefTag[] = []
+  for (const imageUrl of inputImages) {
+    const parsed = parseImageRef(imageUrl)
+    imageRefTags.push({
+      registry: parsed.registry,
+      repository: parsed.repository,
+      tag: parsed.tag
+    })
+  }
+
+  // Step 2: Get digests for all image URLs in a single query
+  const imageUrlDigests = imageRefTags.length > 0
+    ? await getBatchDigestsForTags(teamId, imageRefTags)
+    : []
+
+  // Step 3: Collect all digests and map inputs to digests
+  const allDigests = new Set<string>()
+  const inputToDigestMap = new Map<string, string | undefined>()
+
+  // Add digests from inputDigests
+  for (const digest of inputDigests) {
+    allDigests.add(digest)
+    inputToDigestMap.set(digest, digest)
+  }
+
+  // Add digests from image URLs
+  for (const [index, imageUrl] of inputImages.entries()) {
+    const digest = imageUrlDigests[index]
+
+    inputToDigestMap.set(imageUrl, digest)
+
+    if (digest) {
+      allDigests.add(digest)
+    }
+  }
+
+  // Step 4: Get SBOM results for all digests (team ownership validated via JOIN)
+  const sbomResults = allDigests.size > 0
+    ? await getBatchExternalSboms(teamId, [...allDigests], arch)
+    : new Map<string, BatchSbomResult>()
+
+  // Step 5: Build the results array
+  for (const input of [...inputDigests, ...inputImages]) {
+    const digest = inputToDigestMap.get(input) || null;
+    let sbomData: BatchSbomResult | null = null;
+    if (digest) {
+      sbomData = sbomResults.get(digest) || null;
+      if (!sbomData?.hasAccess) {
+        sbomData = null;
+      }
+    }
+    results.push({
+      input: input,
+      digest: digest,
+      result: sbomData,
+      not_found: sbomData === null,
+    })
+  }
+
+  return results
+},
+  {
+    getTags: (teamId: string, inputDigests: string[], inputImages: string[], arch: string = 'x86_64') => ({
+      'args.team_id': teamId,
+      'args.digests.length': inputDigests.length,
+      'args.images.length': inputImages.length,
+      'args.arch': arch,
+    })
+  })

--- a/securebuild-api/app/api/v1/external-image/scan-summary/route.ts
+++ b/securebuild-api/app/api/v1/external-image/scan-summary/route.ts
@@ -1,0 +1,219 @@
+import { getBatchDigestsForTags, getBatchExternalImageScans, type ImageRefTag, type BatchScanResult } from "@/lib/externalimage/externalimage"
+import { parseImageRef } from "@/lib/externalimage/registry"
+import { NextRequest, NextResponse } from "next/server"
+import { findServiceAccountWithValue } from "@/lib/team/service-account"
+import { traceFunction, withTrace } from "@/lib/observability/tracing"
+
+type ImageScanResultDetails = {
+  counts: SeverityCounts
+}
+
+type SeverityCounts = {
+  critical: number
+  high: number
+  medium: number
+  low: number
+  total: number
+}
+
+type SummaryEntry = {
+  input: string
+  digest: string | null
+  last_scanned_at: string | null
+  digest_first_seen_at: string | null
+  counts: SeverityCounts
+  not_found: boolean
+  image_size_bytes: number
+  scan_status: string | null
+  scan_status_message: string | null
+  scan_status_updated_at: string | null
+}
+
+function emptyCounts(): SeverityCounts {
+  return { critical: 0, high: 0, medium: 0, low: 0, total: 0 }
+}
+
+interface RequestBody {
+  digests?: string[];
+  images?: string[];
+}
+
+// parsed_results already stores counts JSON in the DB
+
+export async function POST(request: NextRequest) {
+  return withTrace('api.external_image.scan_summary', async (span) => {
+    try {
+      const authHeader = request.headers.get('Authorization')
+      if (!authHeader) {
+        return NextResponse.json(
+          { error: 'Authorization header required' },
+          { status: 401 }
+        )
+      }
+
+      const tokenMatch = authHeader.match(/^Bearer\s+(.+)$/i)
+      if (!tokenMatch) {
+        return NextResponse.json(
+          { error: 'Invalid authorization header format. Expected: Bearer <token>' },
+          { status: 401 }
+        )
+      }
+
+      const token = tokenMatch[1]
+      const authResult = await findServiceAccountWithValue(token)
+      if (!authResult) {
+        return NextResponse.json(
+          { error: 'Invalid or expired service account token' },
+          { status: 401 }
+        )
+      }
+
+      const { teamId } = authResult
+
+      span?.setTag('context.team_id', teamId)
+
+      const { searchParams } = new URL(request.url)
+
+      const arch = searchParams.get('arch') || 'amd64'
+      let dbArch: string
+      if (arch === 'amd64') {
+        dbArch = 'x86_64'
+      } else if (arch === 'arm64') {
+        dbArch = 'aarch64'
+      } else {
+        return NextResponse.json({ error: 'Invalid architecture. Supported: amd64, arm64' }, { status: 400 })
+      }
+
+      // Read inputs from JSON body: { digests: string[], images: string[] }
+      let body: unknown
+      try {
+        body = await request.json()
+      } catch {
+        return NextResponse.json({ error: 'Invalid or missing JSON body' }, { status: 400 })
+      }
+
+      const requestBody = body as RequestBody;
+      const inputDigests = Array.isArray(requestBody.digests) ? requestBody.digests : []
+      const inputImages = Array.isArray(requestBody.images) ? requestBody.images : []
+
+      span?.setTag('context.arch', dbArch)
+      span?.setTag('context.digests.length', inputDigests.length)
+      span?.setTag('context.images.length', inputImages.length)
+
+      if (inputDigests.length === 0 && inputImages.length === 0) {
+        return NextResponse.json({ error: 'Missing required parameters. Provide digests and/or images' }, { status: 400 })
+      }
+
+      // Use batch queries to minimize database calls
+      const results = await batchListScanSummaries(teamId, inputDigests, inputImages, dbArch)
+
+      const response = NextResponse.json(results)
+      response.headers.set('X-SecureBuild-Architecture', arch)
+      response.headers.set('X-SecureBuild-Result_Count', results.length.toString())
+      return response
+    } catch (error) {
+      console.error('Error retrieving scan summaries:', error)
+      span?.setTag('error', error as Error)
+      return NextResponse.json(
+        { error: 'Failed to retrieve scan summaries' },
+        { status: 500 }
+      )
+    }
+  })
+}
+
+const batchListScanSummaries = traceFunction('api.external_image.scan_summary.batchListScanSummaries', async (teamId: string, inputDigests: string[], inputImages: string[], arch: string = 'x86_64'): Promise<SummaryEntry[]> => {
+  const results: SummaryEntry[] = []
+
+  if (inputDigests.length === 0 && inputImages.length === 0) {
+    return results
+  }
+
+  // Step 1: Parse image URLs into ImageRefTag objects
+  const imageRefTags: ImageRefTag[] = []
+  for (const imageUrl of inputImages) {
+    const parsed = parseImageRef(imageUrl)
+    imageRefTags.push({
+      registry: parsed.registry,
+      repository: parsed.repository,
+      tag: parsed.tag
+    })
+  }
+
+  // Step 2: Get digests for all image URLs in a single query
+  const imageUrlDigests = imageRefTags.length > 0
+    ? await getBatchDigestsForTags(teamId, imageRefTags)
+    : []
+
+  // Step 3: Collect all digests and map inputs to digests
+  const allDigests = new Set<string>()
+  const inputToDigestMap = new Map<string, string | undefined>()
+
+  // Add digests from inputDigests
+  for (const digest of inputDigests) {
+    allDigests.add(digest)
+    inputToDigestMap.set(digest, digest)
+  }
+
+  // Add digests from image URLs
+  for (const [index, imageUrl] of inputImages.entries()) {
+    const digest = imageUrlDigests[index]
+
+    inputToDigestMap.set(imageUrl, digest)
+
+    if (digest) {
+      allDigests.add(digest)
+    }
+  }
+
+  // Step 4: Get scan results for all digests (team ownership validated via JOIN)
+  const scanResults = allDigests.size > 0
+    ? await getBatchExternalImageScans(teamId, [...allDigests], arch, 'parsed')
+    : new Map<string, BatchScanResult>()
+
+  // Step 5: Build the results array
+  for (const input of [...inputDigests, ...inputImages]) {
+    const digest = inputToDigestMap.get(input) || null;
+    let scanData: BatchScanResult | null = null;
+    if (digest) {
+      scanData = scanResults.get(digest) || null;
+      if (!scanData?.hasAccess) {
+        scanData = null;
+      }
+    }
+
+    let parsedResult: SeverityCounts | null = null
+    if (scanData?.scanResult) {
+      try {
+        const details = JSON.parse(scanData.scanResult) as ImageScanResultDetails
+        parsedResult = details?.counts || emptyCounts()
+      } catch (error) {
+        console.error(`Failed to parse scan result for input ${input}:`, error)
+        // Continue with null result instead of failing the entire request
+      }
+    }
+
+    results.push({
+      input: input,
+      digest: digest,
+      last_scanned_at: scanData?.scanCreatedAt || null,
+      digest_first_seen_at: scanData?.digestFirstSeenAt || null,
+      counts: parsedResult || emptyCounts(),
+      not_found: scanData === null,
+      image_size_bytes: scanData?.imageSizeBytes || 0,
+      scan_status: scanData?.scanStatus || null,
+      scan_status_message: scanData?.scanStatusMessage || null,
+      scan_status_updated_at: scanData?.scanStatusUpdatedAt || null,
+    })
+  }
+
+  return results
+},
+  {
+    getTags: (teamId: string, inputDigests: string[], inputImages: string[], arch: string = 'x86_64') => ({
+      'args.team_id': teamId,
+      'args.digests.length': inputDigests.length,
+      'args.images.length': inputImages.length,
+      'args.arch': arch
+    })
+  })

--- a/securebuild-api/app/api/v1/external-image/scan/route.ts
+++ b/securebuild-api/app/api/v1/external-image/scan/route.ts
@@ -1,0 +1,368 @@
+import { getBatchDigestsForTags, getBatchExternalImageScans, type ImageRefTag, getExternalImageDigestForTag, getExternalImageScan, teamOwnsDigest, BatchScanResult } from "@/lib/externalimage/externalimage"
+import { parseImageRef } from "@/lib/externalimage/registry"
+import { NextRequest, NextResponse } from "next/server"
+import { findServiceAccountWithValue } from "@/lib/team/service-account"
+import { withTrace, traceFunction } from "@/lib/observability/tracing"
+
+export async function GET(request: NextRequest) {
+  return withTrace('api.external_image.scan', async (span) => {
+    try {
+      // Check for Authorization header
+      const authHeader = request.headers.get('Authorization')
+      if (!authHeader) {
+        return NextResponse.json(
+          { error: 'Authorization header required' },
+          { status: 401 }
+        )
+      }
+
+      // Extract Bearer token
+      const tokenMatch = authHeader.match(/^Bearer\s+(.+)$/i)
+      if (!tokenMatch) {
+        return NextResponse.json(
+          { error: 'Invalid authorization header format. Expected: Bearer <token>' },
+          { status: 401 }
+        )
+      }
+
+      const token = tokenMatch[1]
+
+      // Authenticate the service account
+      const authResult = await findServiceAccountWithValue(token)
+      if (!authResult) {
+        return NextResponse.json(
+          { error: 'Invalid or expired service account token' },
+          { status: 401 }
+        )
+      }
+
+      const { teamId } = authResult
+
+      span?.setTag('context.team_id', teamId)
+
+      const { searchParams } = new URL(request.url)
+
+      let digest = searchParams.get('digest')
+      const imageURL = searchParams.get('image_url')
+      const arch = searchParams.get('arch') || 'amd64' // Default to amd64
+      const format = searchParams.get('format') || 'parsed' // Default to parsed
+
+      if (!digest && !imageURL) {
+        return NextResponse.json({ error: 'Missing digest or image_url' }, { status: 400 })
+      }
+
+      // Validate and map architecture
+      let dbArch: string
+      if (arch === 'amd64') {
+        dbArch = 'x86_64'
+      } else if (arch === 'arm64') {
+        dbArch = 'aarch64'
+      } else {
+        return NextResponse.json({ error: 'Invalid architecture. Supported: amd64, arm64' }, { status: 400 })
+      }
+
+      // If we have an image URL, validate access and get digest
+      if (imageURL) {
+        const imageUrlParsed = parseImageRef(imageURL)
+
+        try {
+          digest = await getExternalImageDigestForTag(teamId, imageUrlParsed.registry, imageUrlParsed.repository, imageUrlParsed.tag)
+          if (!digest) {
+            return NextResponse.json(
+              { error: 'Tag not found for this external image' },
+              { status: 404 }
+            )
+          }
+        } catch {
+          return NextResponse.json(
+            { error: 'External image not found or access denied' },
+            { status: 404 }
+          )
+        }
+      }
+
+      if (!digest) {
+        return NextResponse.json({ error: 'Digest not found' }, { status: 404 })
+      }
+
+      // Validate that the team owns this digest
+      const hasAccess = await teamOwnsDigest(teamId, digest)
+      if (!hasAccess) {
+        return NextResponse.json({ error: 'Scan results not found' }, { status: 404 })
+      }
+
+      // Get scan results using the unified function (returns a row even for queued/running when scan_result is NULL)
+      const scanData = await getExternalImageScan(digest, dbArch, format as 'raw' | 'parsed')
+      if (!scanData) {
+        return NextResponse.json({ error: 'Scan results not found' }, { status: 404 })
+      }
+
+      const metadata = {
+        digest,
+        image_digest: scanData.imageDigest,
+        image_size_bytes: scanData.imageSizeBytes,
+        digest_first_seen_at: scanData.digestFirstSeenAt,
+        last_scanned_at: scanData.scanCreatedAt,
+        updated_at: scanData.updatedAt,
+        scan_status: scanData.status,
+        scan_status_message: scanData.scanStatusMessage,
+        scan_status_updated_at: scanData.scanStatusUpdatedAt,
+        scan_attempted_at: scanData.scanAttemptedAt,
+        scan_completed_at: scanData.scanCompletedAt,
+      }
+
+      // When scan result is null/empty (e.g. queued/running), return 200 with metadata only so
+      // clients can read scan_status* and use this endpoint as the replacement for /scan-status.
+      if (!scanData.scanResult || String(scanData.scanResult).trim() === '') {
+        const emptyScan =
+          format === 'parsed'
+            ? { counts: { critical: 0, high: 0, medium: 0, low: 0, total: 0 }, vulnerability_details: [] }
+            : { matches: [] }
+        const response = NextResponse.json({ ...emptyScan, ...metadata })
+        response.headers.set('X-SecureBuild-Scan_Format', format)
+        response.headers.set('X-SecureBuild-Image_Digest', digest)
+        response.headers.set('X-SecureBuild-Architecture', arch)
+        return response
+      }
+
+      // DB may return json/jsonb as string or already-parsed object
+      let scanResult: Record<string, unknown>
+      try {
+        scanResult =
+          typeof scanData.scanResult === 'string'
+            ? (JSON.parse(scanData.scanResult) as Record<string, unknown>)
+            : (scanData.scanResult as Record<string, unknown>)
+      } catch (error) {
+        console.error('parseScanResults error:', error)
+        return NextResponse.json({ error: 'Failed to parse scan results' }, { status: 500 })
+      }
+
+      // Spread the scan result at the top level and add metadata fields
+      // This maintains backward compatibility - existing consumers get the
+      // scan data directly while new consumers can access the additional
+      // metadata fields.
+      const response = NextResponse.json({
+        ...scanResult,
+        ...metadata,
+      })
+
+      response.headers.set('X-SecureBuild-Scan_Format', format)
+      response.headers.set('X-SecureBuild-Image_Digest', digest)
+      response.headers.set('X-SecureBuild-Architecture', arch)
+
+      return response
+    } catch (error) {
+      console.error('Error retrieving scan results:', error)
+      span?.setTag('error', error as Error)
+      return NextResponse.json(
+        { error: 'Failed to retrieve scan results' },
+        { status: 500 }
+      )
+    }
+  })
+}
+
+interface RequestBody {
+  arch?: string;
+  format?: string;
+  digests?: string[];
+  images?: string[];
+}
+
+type ScanResult = Record<string, unknown>;
+
+type ResultEntry = {
+  input: string
+  digest: string | null
+  last_scanned_at: string | null
+  digest_first_seen_at: string | null
+  result: ScanResult | null
+  not_found: boolean
+  image_size_bytes: number
+  scan_status: string | null
+  scan_status_message: string | null
+  scan_status_updated_at: string | null
+  sbom_status: string | null
+  sbom_status_message: string | null
+  sbom_status_updated_at: string | null
+}
+
+export async function POST(request: NextRequest) {
+  return withTrace('api.external_image.scan', async (span) => {
+    try {
+      const authHeader = request.headers.get('Authorization')
+      if (!authHeader) {
+        return NextResponse.json(
+          { error: 'Authorization header required' },
+          { status: 401 }
+        )
+      }
+
+      const tokenMatch = authHeader.match(/^Bearer\s+(.+)$/i)
+      if (!tokenMatch) {
+        return NextResponse.json(
+          { error: 'Invalid authorization header format. Expected: Bearer <token>' },
+          { status: 401 }
+        )
+      }
+
+      const token = tokenMatch[1]
+      const authResult = await findServiceAccountWithValue(token)
+      if (!authResult) {
+        return NextResponse.json(
+          { error: 'Invalid or expired service account token' },
+          { status: 401 }
+        )
+      }
+
+      const { teamId } = authResult
+
+      span?.setTag('context.team_id', teamId)
+
+      let body: unknown
+      try {
+        body = await request.json()
+      } catch {
+        return NextResponse.json({ error: 'Invalid or missing JSON body' }, { status: 400 })
+      }
+
+      const requestBody = body as RequestBody;
+      const arch = requestBody.arch || 'amd64'
+      const format = requestBody.format || 'parsed'
+
+      let dbArch: string
+      if (arch === 'amd64') {
+        dbArch = 'x86_64'
+      } else if (arch === 'arm64') {
+        dbArch = 'aarch64'
+      } else {
+        return NextResponse.json({ error: 'Invalid architecture. Supported: amd64, arm64' }, { status: 400 })
+      }
+
+      const inputDigests = Array.isArray(requestBody.digests) ? requestBody.digests : []
+      const inputImages = Array.isArray(requestBody.images) ? requestBody.images : []
+
+      span?.setTag('context.arch', dbArch)
+      span?.setTag('context.digests.length', inputDigests.length)
+      span?.setTag('context.images.length', inputImages.length)
+
+      if (inputDigests.length === 0 && inputImages.length === 0) {
+        return NextResponse.json({ error: 'Missing required parameters. Provide digests and/or images' }, { status: 400 })
+      }
+
+      const results = await batchListScans(teamId, inputDigests, inputImages, format as 'raw' | 'parsed', dbArch)
+
+      const response = NextResponse.json(results)
+      response.headers.set('X-SecureBuild-Architecture', arch)
+      response.headers.set('X-SecureBuild-Scan_Format', format)
+      response.headers.set('X-SecureBuild-Result_Count', results.length.toString())
+      return response
+    } catch (error) {
+      console.error('Error retrieving scan results (POST):', error)
+      span?.setTag('error', error as Error)
+      return NextResponse.json(
+        { error: 'Failed to retrieve scan results' },
+        { status: 500 }
+      )
+    }
+  })
+}
+
+const batchListScans = traceFunction('api.external_image.scan.batchListScans', async (teamId: string, inputDigests: string[], inputImages: string[], format: 'raw' | 'parsed', arch: string = 'x86_64'): Promise<ResultEntry[]> => {
+  const results: ResultEntry[] = []
+
+  if (inputDigests.length === 0 && inputImages.length === 0) {
+    return results
+  }
+
+  // Step 1: Parse image URLs into ImageRefTag objects
+  const imageRefTags: ImageRefTag[] = []
+  for (const imageUrl of inputImages) {
+    const parsed = parseImageRef(imageUrl)
+    imageRefTags.push({
+      registry: parsed.registry,
+      repository: parsed.repository,
+      tag: parsed.tag
+    })
+  }
+
+  // Step 2: Get digests for all image URLs in a single query
+  const imageUrlDigests = imageRefTags.length > 0
+    ? await getBatchDigestsForTags(teamId, imageRefTags)
+    : []
+
+  // Step 3: Collect all digests and map inputs to digests
+  const allDigests = new Set<string>()
+  const inputToDigestMap = new Map<string, string | undefined>()
+
+  // Add digests from inputDigests
+  for (const digest of inputDigests) {
+    allDigests.add(digest)
+    inputToDigestMap.set(digest, digest)
+  }
+
+  // Add digests from image URLs
+  for (const [index, imageUrl] of inputImages.entries()) {
+    const digest = imageUrlDigests[index]
+
+    inputToDigestMap.set(imageUrl, digest)
+
+    if (digest) {
+      allDigests.add(digest)
+    }
+  }
+
+  // Step 4: Get scan results for all digests (team ownership validated via JOIN)
+  const scanResults = allDigests.size > 0
+    ? await getBatchExternalImageScans(teamId, [...allDigests], arch, format)
+    : new Map<string, BatchScanResult>()
+
+  // Step 5: Build the results array
+  for (const input of [...inputDigests, ...inputImages]) {
+    const digest = inputToDigestMap.get(input) || null;
+    let scanData: BatchScanResult | null = null;
+    if (digest) {
+      scanData = scanResults.get(digest) || null;
+      if (!scanData?.hasAccess) {
+        scanData = null;
+      }
+    }
+
+    let parsedResult: ScanResult | null = null
+    if (scanData?.scanResult) {
+      try {
+        parsedResult = JSON.parse(scanData.scanResult)
+      } catch (error) {
+        console.error(`Failed to parse scan result for input ${input}:`, error)
+        // Continue with null result instead of failing the entire request
+      }
+    }
+
+    results.push({
+      input: input,
+      digest: scanData?.digest || null,
+      last_scanned_at: scanData?.scanCreatedAt || null,
+      digest_first_seen_at: scanData?.digestFirstSeenAt || null,
+      result: parsedResult,
+      not_found: scanData === null,
+      image_size_bytes: scanData?.imageSizeBytes || 0,
+      scan_status: scanData?.scanStatus || null,
+      scan_status_message: scanData?.scanStatusMessage || null,
+      scan_status_updated_at: scanData?.scanStatusUpdatedAt || null,
+      sbom_status: scanData?.sbomStatus || null,
+      sbom_status_message: scanData?.sbomStatusMessage || null,
+      sbom_status_updated_at: scanData?.sbomStatusUpdatedAt || null,
+    })
+  }
+
+  return results
+},
+  {
+    getTags: (teamId: string, inputDigests: string[], inputImages: string[], format: 'raw' | 'parsed', arch: string = 'x86_64') => ({
+      'args.team_id': teamId,
+      'args.digests.length': inputDigests.length,
+      'args.images.length': inputImages.length,
+      'args.format': format,
+      'args.arch': arch
+    })
+  })

--- a/securebuild-api/app/layout.tsx
+++ b/securebuild-api/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/securebuild-api/datadog/tracer.ts
+++ b/securebuild-api/datadog/tracer.ts
@@ -1,0 +1,97 @@
+import type { Tracer, Span, init as ddTraceInit } from 'dd-trace';
+import type { IncomingMessage } from 'http';
+
+const rawFlag = String(process.env.DD_ENABLED || '').toLowerCase();
+const isEnabled = rawFlag === 'true' || rawFlag === '1';
+
+process.env.DD_TRACE_ENABLED = isEnabled ? '1' : '0';
+
+let tracer: Tracer | null = null;
+
+if (isEnabled) {
+  const serviceName = process.env.DD_SERVICE || 'securebuild-api';
+  const environment = process.env.DD_ENV || process.env.NODE_ENV || 'development';
+  // DD_VERSION is set in the container image during build (see dagger/securebuild-www.go)
+  const version = process.env.DD_VERSION || process.env.NEXT_PUBLIC_VERSION || '0.0.0-dev';
+
+  const agentHost = process.env.DD_AGENT_HOST || process.env.DATADOG_AGENT_HOST || '127.0.0.1';
+  const agentPort = process.env.DD_TRACE_AGENT_PORT || '8126';
+
+  process.env.DD_SERVICE = serviceName;
+  process.env.DD_ENV = environment;
+  if (version) {
+    process.env.DD_VERSION = version;
+  }
+  process.env.DD_AGENT_HOST = agentHost;
+  process.env.DD_TRACE_AGENT_PORT = agentPort;
+
+  const dbmPropagationMode = (process.env.DD_DBM_PROPAGATION_MODE || 'full') as 'disabled' | 'service' | 'full';
+
+  process.env.DD_DBM_PROPAGATION_MODE = dbmPropagationMode;
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const ddTrace = require('dd-trace');
+    tracer = (ddTrace.init as typeof ddTraceInit)({
+      service: serviceName,
+      env: environment,
+      version,
+      logInjection: true,
+      runtimeMetrics: true,
+      appsec: false,
+      profiling: false,
+      startupLogs: false,
+    }) as Tracer;
+
+    // Disable low-level network instrumentation for localhost connections
+    tracer.use('dns', false);
+    tracer.use('net', false);
+    // Configure http plugin to set resource.name and http.route manually
+    tracer.use('http', {
+      server: {
+        hooks: {
+          request: (span?: Span, req?: IncomingMessage) => {
+            if (!span) return;
+
+            const url = req?.url || '';
+            const method = req?.method || 'GET';
+
+            const path = url.split('?')[0]; // Remove query string
+            if (!path.startsWith('/api/')) {
+              // Drop non-API routes
+              // @ts-expect-error - using an internal property
+              span.context()._trace.isRecording = false;
+              return;
+            }
+
+            const routePattern = getRoutePattern(path);
+
+            span.setTag('resource.name', `${method} ${routePattern}`);
+            span.setTag('http.route', routePattern);
+          }
+        }
+      }
+    });
+  } catch (err) {
+    // Do not crash the app if tracing fails to initialize
+    console.error('[datadog] failed to initialize tracing', err);
+    tracer = null;
+  }
+}
+
+  // Function to convert actual paths to route patterns
+  const getRoutePattern = (path: string): string => {
+    // Define route patterns for dynamic routes
+    const routePatterns: { pattern: RegExp; replacement: string }[] = [];
+
+    for (const { pattern, replacement } of routePatterns) {
+      if (pattern.test(path)) {
+        return replacement;
+      }
+    }
+
+    // Return original path if no pattern matches
+    return path;
+  }
+
+export default tracer;

--- a/securebuild-api/eslint.config.mjs
+++ b/securebuild-api/eslint.config.mjs
@@ -1,0 +1,17 @@
+import nextConfig from 'eslint-config-next';
+
+const config = [
+  ...nextConfig,
+  {
+    ignores: [
+      'integration/**',
+      'node_modules/**',
+      '.next/**',
+      'out/**',
+      'build/**',
+      'next-env.d.ts',
+    ],
+  },
+];
+
+export default config;

--- a/securebuild-api/instrumentation.ts
+++ b/securebuild-api/instrumentation.ts
@@ -1,0 +1,12 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    // Only load tracer if Datadog is actually enabled
+    const rawFlag = String(process.env.DD_ENABLED || '').toLowerCase();
+    const isEnabled = rawFlag === 'true' || rawFlag === '1';
+
+    if (isEnabled) {
+      // Load the tracer only when explicitly enabled
+      await import('./datadog/tracer');
+    }
+  }
+}

--- a/securebuild-api/integration/README.md
+++ b/securebuild-api/integration/README.md
@@ -1,0 +1,25 @@
+# securebuild-api integration tests
+
+The suite uses **real HTTP requests** (no module mocking): Testcontainers
+PostgreSQL + a local Docker `registry:3.0.0` (Testcontainers) + a real Next.js
+dev server on a random port. A tiny scratch image is pushed to the local
+registry at setup; the create path resolves its digest from it — zero external
+dependencies. No worker runs; scan/SBOM data is pre-seeded via YAML.
+
+## Run
+
+```bash
+npm run test:integration
+```
+
+Requires Docker (for Testcontainers) and `schemahero` on PATH (schema + seed
+data are applied via SchemaHero from `db/schema/tables`).
+
+## Test flow
+
+- **Create** (`create.test.ts`): `POST /external-image` → 201 + digest, then
+  `GET /external-image?sha=<digest>` → status fields (`sbom_status='pending'`).
+- **Read** (`scan.test.ts`): against the seeded "existing" image —
+  `GET /scan`, `POST /scan`, `POST /scan-summary`, `GET /sbom` (by digest and
+  image_url). Validates shape, not values.
+- **Auth** (both files): missing/invalid token → 401 on every endpoint.

--- a/securebuild-api/integration/api/v1/external-image/create.test.ts
+++ b/securebuild-api/integration/api/v1/external-image/create.test.ts
@@ -1,0 +1,76 @@
+import * as path from 'path';
+import { setupTestEnvironment, TestEnvironment } from '../../../fixtures/environment';
+import { HttpClient } from '../../../fixtures/http-client';
+
+/**
+ * Integration tests for POST/GET /api/v1/external-image (the "create" path).
+ *
+ * Phase 1 — Create:  POST a new image -> 201 + digest, then GET its status.
+ * Phase 3 — Auth:    missing/invalid token -> 401.
+ *
+ * Runs against a local Testcontainers stack using real HTTP requests.
+ */
+describe('POST/GET /api/v1/external-image', () => {
+  let env: TestEnvironment;
+  let createdDigest: string;
+
+  beforeAll(async () => {
+    const seedDataDir = path.join(__dirname, 'seed-data');
+    env = await setupTestEnvironment(seedDataDir);
+  });
+
+  afterAll(async () => {
+    await env.teardown();
+  });
+
+  describe('Phase 1 — Create', () => {
+    it('POST /external-image returns 201 with digest', async () => {
+      const res = await env.client.post('/api/v1/external-image', {
+        image_url: env.createImage,
+      });
+
+      expect(res.status).toBe(201);
+      const data = res.data as Record<string, unknown>;
+      expect(typeof data.digest).toBe('string');
+      expect((data.digest as string).startsWith('sha256:')).toBe(true);
+      expect(data.image_url).toBe(env.createImage);
+      expect(data.status).toBe(201);
+
+      createdDigest = data.digest as string;
+    });
+
+    it('GET /external-image?sha=<createdDigest> returns status fields', async () => {
+      // No worker runs — the created image has sbom_status='pending' immediately.
+      const res = await env.client.get(`/api/v1/external-image?sha=${encodeURIComponent(createdDigest)}`);
+
+      expect(res.status).toBe(200);
+      const data = res.data as Record<string, unknown>;
+      expect(data.digest).toBe(createdDigest);
+      expect(data.sbom_status).toBe('pending');
+      expect(data.scan_status).toBeDefined();
+      expect(Array.isArray(data.platforms)).toBe(true);
+    });
+  });
+
+  describe('Phase 3 — Auth', () => {
+    it('POST /external-image without token returns 401', async () => {
+      const res = await env.client.postNoAuth('/api/v1/external-image', {
+        image_url: env.createImage,
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it('GET /external-image without token returns 401', async () => {
+      const res = await env.client.getNoAuth(`/api/v1/external-image?sha=${encodeURIComponent(createdDigest)}`);
+      expect(res.status).toBe(401);
+    });
+
+    it('POST /external-image with invalid token returns 401', async () => {
+      const badClient = new HttpClient(env.baseUrl, 'invalid-token');
+      const res = await badClient.post('/api/v1/external-image', {
+        image_url: env.createImage,
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/securebuild-api/integration/api/v1/external-image/scan.test.ts
+++ b/securebuild-api/integration/api/v1/external-image/scan.test.ts
@@ -1,0 +1,184 @@
+import * as path from 'path';
+import { setupTestEnvironment, TestEnvironment } from '../../../fixtures/environment';
+import { HttpClient } from '../../../fixtures/http-client';
+
+const VALID_SCAN_STATUSES = new Set(['queued', 'running', 'succeeded', 'failed']);
+
+/**
+ * Integration tests for the read endpoints (scan, scan-summary, sbom).
+ *
+ * Phase 2 — Read:  validates shape of scan/scan-summary/sbom responses against
+ *                  the pre-scanned "existing" image (seeded via YAML).
+ * Phase 3 — Auth:  missing token -> 401 on each read endpoint.
+ *
+ * Runs against a local Testcontainers stack using real HTTP requests.
+ */
+describe('Read endpoints /scan, /scan-summary, /sbom', () => {
+  let env: TestEnvironment;
+
+  beforeAll(async () => {
+    const seedDataDir = path.join(__dirname, 'seed-data');
+    env = await setupTestEnvironment(seedDataDir);
+  });
+
+  afterAll(async () => {
+    await env.teardown();
+  });
+
+  describe('Phase 2 — Read (existing image)', () => {
+    const digest = () => env.existingDigest;
+    const image = () => env.existingImage;
+
+    it('GET /scan?digest&arch=amd64&format=parsed returns counts + vulnerability_details', async () => {
+      const res = await env.client.get(
+        `/api/v1/external-image/scan?digest=${encodeURIComponent(digest())}&arch=amd64&format=parsed`,
+      );
+      expect(res.status).toBe(200);
+
+      const data = res.data as Record<string, unknown>;
+      expect(data.counts).toBeDefined();
+      const counts = data.counts as Record<string, unknown>;
+      expect(typeof counts.critical).toBe('number');
+      expect(typeof counts.high).toBe('number');
+      expect(typeof counts.medium).toBe('number');
+      expect(typeof counts.low).toBe('number');
+      expect(typeof counts.total).toBe('number');
+      expect(Array.isArray(data.vulnerability_details)).toBe(true);
+
+      expect(VALID_SCAN_STATUSES.has(String(data.scan_status))).toBe(true);
+      expect(data.digest).toBe(digest());
+
+      expect(res.headers.get('X-SecureBuild-Scan_Format')).toBe('parsed');
+      expect(res.headers.get('X-SecureBuild-Image_Digest')).toBe(digest());
+      expect(res.headers.get('X-SecureBuild-Architecture')).toBe('amd64');
+    });
+
+    it('POST /scan {digests} returns array with expected shape', async () => {
+      const res = await env.client.post('/api/v1/external-image/scan', {
+        digests: [digest()],
+        arch: 'amd64',
+        format: 'parsed',
+      });
+      expect(res.status).toBe(200);
+
+      const data = res.data as Record<string, unknown>[];
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBe(1);
+
+      const entry = data[0];
+      expect(entry.input).toBe(digest());
+      expect(typeof entry.digest).toBe('string');
+      expect(typeof entry.not_found).toBe('boolean');
+      expect(entry.not_found).toBe(false);
+      expect(VALID_SCAN_STATUSES.has(String(entry.scan_status))).toBe(true);
+      expect(entry.result).toBeDefined();
+      expect((entry.result as Record<string, unknown>).counts).toBeDefined();
+
+      expect(res.headers.get('X-SecureBuild-Result_Count')).toBe('1');
+    });
+
+    it('POST /scan {images, format:raw} returns array with matches', async () => {
+      const res = await env.client.post('/api/v1/external-image/scan', {
+        images: [image()],
+        arch: 'amd64',
+        format: 'raw',
+      });
+      expect(res.status).toBe(200);
+
+      const data = res.data as Record<string, unknown>[];
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBe(1);
+
+      const entry = data[0];
+      expect(entry.input).toBe(image());
+      expect(entry.not_found).toBe(false);
+      expect(entry.result).toBeDefined();
+      expect(Array.isArray((entry.result as Record<string, unknown>).matches)).toBe(true);
+
+      expect(res.headers.get('X-SecureBuild-Scan_Format')).toBe('raw');
+    });
+
+    it('POST /scan-summary {digests} returns counts', async () => {
+      const res = await env.client.post('/api/v1/external-image/scan-summary', {
+        digests: [digest()],
+      });
+      expect(res.status).toBe(200);
+
+      const data = res.data as Record<string, unknown>[];
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBe(1);
+
+      const entry = data[0];
+      expect(entry.input).toBe(digest());
+      expect(entry.not_found).toBe(false);
+      const counts = entry.counts as Record<string, unknown>;
+      expect(typeof counts.critical).toBe('number');
+      expect(typeof counts.high).toBe('number');
+      expect(typeof counts.medium).toBe('number');
+      expect(typeof counts.low).toBe('number');
+      expect(typeof counts.total).toBe('number');
+
+      expect(res.headers.get('X-SecureBuild-Result_Count')).toBe('1');
+    });
+
+    it('GET /sbom?digest returns SPDX SBOM', async () => {
+      const res = await env.client.get(`/api/v1/external-image/sbom?digest=${encodeURIComponent(digest())}`);
+      expect(res.status).toBe(200);
+
+      const data = res.data as Record<string, unknown>;
+      expect(data.SPDXID).toBeDefined();
+      expect(Array.isArray(data.packages)).toBe(true);
+      expect(Array.isArray(data.relationships)).toBe(true);
+
+      expect(res.headers.get('X-SecureBuild-Image_Digest')).toBe(digest());
+    });
+
+    it('GET /sbom?image_url returns SPDX SBOM', async () => {
+      const res = await env.client.get(`/api/v1/external-image/sbom?image_url=${encodeURIComponent(image())}`);
+      expect(res.status).toBe(200);
+
+      const data = res.data as Record<string, unknown>;
+      expect(data.SPDXID).toBeDefined();
+      expect(Array.isArray(data.packages)).toBe(true);
+      expect(Array.isArray(data.relationships)).toBe(true);
+    });
+  });
+
+  describe('Phase 3 — Auth', () => {
+    it('GET /scan without token returns 401', async () => {
+      const res = await env.client.getNoAuth(
+        `/api/v1/external-image/scan?digest=${encodeURIComponent(env.existingDigest)}&arch=amd64`,
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it('POST /scan without token returns 401', async () => {
+      const res = await env.client.postNoAuth('/api/v1/external-image/scan', {
+        digests: [env.existingDigest],
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it('POST /scan-summary without token returns 401', async () => {
+      const res = await env.client.postNoAuth('/api/v1/external-image/scan-summary', {
+        digests: [env.existingDigest],
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it('GET /sbom without token returns 401', async () => {
+      const res = await env.client.getNoAuth(
+        `/api/v1/external-image/sbom?digest=${encodeURIComponent(env.existingDigest)}`,
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it('GET /scan with invalid token returns 401', async () => {
+      const badClient = new HttpClient(env.baseUrl, 'invalid-token');
+      const res = await badClient.get(
+        `/api/v1/external-image/scan?digest=${encodeURIComponent(env.existingDigest)}&arch=amd64`,
+      );
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/securebuild-api/integration/api/v1/external-image/seed-data/external-image-sbom-status.yaml
+++ b/securebuild-api/integration/api/v1/external-image/seed-data/external-image-sbom-status.yaml
@@ -1,0 +1,34 @@
+database: securebuild
+name: external_image_sbom_status
+requires:
+  - external-image-tag
+seedData:
+  rows:
+    # Pending SBOM status
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:pending123456789012345678901234567890123456789012345678901234"
+        - column: status
+          value:
+            str: "pending"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: status_updated_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+    # Generating SBOM status
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:generating123456789012345678901234567890123456789012345678901"
+        - column: status
+          value:
+            str: "generating"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: status_updated_at
+          value:
+            str: "2024-01-01T00:00:15Z"

--- a/securebuild-api/integration/api/v1/external-image/seed-data/external-image-sbom.yaml
+++ b/securebuild-api/integration/api/v1/external-image/seed-data/external-image-sbom.yaml
@@ -1,0 +1,106 @@
+database: securebuild
+name: external_image_sbom
+requires:
+  - external-image-tag
+seedData:
+  rows:
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:abc123def456789012345678901234567890123456789012345678901234"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: sbom
+          value:
+            str: '{"SPDXID":"SPDXRef-DOCUMENT","spdxVersion":"SPDX-2.3","name":"test-image","dataLicense":"CC0-1.0","documentNamespace":"https://securebuild.io/test/image","creationInfo":{"created":"2024-01-01T00:00:00Z","creators":["Tool: SecureBuild test"]},"packages":[{"SPDXID":"SPDXRef-package-test","name":"test-pkg","downloadLocation":"NOASSERTION","filesAnalyzed":false,"licenseConcluded":"NOASSERTION"}],"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-package-test"}]}'
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: source
+          value:
+            str: "grype"
+        - column: image_size_bytes
+          value:
+            str: "1024000"
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:abc123def456789012345678901234567890123456789012345678901234"
+        - column: arch
+          value:
+            str: "aarch64"
+        - column: sbom
+          value:
+            str: '{"SPDXID":"SPDXRef-DOCUMENT","spdxVersion":"SPDX-2.3","name":"test-image","dataLicense":"CC0-1.0","documentNamespace":"https://securebuild.io/test/image","creationInfo":{"created":"2024-01-01T00:00:00Z","creators":["Tool: SecureBuild test"]},"packages":[{"SPDXID":"SPDXRef-package-test","name":"test-pkg","downloadLocation":"NOASSERTION","filesAnalyzed":false,"licenseConcluded":"NOASSERTION"}],"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-package-test"}]}'
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: source
+          value:
+            str: "grype"
+        - column: image_size_bytes
+          value:
+            str: "1024000"
+    # Queued scan SBOM
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:queued123456789012345678901234567890123456789012345678901234"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: sbom
+          value:
+            str: '{"SPDXID":"SPDXRef-DOCUMENT","spdxVersion":"SPDX-2.3","name":"test-image","dataLicense":"CC0-1.0","documentNamespace":"https://securebuild.io/test/image","creationInfo":{"created":"2024-01-01T00:00:00Z","creators":["Tool: SecureBuild test"]},"packages":[{"SPDXID":"SPDXRef-package-test","name":"test-pkg","downloadLocation":"NOASSERTION","filesAnalyzed":false,"licenseConcluded":"NOASSERTION"}],"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-package-test"}]}'
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: source
+          value:
+            str: "grype"
+        - column: image_size_bytes
+          value:
+            int: 1024000
+    # Running scan SBOM
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:running123456789012345678901234567890123456789012345678901234"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: sbom
+          value:
+            str: '{"SPDXID":"SPDXRef-DOCUMENT","spdxVersion":"SPDX-2.3","name":"test-image","dataLicense":"CC0-1.0","documentNamespace":"https://securebuild.io/test/image","creationInfo":{"created":"2024-01-01T00:00:00Z","creators":["Tool: SecureBuild test"]},"packages":[{"SPDXID":"SPDXRef-package-test","name":"test-pkg","downloadLocation":"NOASSERTION","filesAnalyzed":false,"licenseConcluded":"NOASSERTION"}],"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-package-test"}]}'
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: source
+          value:
+            str: "grype"
+        - column: image_size_bytes
+          value:
+            int: 1024000
+    # Failed scan SBOM
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:failed123456789012345678901234567890123456789012345678901234"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: sbom
+          value:
+            str: '{"SPDXID":"SPDXRef-DOCUMENT","spdxVersion":"SPDX-2.3","name":"test-image","dataLicense":"CC0-1.0","documentNamespace":"https://securebuild.io/test/image","creationInfo":{"created":"2024-01-01T00:00:00Z","creators":["Tool: SecureBuild test"]},"packages":[{"SPDXID":"SPDXRef-package-test","name":"test-pkg","downloadLocation":"NOASSERTION","filesAnalyzed":false,"licenseConcluded":"NOASSERTION"}],"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-package-test"}]}'
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: source
+          value:
+            str: "grype"
+        - column: image_size_bytes
+          value:
+            int: 1024000
+    # NOTE: No SBOM entries for pending_sbom and generating_sbom test cases
+    # These statuses represent states BEFORE SBOM generation completes

--- a/securebuild-api/integration/api/v1/external-image/seed-data/external-image-scan.yaml
+++ b/securebuild-api/integration/api/v1/external-image/seed-data/external-image-scan.yaml
@@ -1,0 +1,398 @@
+database: securebuild
+name: external_image_scan
+requires:
+  - external-image-sbom
+seedData:
+  rows:
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:abc123def456789012345678901234567890123456789012345678901234"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: parsed_results
+          value:
+            str: '{"counts":{"critical":0,"high":1,"medium":0,"low":0,"total":1,"fixable":0}}'
+        - column: parsed_results_details
+          value:
+            str: |
+              {
+                "descriptor": {
+                  "name": "grype",
+                  "version": "0.95.0"
+                },
+                "counts": {
+                  "critical": 0,
+                  "high": 1,
+                  "medium": 0,
+                  "low": 0,
+                  "total": 1,
+                  "fixable": 0
+                },
+                "fixed_counts": {
+                  "critical": 0,
+                  "high": 0,
+                  "medium": 0,
+                  "low": 0,
+                  "total": 0,
+                  "fixable": 0
+                },
+                "created_at": "2026-01-12T15:57:01.425731Z",
+                "critical": {},
+                "high": {
+                  "CVE-2025-9086": "1. A cookie is set using the `secure` keyword for `https://target`   2. curl is redirected to or otherwise made to speak with `http://target` (same     hostname, but using clear text HTTP) using the same cookie set   3. The same cookie name is set - but with just a slash as path (`path=\"/\",`).    Since this site is not secure, the cookie *should* just be ignored. 4. A bug in the path comparison logic makes curl read outside a heap buffer    boundary  The bug either causes a crash or it potentially makes the comparison come to the wrong conclusion and lets the clear-text site override the contents of the secure cookie, contrary to expectations and depending on the memory contents immediately following the single-byte allocation that holds the path.  The presumed and correct behavior would be to plainly ignore the second set of the cookie since it was already set as secure on a secure host so overriding it on an insecure host should not be okay."
+                },
+                "medium": {},
+                "low": {},
+                "vulnerability_details": [
+                  {
+                    "cve": "CVE-2025-9086",
+                    "description": "1. A cookie is set using the `secure` keyword for `https://target`   2. curl is redirected to or otherwise made to speak with `http://target` (same     hostname, but using clear text HTTP) using the same cookie set   3. The same cookie name is set - but with just a slash as path (`path=\"/\",`).    Since this site is not secure, the cookie *should* just be ignored. 4. A bug in the path comparison logic makes curl read outside a heap buffer    boundary  The bug either causes a crash or it potentially makes the comparison come to the wrong conclusion and lets the clear-text site override the contents of the secure cookie, contrary to expectations and depending on the memory contents immediately following the single-byte allocation that holds the path.  The presumed and correct behavior would be to plainly ignore the second set of the cookie since it was already set as secure on a secure host so overriding it on an insecure host should not be okay.",
+                    "artifact_id": "Package-deb-curl-61f95e16aafc9e56",
+                    "artifact_type": "deb",
+                    "artifact_name": "curl",
+                    "artifact_version": "7.88.1-10+deb12u14",
+                    "artifact_path": "",
+                    "fix_state": "wont-fix",
+                    "fix_versions": [],
+                    "severity": "high",
+                    "epss_percentile": 0.06919,
+                    "risk": 0.020249999999999997
+                  }
+                ]
+              }
+        - column: raw_result
+          value:
+            str: |
+              {
+                "descriptor": {
+                  "name": "grype",
+                  "version": "0.95.0",
+                  "configuration": {
+                    "output": ["json"],
+                    "fail-on-severity": "medium"
+                  },
+                  "timestamp": "2024-01-01T00:00:00Z"
+                },
+                "distro": {
+                  "name": "debian",
+                  "version": "12",
+                  "idLike": []
+                },
+                "matches": [
+                  {
+                    "vulnerability": {
+                      "id": "CVE-2025-9086",
+                      "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2025-9086",
+                      "namespace": "nvd:cpe",
+                      "severity": "High",
+                      "urls": ["https://curl.se/docs/CVE-2025-9086.html"],
+                      "description": "1. A cookie is set using the `secure` keyword for `https://target`\n2. curl is redirected to or otherwise made to speak with `http://target` (same\n   hostname, but using clear text HTTP) using the same cookie set\n3. The same cookie name is set - but with just a slash as path (`path='/'`).\n   Since this site is not secure, the cookie *should* just be ignored.\n4. A bug in the path comparison logic makes curl read outside a heap buffer\n   boundary\n\nThe bug either causes a crash or it potentially makes the comparison come to\nthe wrong conclusion and lets the clear-text site override the contents of the\nsecure cookie, contrary to expectations and depending on the memory contents\nimmediately following the single-byte allocation that holds the path.\n\nThe presumed and correct behavior would be to plainly ignore the second set of\nthe cookie since it was already set as secure on a secure host so overriding\nit on an insecure host should not be okay.",
+                      "cvss": [],
+                      "epss": [
+                        {
+                          "cve": "CVE-2025-9086",
+                          "epss": 0.00071,
+                          "percentile": 0.06919,
+                          "date": "2024-01-01"
+                        }
+                      ],
+                      "fix": {
+                        "versions": [],
+                        "state": "wont-fix"
+                      },
+                      "advisories": [],
+                      "risk": 0.020249999999999997
+                    },
+                    "relatedVulnerabilities": [],
+                    "matchDetails": [
+                      {
+                        "type": "cpe-match",
+                        "matcher": "apk-matcher",
+                        "searchedBy": {
+                          "namespace": "nvd:cpe",
+                          "cpes": ["cpe:2.3:a:haxx:curl:7.88.1:*:*:*:*:*:*:*"],
+                          "package": {
+                            "name": "curl",
+                            "version": "7.88.1-10+deb12u14"
+                          }
+                        },
+                        "found": {
+                          "vulnerabilityID": "CVE-2025-9086",
+                          "versionConstraint": ">= 7.31.0, < 8.16.0 (wont-fix)",
+                          "cpes": ["cpe:2.3:a:haxx:curl:*:*:*:*:*:*:*:*"]
+                        }
+                      }
+                    ],
+                    "artifact": {
+                      "id": "Package-deb-curl-61f95e16aafc9e56",
+                      "name": "curl",
+                      "version": "7.88.1-10+deb12u14",
+                      "type": "deb",
+                      "locations": [
+                        {
+                          "path": "/usr/lib/dpkg/status",
+                          "layerID": "sha256:abc123def456",
+                          "accessPath": "/usr/lib/dpkg/status"
+                        }
+                      ],
+                      "language": "",
+                      "licenses": [],
+                      "cpes": ["cpe:2.3:a:haxx:curl:7.88.1:*:*:*:*:*:*:*"],
+                      "purl": "pkg:deb/debian/curl@7.88.1-10+deb12u14?arch=amd64&distro=debian-12",
+                      "upstreams": []
+                    }
+                  }
+                ],
+                "source": {
+                  "type": "image",
+                  "target": {
+                    "userInput": "test-registry.example.com/test-org/test-image:latest",
+                    "imageID": "sha256:abc123def456789012345678901234567890123456789012345678901234",
+                    "manifestDigest": "sha256:abc123def456789012345678901234567890123456789012345678901234",
+                    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                    "tags": ["test-registry.example.com/test-org/test-image:latest"],
+                    "imageSize": 1024000,
+                    "layers": [],
+                    "manifest": "",
+                    "config": "",
+                    "repoDigests": [],
+                    "architecture": "amd64",
+                    "os": "linux"
+                  }
+                }
+              }
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: status
+          value:
+            str: "succeeded"
+        - column: scan_status_updated_at
+          value:
+            str: "2024-01-01T00:05:00Z"
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:abc123def456789012345678901234567890123456789012345678901234"
+        - column: arch
+          value:
+            str: "aarch64"
+        - column: parsed_results
+          value:
+            str: '{"counts":{"critical":0,"high":1,"medium":0,"low":0,"total":1,"fixable":0}}'
+        - column: parsed_results_details
+          value:
+            str: |
+              {
+                "descriptor": {
+                  "name": "grype",
+                  "version": "0.95.0"
+                },
+                "counts": {
+                  "critical": 0,
+                  "high": 1,
+                  "medium": 0,
+                  "low": 0,
+                  "total": 1,
+                  "fixable": 0
+                },
+                "fixed_counts": {
+                  "critical": 0,
+                  "high": 0,
+                  "medium": 0,
+                  "low": 0,
+                  "total": 0,
+                  "fixable": 0
+                },
+                "created_at": "2026-01-12T15:57:01.425731Z",
+                "critical": {},
+                "high": {
+                  "CVE-2025-9086": "1. A cookie is set using the `secure` keyword for `https://target`   2. curl is redirected to or otherwise made to speak with `http://target` (same     hostname, but using clear text HTTP) using the same cookie set   3. The same cookie name is set - but with just a slash as path (`path=\"/\",`).    Since this site is not secure, the cookie *should* just be ignored. 4. A bug in the path comparison logic makes curl read outside a heap buffer    boundary  The bug either causes a crash or it potentially makes the comparison come to the wrong conclusion and lets the clear-text site override the contents of the secure cookie, contrary to expectations and depending on the memory contents immediately following the single-byte allocation that holds the path.  The presumed and correct behavior would be to plainly ignore the second set of the cookie since it was already set as secure on a secure host so overriding it on an insecure host should not be okay."
+                },
+                "medium": {},
+                "low": {},
+                "vulnerability_details": [
+                  {
+                    "cve": "CVE-2025-9086",
+                    "description": "1. A cookie is set using the `secure` keyword for `https://target`   2. curl is redirected to or otherwise made to speak with `http://target` (same     hostname, but using clear text HTTP) using the same cookie set   3. The same cookie name is set - but with just a slash as path (`path=\"/\",`).    Since this site is not secure, the cookie *should* just be ignored. 4. A bug in the path comparison logic makes curl read outside a heap buffer    boundary  The bug either causes a crash or it potentially makes the comparison come to the wrong conclusion and lets the clear-text site override the contents of the secure cookie, contrary to expectations and depending on the memory contents immediately following the single-byte allocation that holds the path.  The presumed and correct behavior would be to plainly ignore the second set of the cookie since it was already set as secure on a secure host so overriding it on an insecure host should not be okay.",
+                    "artifact_id": "Package-deb-curl-61f95e16aafc9e56",
+                    "artifact_type": "deb",
+                    "artifact_name": "curl",
+                    "artifact_version": "7.88.1-10+deb12u14",
+                    "artifact_path": "",
+                    "fix_state": "wont-fix",
+                    "fix_versions": [],
+                    "severity": "high",
+                    "epss_percentile": 0.06919,
+                    "risk": 0.020249999999999997
+                  }
+                ]
+              }
+        - column: raw_result
+          value:
+            str: |
+              {
+                "descriptor": {
+                  "name": "grype",
+                  "version": "0.95.0",
+                  "configuration": {
+                    "output": ["json"],
+                    "fail-on-severity": "medium"
+                  },
+                  "timestamp": "2024-01-01T00:00:00Z"
+                },
+                "distro": {
+                  "name": "debian",
+                  "version": "12",
+                  "idLike": []
+                },
+                "matches": [
+                  {
+                    "vulnerability": {
+                      "id": "CVE-2025-9086",
+                      "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2025-9086",
+                      "namespace": "nvd:cpe",
+                      "severity": "High",
+                      "urls": ["https://curl.se/docs/CVE-2025-9086.html"],
+                      "description": "1. A cookie is set using the `secure` keyword for `https://target`\n2. curl is redirected to or otherwise made to speak with `http://target` (same\n   hostname, but using clear text HTTP) using the same cookie set\n3. The same cookie name is set - but with just a slash as path (`path='/'`).\n   Since this site is not secure, the cookie *should* just be ignored.\n4. A bug in the path comparison logic makes curl read outside a heap buffer\n   boundary\n\nThe bug either causes a crash or it potentially makes the comparison come to\nthe wrong conclusion and lets the clear-text site override the contents of the\nsecure cookie, contrary to expectations and depending on the memory contents\nimmediately following the single-byte allocation that holds the path.\n\nThe presumed and correct behavior would be to plainly ignore the second set of\nthe cookie since it was already set as secure on a secure host so overriding\nit on an insecure host should not be okay.",
+                      "cvss": [],
+                      "epss": [
+                        {
+                          "cve": "CVE-2025-9086",
+                          "epss": 0.00071,
+                          "percentile": 0.06919,
+                          "date": "2024-01-01"
+                        }
+                      ],
+                      "fix": {
+                        "versions": [],
+                        "state": "wont-fix"
+                      },
+                      "advisories": [],
+                      "risk": 0.020249999999999997
+                    },
+                    "relatedVulnerabilities": [],
+                    "matchDetails": [
+                      {
+                        "type": "cpe-match",
+                        "matcher": "apk-matcher",
+                        "searchedBy": {
+                          "namespace": "nvd:cpe",
+                          "cpes": ["cpe:2.3:a:haxx:curl:7.88.1:*:*:*:*:*:*:*"],
+                          "package": {
+                            "name": "curl",
+                            "version": "7.88.1-10+deb12u14"
+                          }
+                        },
+                        "found": {
+                          "vulnerabilityID": "CVE-2025-9086",
+                          "versionConstraint": ">= 7.31.0, < 8.16.0 (wont-fix)",
+                          "cpes": ["cpe:2.3:a:haxx:curl:*:*:*:*:*:*:*:*"]
+                        }
+                      }
+                    ],
+                    "artifact": {
+                      "id": "Package-deb-curl-61f95e16aafc9e56",
+                      "name": "curl",
+                      "version": "7.88.1-10+deb12u14",
+                      "type": "deb",
+                      "locations": [
+                        {
+                          "path": "/usr/lib/dpkg/status",
+                          "layerID": "sha256:abc123def456",
+                          "accessPath": "/usr/lib/dpkg/status"
+                        }
+                      ],
+                      "language": "",
+                      "licenses": [],
+                      "cpes": ["cpe:2.3:a:haxx:curl:7.88.1:*:*:*:*:*:*:*"],
+                      "purl": "pkg:deb/debian/curl@7.88.1-10+deb12u14?arch=amd64&distro=debian-12",
+                      "upstreams": []
+                    }
+                  }
+                ],
+                "source": {
+                  "type": "image",
+                  "target": {
+                    "userInput": "test-registry.example.com/test-org/test-image:latest",
+                    "imageID": "sha256:abc123def456789012345678901234567890123456789012345678901234",
+                    "manifestDigest": "sha256:abc123def456789012345678901234567890123456789012345678901234",
+                    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                    "tags": ["test-registry.example.com/test-org/test-image:latest"],
+                    "imageSize": 1024000,
+                    "layers": [],
+                    "manifest": "",
+                    "config": "",
+                    "repoDigests": [],
+                    "architecture": "amd64",
+                    "os": "linux"
+                  }
+                }
+              }
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: status
+          value:
+            str: "succeeded"
+        - column: scan_status_updated_at
+          value:
+            str: "2024-01-01T00:05:00Z"
+    # Queued scan
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:queued123456789012345678901234567890123456789012345678901234"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: status
+          value:
+            str: "queued"
+        - column: scan_status_updated_at
+          value:
+            str: "2024-01-01T00:00:30Z"
+    # Running scan
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:running123456789012345678901234567890123456789012345678901234"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: status
+          value:
+            str: "running"
+        - column: scan_status_updated_at
+          value:
+            str: "2024-01-01T00:01:00Z"
+    # Failed scan
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:failed123456789012345678901234567890123456789012345678901234"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: status
+          value:
+            str: "failed"
+        - column: scan_status_message
+          value:
+            str: "Failed to pull image: authentication required"
+        - column: scan_status_updated_at
+          value:
+            str: "2024-01-01T00:02:00Z"
+    # Note: pending_sbom and generating_sbom statuses have been moved to a separate
+    # SBOM status table (external_image_sbom_status) and are no longer part of scan status

--- a/securebuild-api/integration/api/v1/external-image/seed-data/external-image-tag.yaml
+++ b/securebuild-api/integration/api/v1/external-image/seed-data/external-image-tag.yaml
@@ -1,0 +1,165 @@
+database: securebuild
+name: external_image_tag
+requires:
+  - external-image
+seedData:
+  rows:
+    - columns:
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: image_tag
+          value:
+            str: "latest"
+        - column: digest
+          value:
+            str: "sha256:abc123def456789012345678901234567890123456789012345678901234"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: next_check_digest_at
+          value:
+            str: "2024-01-02T00:00:00Z"
+        - column: next_scan_at
+          value:
+            str: "2024-01-02T00:00:00Z"
+    - columns:
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: image_tag
+          value:
+            str: "unscanned"
+        - column: digest
+          value:
+            str: "sha256:unscanned123456789012345678901234567890123456789012345678901"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: next_check_digest_at
+          value:
+            str: "2024-01-02T00:00:00Z"
+        - column: next_scan_at
+          value:
+            str: "2024-01-02T00:00:00Z"
+    # Queued scan tag
+    - columns:
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: image_tag
+          value:
+            str: "queued"
+        - column: digest
+          value:
+            str: "sha256:queued123456789012345678901234567890123456789012345678901234"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: next_check_digest_at
+          value:
+            str: "2024-01-02T00:00:00Z"
+        - column: next_scan_at
+          value:
+            str: "2024-01-02T00:00:00Z"
+    # Running scan tag
+    - columns:
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: image_tag
+          value:
+            str: "running"
+        - column: digest
+          value:
+            str: "sha256:running123456789012345678901234567890123456789012345678901234"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: next_check_digest_at
+          value:
+            str: "2024-01-02T00:00:00Z"
+        - column: next_scan_at
+          value:
+            str: "2024-01-02T00:00:00Z"
+    # Failed scan tag
+    - columns:
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: image_tag
+          value:
+            str: "failed"
+        - column: digest
+          value:
+            str: "sha256:failed123456789012345678901234567890123456789012345678901234"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: next_check_digest_at
+          value:
+            str: "2024-01-02T00:00:00Z"
+        - column: next_scan_at
+          value:
+            str: "2024-01-02T00:00:00Z"
+    # Pending SBOM scan tag
+    - columns:
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: image_tag
+          value:
+            str: "pending_sbom"
+        - column: digest
+          value:
+            str: "sha256:pending123456789012345678901234567890123456789012345678901234"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: next_check_digest_at
+          value:
+            str: "2024-01-02T00:00:00Z"
+        - column: next_scan_at
+          value:
+            str: "2024-01-02T00:00:00Z"
+    # Generating SBOM scan tag
+    - columns:
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: image_tag
+          value:
+            str: "generating_sbom"
+        - column: digest
+          value:
+            str: "sha256:generating123456789012345678901234567890123456789012345678901"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: next_check_digest_at
+          value:
+            str: "2024-01-02T00:00:00Z"
+        - column: next_scan_at
+          value:
+            str: "2024-01-02T00:00:00Z"

--- a/securebuild-api/integration/api/v1/external-image/seed-data/external-image-team.yaml
+++ b/securebuild-api/integration/api/v1/external-image/seed-data/external-image-team.yaml
@@ -1,0 +1,124 @@
+database: securebuild
+name: external_image_team
+requires:
+  - securebuild-team
+  - external-image-tag
+seedData:
+  rows:
+    - columns:
+        - column: team_id
+          value:
+            str: "test-team-alpha"
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: image_tag
+          value:
+            str: "latest"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+    - columns:
+        - column: team_id
+          value:
+            str: "test-team-alpha"
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: image_tag
+          value:
+            str: "unscanned"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+    # Queued scan team access
+    - columns:
+        - column: team_id
+          value:
+            str: "test-team-alpha"
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: image_tag
+          value:
+            str: "queued"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+    # Running scan team access
+    - columns:
+        - column: team_id
+          value:
+            str: "test-team-alpha"
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: image_tag
+          value:
+            str: "running"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+    # Failed scan team access
+    - columns:
+        - column: team_id
+          value:
+            str: "test-team-alpha"
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: image_tag
+          value:
+            str: "failed"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+    # Pending SBOM scan team access
+    - columns:
+        - column: team_id
+          value:
+            str: "test-team-alpha"
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: image_tag
+          value:
+            str: "pending_sbom"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+    # Generating SBOM scan team access
+    - columns:
+        - column: team_id
+          value:
+            str: "test-team-alpha"
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: image_tag
+          value:
+            str: "generating_sbom"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"

--- a/securebuild-api/integration/api/v1/external-image/seed-data/external-image.yaml
+++ b/securebuild-api/integration/api/v1/external-image/seed-data/external-image.yaml
@@ -1,0 +1,15 @@
+database: securebuild
+name: external_image
+requires: []
+seedData:
+  rows:
+    - columns:
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"

--- a/securebuild-api/integration/api/v1/external-image/seed-data/securebuild-team.yaml
+++ b/securebuild-api/integration/api/v1/external-image/seed-data/securebuild-team.yaml
@@ -1,0 +1,24 @@
+database: securebuild
+name: securebuild_team
+requires: []
+seedData:
+  rows:
+    - columns:
+        - column: id
+          value:
+            str: "test-team-alpha"
+        - column: name
+          value:
+            str: "Test Team Alpha"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: registry_username
+          value:
+            str: "test-alpha"
+        - column: full_catalog_access
+          value:
+            str: "true"
+        - column: feature_flags
+          value:
+            str: "{}"

--- a/securebuild-api/integration/fixtures/auth.ts
+++ b/securebuild-api/integration/fixtures/auth.ts
@@ -1,0 +1,63 @@
+import { Pool } from 'pg';
+import srs from 'secure-random-string';
+import { generateServiceAccountToken } from '../../lib/team/token';
+
+/**
+ * Interface for test service account data
+ */
+export interface TestServiceAccount {
+  id: string;
+  name: string;
+  token: string; // Raw token value for API authentication
+  partialValue: string;
+  teamId: string;
+}
+
+/**
+ * Creates a test service account with a token for API authentication
+ *
+ * Note: This function expects teams to already exist in the database
+ * (typically via SchemaHero seed data in *.seed.yaml files)
+ *
+ * This function uses the production generateServiceAccountToken() function
+ * to create tokens exactly as they would be in production.
+ *
+ * @param pool - PostgreSQL connection pool
+ * @param teamId - Team ID to associate the service account with
+ * @param name - Service account name (default: "Test Service Account")
+ * @returns TestServiceAccount with the created service account and raw token
+ */
+export async function createTestServiceAccount(
+  pool: Pool,
+  teamId: string,
+  name: string = 'Test Service Account'
+): Promise<TestServiceAccount> {
+  // Generate token using production function
+  const { token: rawToken, hash, partialValue } = generateServiceAccountToken();
+
+  const id = `sa-${srs({ length: 12, alphanumeric: true })}`;
+  const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000); // 30 days from now
+  const expiresIn = '30';
+
+  await pool.query(
+    `
+      INSERT INTO service_account (
+        id, name, partial_value, expires_at, expires_in,
+        created_at, last_used_at, bcrypt_hash, team_id, hash_algorithm
+      )
+      VALUES ($1, $2, $3, $4, $5, NOW(), NULL, $6, $7, $8)
+    `,
+    [id, name, partialValue, expiresAt, expiresIn, hash, teamId, 'sha256']
+  );
+
+  console.log(`Created test service account: ${id} (team: ${teamId})`);
+  console.log(`Token: ${rawToken.substring(0, 20)}...`);
+
+  return {
+    id,
+    name,
+    token: rawToken,
+    partialValue,
+    teamId,
+  };
+}

--- a/securebuild-api/integration/fixtures/database.ts
+++ b/securebuild-api/integration/fixtures/database.ts
@@ -1,0 +1,169 @@
+import { Client, Pool } from 'pg';
+import { PostgreSqlContainer, StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+const execAsync = promisify(exec);
+
+export interface TestDatabase {
+  container: StartedPostgreSqlContainer;
+  pool: Pool;
+  connectionString: string;
+  host: string;
+  port: number;
+}
+
+/**
+ * Finds the project root by looking for go.mod
+ */
+async function findProjectRoot(): Promise<string> {
+  let dir = __dirname;
+
+  while (dir !== '/') {
+    try {
+      await fs.access(path.join(dir, 'go.mod'));
+      return dir;
+    } catch {
+      // go.mod not found, go up one level
+    }
+    dir = path.dirname(dir);
+  }
+
+  throw new Error('Could not find project root (looking for go.mod)');
+}
+
+/**
+ * Applies SchemaHero YAML files from a directory
+ *
+ * This function can apply either schema definitions or seed data depending
+ * on the isSeedData flag. It calls schemahero plan once for the entire directory.
+ *
+ * @param testDB - The test database to apply to
+ * @param yamlDir - Absolute path to the directory containing YAML files
+ * @param isSeedData - If true, adds --seed-data flag to schemahero plan
+ */
+export async function applySchemaHero(
+  testDB: TestDatabase,
+  yamlDir: string,
+  isSeedData: boolean = false
+): Promise<void> {
+  const projectRoot = await findProjectRoot();
+  const fileType = isSeedData ? 'seed data' : 'schema';
+
+  console.log(`Applying ${fileType} from: ${path.basename(yamlDir)}`);
+
+  // Create a temporary file for the DDL output
+  const ddlFile = path.join('/tmp', `schemahero-${isSeedData ? 'seed' : 'ddl'}-${Date.now()}-${Math.random().toString(36).substring(7)}.sql`);
+
+  try {
+    // Run schemahero plan to generate DDL for entire directory
+    const seedDataFlag = isSeedData ? ' --seed-data' : '';
+    const planCmd = `schemahero plan --spec-file "${yamlDir}" --uri "${testDB.connectionString}" --driver postgres --out "${ddlFile}"${seedDataFlag}`;
+    await execAsync(planCmd, { cwd: projectRoot });
+
+    // Run schemahero apply to execute the DDL
+    const applyCmd = `schemahero apply --ddl "${ddlFile}" --uri "${testDB.connectionString}" --driver postgres`;
+    await execAsync(applyCmd, { cwd: projectRoot });
+
+    console.log(`All ${fileType} applied successfully`);
+  } catch (error) {
+    console.error(`Failed to apply ${fileType}:`, error);
+    throw error;
+  } finally {
+    // Clean up temporary DDL file
+    try {
+      await fs.unlink(ddlFile);
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+}
+
+/**
+ * Creates a PostgreSQL test database container and applies all SchemaHero schemas
+ *
+ * Each test should call this function to get a fresh, isolated database.
+ * Don't forget to call teardownTestDatabase() when done.
+ *
+ * @returns TestDatabase with container, pool, and connection details
+ */
+export async function setupTestDatabase(): Promise<TestDatabase> {
+  console.log('Starting PostgreSQL container...');
+
+  // Start PostgreSQL container (no port binding to avoid conflicts)
+  const container = await new PostgreSqlContainer('postgres:17')
+    .withDatabase('securebuild_test')
+    .withUsername('test_user')
+    .withPassword('test_password')
+    .start();
+
+  const host = container.getHost();
+  const port = container.getPort();
+  const connectionString = `postgresql://test_user:test_password@${host}:${port}/securebuild_test?sslmode=disable`;
+
+  console.log(`PostgreSQL container started at ${host}:${port}`);
+
+  // Create connection pool
+  const pool = new Pool({
+    host,
+    port,
+    database: 'securebuild_test',
+    user: 'test_user',
+    password: 'test_password',
+  });
+
+  // Wait for database to be ready
+  let retries = 30;
+  while (retries > 0) {
+    try {
+      await pool.query('SELECT 1');
+      console.log('Database is ready');
+      break;
+    } catch (error) {
+      retries--;
+      if (retries === 0) {
+        throw new Error('Database failed to become ready');
+      }
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+  }
+
+  const testDB: TestDatabase = {
+    container,
+    pool,
+    connectionString,
+    host,
+    port,
+  };
+
+  // Apply database schema using SchemaHero
+  console.log('Applying database schemas...');
+  const projectRoot = await findProjectRoot();
+  const schemaDir = path.join(projectRoot, 'db', 'schema', 'tables');
+  await applySchemaHero(testDB, schemaDir, false);
+
+  return testDB;
+}
+
+/**
+ * Tears down the test database container and closes connections
+ *
+ * @param testDB - The TestDatabase to clean up
+ */
+export async function teardownTestDatabase(testDB: TestDatabase): Promise<void> {
+  console.log('Tearing down test database...');
+
+  if (testDB.pool) {
+    await testDB.pool.end();
+    console.log('Database pool closed');
+  }
+
+  if (testDB.container) {
+    await testDB.container.stop();
+    console.log('Container stopped');
+  }
+
+  console.log('Test database cleanup completed');
+}

--- a/securebuild-api/integration/fixtures/environment.ts
+++ b/securebuild-api/integration/fixtures/environment.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared test environment for the external-image integration tests.
+ *
+ * Testcontainers PostgreSQL + local Docker registry + real Next.js server on a
+ * random port. No worker runs; scan/SBOM data is seeded.
+ *
+ * Uses real HTTP requests via HttpClient — no module mocking.
+ */
+
+import { setupTestDatabase, teardownTestDatabase, applySchemaHero, TestDatabase } from './database';
+import { createTestServiceAccount } from './auth';
+import { setupTestRegistry, teardownTestRegistry, TestRegistry } from './registry';
+import { startTestServer, TestServer } from './server';
+import { HttpClient } from './http-client';
+
+// Seeded "existing" image used for read endpoint validation.
+export const SEEDED_EXISTING_IMAGE = 'test-registry.example.com/test-org/test-image:latest';
+export const SEEDED_EXISTING_DIGEST = 'sha256:abc123def456789012345678901234567890123456789012345678901234';
+
+export const SEED_TEAM_ID = 'test-team-alpha';
+
+// Encryption secret for storing registry pull credentials.
+const TEST_ENCRYPTION_SECRET = 'test-encryption-secret-32bytes!!';
+
+export interface TestEnvironment {
+  client: HttpClient;
+  baseUrl: string;
+  token: string;
+  createImage: string;
+  existingImage: string;
+  existingDigest: string;
+  teardown: () => Promise<void>;
+}
+
+export async function setupTestEnvironment(seedDataDir: string): Promise<TestEnvironment> {
+  const testDB: TestDatabase = await setupTestDatabase();
+
+  await applySchemaHero(testDB, seedDataDir, true);
+
+  const serviceAccount = await createTestServiceAccount(testDB.pool, SEED_TEAM_ID);
+
+  const registry: TestRegistry = await setupTestRegistry();
+
+  const serverEnv: Record<string, string> = {
+    DB_URI: testDB.connectionString,
+    EXTERNAL_REGISTRY_ENCRYPTION_SECRET: TEST_ENCRYPTION_SECRET,
+  };
+
+  const server: TestServer = await startTestServer(serverEnv);
+
+  const client = new HttpClient(server.baseUrl, serviceAccount.token);
+
+  const teardown = async () => {
+    await server.stop();
+
+    const { closePoolByUri } = await import('@/lib/data/db');
+    await closePoolByUri(testDB.connectionString);
+
+    await teardownTestDatabase(testDB);
+    await teardownTestRegistry(registry);
+  };
+
+  return {
+    client,
+    baseUrl: server.baseUrl,
+    token: serviceAccount.token,
+    createImage: registry.imageUrl,
+    existingImage: SEEDED_EXISTING_IMAGE,
+    existingDigest: SEEDED_EXISTING_DIGEST,
+    teardown,
+  };
+}

--- a/securebuild-api/integration/fixtures/http-client.ts
+++ b/securebuild-api/integration/fixtures/http-client.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared HTTP client for integration tests.
+ *
+ * Makes real HTTP requests against a local Next.js server (Testcontainers
+ * stack). No module mocking — mirrors the Go integration tests in
+ * integration/ociproxy.
+ */
+
+export interface HttpResponse {
+  status: number;
+  ok: boolean;
+  headers: Headers;
+  data: unknown;
+}
+
+export class HttpClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly token: string,
+  ) {}
+
+  private headers(extra?: Record<string, string>): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.token}`,
+      ...extra,
+    };
+  }
+
+  async get(path: string): Promise<HttpResponse> {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method: 'GET',
+      headers: this.headers(),
+    });
+    return this.toResponse(res);
+  }
+
+  async getNoAuth(path: string): Promise<HttpResponse> {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method: 'GET',
+    });
+    return this.toResponse(res);
+  }
+
+  async post(path: string, body?: unknown): Promise<HttpResponse> {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers: this.headers({ 'Content-Type': 'application/json' }),
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    return this.toResponse(res);
+  }
+
+  async postNoAuth(path: string, body?: unknown): Promise<HttpResponse> {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    return this.toResponse(res);
+  }
+
+  private async toResponse(res: globalThis.Response): Promise<HttpResponse> {
+    const text = await res.text();
+    let data: unknown = text;
+    const contentType = res.headers.get('content-type') || '';
+    if (contentType.includes('application/json') && text) {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        // keep raw text
+      }
+    }
+    return {
+      status: res.status,
+      ok: res.ok,
+      headers: res.headers,
+      data,
+    };
+  }
+}

--- a/securebuild-api/integration/fixtures/registry.ts
+++ b/securebuild-api/integration/fixtures/registry.ts
@@ -1,0 +1,134 @@
+/**
+ * Local Docker distribution registry for integration tests.
+ *
+ * Starts a `registry:3.0.0` container (plain HTTP, no auth) via Testcontainers
+ * and pushes a minimal scratch image (config + manifest, no layers) using the
+ * Docker Registry HTTP API v2. POST /external-image resolves the digest from
+ * this local registry — zero external network dependencies.
+ *
+ * Ports the approach from the Go testutil registry
+ * (integration/testutil/registry.go) but uses plain HTTP so the registry
+ * client can reach it directly without TLS configuration.
+ */
+
+import { GenericContainer, StartedTestContainer, Wait } from 'testcontainers';
+import * as crypto from 'crypto';
+
+export interface TestRegistry {
+  container: StartedTestContainer;
+  host: string;
+  port: number;
+  baseUrl: string;
+  imageUrl: string;
+  digest: string;
+}
+
+function sha256hex(buf: Buffer): string {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+function resolveUploadUrl(baseUrl: string, location: string, digest: string): string {
+  let pathAndQuery: string;
+  if (location.startsWith('http://') || location.startsWith('https://')) {
+    const u = new URL(location);
+    pathAndQuery = u.pathname + (u.search || '');
+  } else {
+    pathAndQuery = location.startsWith('/') ? location : `/${location}`;
+  }
+  const sep = pathAndQuery.includes('?') ? '&' : '?';
+  return `${baseUrl}${pathAndQuery}${sep}digest=${encodeURIComponent(digest)}`;
+}
+
+async function uploadBlob(baseUrl: string, repository: string, blob: Buffer, digest: string): Promise<void> {
+  const postRes = await fetch(`${baseUrl}/v2/${repository}/blobs/uploads/`, { method: 'POST' });
+  if (postRes.status !== 202) {
+    throw new Error(`blob upload POST failed: ${postRes.status} ${await postRes.text()}`);
+  }
+  const location = postRes.headers.get('location');
+  if (!location) {
+    throw new Error('no Location header returned for blob upload');
+  }
+
+  const uploadUrl = resolveUploadUrl(baseUrl, location, digest);
+  const putRes = await fetch(uploadUrl, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'Content-Length': blob.length.toString(),
+    },
+    body: new Uint8Array(blob),
+  });
+  if (putRes.status !== 201) {
+    throw new Error(`blob upload PUT failed: ${putRes.status} ${await putRes.text()}`);
+  }
+}
+
+/**
+ * Push a minimal scratch image (config blob + schema-2 manifest, no layers)
+ * to the local registry. Returns the manifest digest.
+ */
+async function pushScratchImage(baseUrl: string, repository: string, tag: string): Promise<string> {
+  const configJson = JSON.stringify({
+    architecture: 'amd64',
+    os: 'linux',
+    config: {},
+    created: '2024-01-01T00:00:00Z',
+    history: [],
+    rootfs: { type: 'layers', diff_ids: [] },
+  });
+  const configBuf = Buffer.from(configJson, 'utf-8');
+  const configDigest = `sha256:${sha256hex(configBuf)}`;
+  await uploadBlob(baseUrl, repository, configBuf, configDigest);
+
+  const manifest = {
+    schemaVersion: 2,
+    mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+    config: {
+      mediaType: 'application/vnd.docker.container.image.v1+json',
+      size: configBuf.length,
+      digest: configDigest,
+    },
+    layers: [],
+  };
+  const manifestJson = JSON.stringify(manifest);
+
+  const manifestUrl = `${baseUrl}/v2/${repository}/manifests/${tag}`;
+  const putRes = await fetch(manifestUrl, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/vnd.docker.distribution.manifest.v2+json' },
+    body: manifestJson,
+  });
+  if (!putRes.ok) {
+    throw new Error(`manifest PUT failed: ${putRes.status} ${await putRes.text()}`);
+  }
+
+  return `sha256:${sha256hex(Buffer.from(manifestJson, 'utf-8'))}`;
+}
+
+export async function setupTestRegistry(repository = 'test-image', tag = 'latest'): Promise<TestRegistry> {
+  console.log('Starting local Docker registry container...');
+
+  const container = await new GenericContainer('registry:3.0.0')
+    .withExposedPorts(5000)
+    .withWaitStrategy(Wait.forHttp('/v2/', 5000))
+    .start();
+
+  const host = container.getHost();
+  const port = container.getMappedPort(5000);
+  const baseUrl = `http://${host}:${port}`;
+
+  console.log(`Local registry started at ${baseUrl}`);
+
+  const digest = await pushScratchImage(baseUrl, repository, tag);
+  const imageUrl = `${host}:${port}/${repository}:${tag}`;
+
+  console.log(`Pushed scratch image ${imageUrl} (digest ${digest})`);
+
+  return { container, host, port, baseUrl, imageUrl, digest };
+}
+
+export async function teardownTestRegistry(registry: TestRegistry): Promise<void> {
+  console.log('Tearing down local registry...');
+  await registry.container.stop();
+  console.log('Local registry stopped');
+}

--- a/securebuild-api/integration/fixtures/server.ts
+++ b/securebuild-api/integration/fixtures/server.ts
@@ -1,0 +1,127 @@
+/**
+ * Starts a real Next.js server on a random port for integration tests.
+ *
+ * The server is a separate child process that reads DB_URI (and other env) from
+ * its environment — no module mocking. Tests then exercise the API over real
+ * HTTP via the shared HttpClient.
+ */
+
+import { spawn, ChildProcess } from 'child_process';
+import * as net from 'net';
+import * as path from 'path';
+
+export interface TestServer {
+  baseUrl: string;
+  port: number;
+  stop: () => Promise<void>;
+}
+
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, () => {
+      const address = srv.address();
+      if (address && typeof address === 'object') {
+        const port = address.port;
+        srv.close(() => resolve(port));
+      } else {
+        srv.close();
+        reject(new Error('failed to find a free port'));
+      }
+    });
+  });
+}
+
+function waitForServer(baseUrl: string, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const poll = async () => {
+      if (Date.now() - start > timeoutMs) {
+        reject(new Error(`server at ${baseUrl} did not become ready within ${timeoutMs}ms`));
+        return;
+      }
+      try {
+        // Any HTTP response (including 401) means the server is up and routing.
+        const res = await fetch(`${baseUrl}/api/v1/external-image`, { method: 'GET' });
+        if (res.status !== 0) {
+          resolve();
+          return;
+        }
+      } catch {
+        // not ready yet
+      }
+      setTimeout(poll, 500);
+    };
+    poll();
+  });
+}
+
+export async function startTestServer(env: Record<string, string>, timeoutMs = 180000): Promise<TestServer> {
+  const port = await findFreePort();
+  const apiDir = path.resolve(__dirname, '..', '..');
+  const baseUrl = `http://localhost:${port}`;
+
+  const nextBin = require.resolve('next/dist/bin/next');
+
+  console.log(`Starting Next.js dev server on port ${port} (cwd: ${apiDir})`);
+
+  const childEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...env,
+    NODE_ENV: 'development',
+    PORT: String(port),
+    DD_ENABLED: '',
+    NEXT_TELEMETRY_DISABLED: '1',
+  };
+
+  const child: ChildProcess = spawn('node', [nextBin, 'dev', '-p', String(port)], {
+    cwd: apiDir,
+    env: childEnv,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true,
+  });
+
+  child.stdout?.on('data', (chunk: Buffer) => {
+    process.stdout.write(`[next-dev] ${chunk}`);
+  });
+  child.stderr?.on('data', (chunk: Buffer) => {
+    process.stderr.write(`[next-dev] ${chunk}`);
+  });
+
+  const stop = (): Promise<void> => {
+    return new Promise((resolve) => {
+      if (child.killed || child.exitCode !== null) {
+        resolve();
+        return;
+      }
+      child.once('exit', () => resolve());
+      try {
+        // Kill the whole process group (dev server may spawn children).
+        process.kill(-child.pid!, 'SIGTERM');
+      } catch {
+        child.kill('SIGTERM');
+      }
+      // Fallback force-kill after grace period (unref so it doesn't hold the event loop)
+      const forceKill = setTimeout(() => {
+        try {
+          if (!child.killed && child.exitCode === null) child.kill('SIGKILL');
+        } catch {
+          // ignore
+        }
+      }, 5000);
+      forceKill.unref();
+    });
+  };
+
+  try {
+    await waitForServer(baseUrl, timeoutMs);
+    console.log(`Next.js server ready at ${baseUrl}`);
+  } catch (err) {
+    await stop();
+    throw err;
+  }
+
+  return { baseUrl, port, stop };
+}

--- a/securebuild-api/integration/jest.config.js
+++ b/securebuild-api/integration/jest.config.js
@@ -1,0 +1,30 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/integration/**/test.ts', '**/integration/**/*.test.ts'],
+  testTimeout: 300000, // 5 minutes for container startup, server boot, and schema application
+  maxWorkers: 1, // Serial: Testcontainers + spawned servers share Docker/network resources
+  verbose: true,
+  collectCoverage: false,
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      tsconfig: {
+        esModuleInterop: true,
+        allowSyntheticDefaultImports: true,
+        moduleResolution: 'node',
+        resolveJsonModule: true,
+        isolatedModules: true,
+      },
+    }],
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/../$1',
+    '^server-only$': '<rootDir>/../__mocks__/server-only.js',
+  },
+  setupFiles: ['<rootDir>/setup.ts'],
+  setupFilesAfterEnv: [],
+  globalSetup: undefined,
+  globalTeardown: undefined,
+};

--- a/securebuild-api/integration/setup.ts
+++ b/securebuild-api/integration/setup.ts
@@ -1,0 +1,12 @@
+/**
+ * Global setup for integration tests
+ *
+ * This file sets up environment variables for integration tests.
+ * - DB_URI placeholder prevents module initialization errors
+ */
+
+// Set a placeholder to prevent errors during module initialization
+// This will be overwritten by each test suite with the correct connection string
+process.env.DB_URI = process.env.DB_URI || 'postgresql://placeholder:placeholder@localhost:5432/placeholder';
+
+export {};

--- a/securebuild-api/jest.config.js
+++ b/securebuild-api/jest.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/lib', '<rootDir>/app'],
+  testMatch: ['**/__tests__/**/*.test.ts', '**/?(*.)test.ts'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+    '^server-only$': '<rootDir>/__mocks__/server-only.js',
+  },
+  collectCoverageFrom: [
+    'lib/**/*.ts',
+    'app/**/*.ts',
+    '!lib/**/*.d.ts',
+    '!app/**/*.d.ts',
+  ],
+  testPathIgnorePatterns: [
+    '<rootDir>/.next/',
+    '<rootDir>/node_modules/',
+    '<rootDir>/integration/'
+  ],
+};

--- a/securebuild-api/lib/data/db.ts
+++ b/securebuild-api/lib/data/db.ts
@@ -1,0 +1,97 @@
+import { Pool, PoolConfig } from "pg";
+import { parse } from "url";
+import { parse as parseQueryString } from "querystring";
+import { PoolClient } from "pg";
+
+// Production mode: single pool (singleton)
+let pool: Pool | null = null;
+
+// Test mode: map of URI -> Pool for test isolation
+const testPools: Map<string, Pool> = new Map();
+
+export function getDB(uri: string): Pool {
+  const isTestMode = process.env.NODE_ENV === 'test';
+
+  // Test mode: use separate pools per URI for test isolation
+  if (isTestMode) {
+    if (testPools.has(uri)) {
+      return testPools.get(uri)!;
+    }
+
+    const newPool = createPool(uri);
+    testPools.set(uri, newPool);
+    return newPool;
+  }
+
+  // Production mode: use singleton pool
+  if (pool) {
+    return pool;
+  }
+
+  pool = createPool(uri);
+  return pool;
+}
+
+function createPool(uri: string): Pool {
+  const params = parse(uri);
+  const auth = params.auth?.split(":") || [];
+
+  let ssl: boolean | { rejectUnauthorized: boolean } = {
+    rejectUnauthorized: false,
+  };
+  const parsedQuery = parseQueryString(params.query || "");
+  if (parsedQuery.sslmode === "disable") {
+    ssl = false;
+  }
+
+  const config: PoolConfig = {
+    user: auth[0],
+    password: auth[1],
+    host: params.hostname || "",
+    port: parseInt(params.port || "5432"),
+    database: params.pathname?.split("/")[1] || "",
+    ssl,
+    max: 10,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 2000,
+  };
+
+  return new Pool(config);
+}
+
+/**
+ * Closes a specific pool by URI (test mode only).
+ * In production, pools remain open for the lifetime of the server.
+ */
+export async function closePoolByUri(uri: string): Promise<void> {
+  if (process.env.NODE_ENV === 'test' && testPools.has(uri)) {
+    const pool = testPools.get(uri)!;
+    await pool.end();
+    testPools.delete(uri);
+  }
+}
+
+export async function withClient<T>(db: Pool, fn: (client: PoolClient) => Promise<T>): Promise<T> {
+  const client = await db.connect();
+  try {
+    return await fn(client);
+  } finally {
+    client.release();
+  }
+}
+
+export async function withTransaction<T>(db: Pool, fn: (client: PoolClient) => Promise<T>): Promise<T> {
+  const client = await db.connect();
+  try {
+    await client.query('BEGIN');
+    const result = await fn(client);
+    await client.query('COMMIT');
+    return result;
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+

--- a/securebuild-api/lib/data/param.ts
+++ b/securebuild-api/lib/data/param.ts
@@ -1,0 +1,30 @@
+interface Params {
+  isLoaded: boolean;
+  DBUri: string;
+  authMethod?: string;
+  DB_URI: string;
+}
+
+const params: Params = {
+  isLoaded: false,
+  DBUri: process.env["SECUREBUILD_PG_URI"] || process.env["DB_URI"]!,
+  DB_URI: process.env["SECUREBUILD_PG_URI"] || process.env["DB_URI"]!,
+};
+
+export async function loadParams() {
+  params.isLoaded = true;
+}
+
+export async function getParam(key: keyof Params): Promise<string> {
+  if (!params.isLoaded) {
+    await loadParams();
+  }
+
+  switch (key) {
+    case "DB_URI":
+    case "DBUri":
+      return params.DBUri;
+    default:
+      throw new Error(`unknown param ${key}`);
+  }
+}

--- a/securebuild-api/lib/externalimage/externalimage.ts
+++ b/securebuild-api/lib/externalimage/externalimage.ts
@@ -1,0 +1,1168 @@
+import { TrackedExternalImage } from '../types/externalimage';
+import { getDB, withTransaction } from '../data/db';
+import { getParam } from '../data/param';
+import { traceFunction } from '../observability/tracing';
+import { parseUTCTimestamp } from '../utils/timestamp';
+
+
+export async function upsertExternalImage(registry: string, imageName: string, imageTag: string, digest: string, username: string | null, password: string | null, teamId: string): Promise<TrackedExternalImage> {
+  try {
+    const db = getDB(await getParam("DB_URI"))
+
+    await withTransaction(db, async (client) => {
+      const inFourHours = new Date(Date.now() + 1000 * 60 * 60 * 4)
+      const query = `insert into external_image (registry, image_name, created_at) values ($1, $2, $3) on conflict (registry, image_name) do nothing`
+
+      await client.query(query, [registry, imageName, new Date()])
+
+      const queryTag = `insert into external_image_tag (registry, image_name, image_tag, created_at, digest, next_check_digest_at, next_scan_at) values ($1, $2, $3, $4, $5, $6, $7) on conflict (registry, image_name, image_tag) do update set digest = $5, next_check_digest_at = $6, next_scan_at = $7`
+      await client.query(queryTag, [registry, imageName, imageTag, new Date(), digest, inFourHours, inFourHours])
+
+      if (username && password) {
+        let encryptedPassword: string | null = null;
+        if (password) {
+          encryptedPassword = await encryptPassword(password);
+        }
+
+        const query = `insert into external_image_credential (registry, image_name, username, password, created_at, team_id) values ($1, $2, $3, $4, $5, $6) on conflict (registry, image_name, team_id) do update set username = $3, password = $4`
+        await client.query(query, [registry, imageName, username, encryptedPassword, new Date(), teamId])
+      }
+
+      const teamQuery = `insert into external_image_team (team_id, registry, image_name, image_tag, created_at) values ($1, $2, $3, $4, $5) on conflict (team_id, registry, image_name, image_tag) do nothing`
+      await client.query(teamQuery, [teamId, registry, imageName, imageTag, new Date()])
+    })
+
+    // Initialize SBOM status as 'pending' to ensure it's immediately available via the API
+    // Uses ON CONFLICT DO NOTHING so it's safe to call unconditionally
+    // Non-critical: if this fails we still want to enqueue SBOM work and proceed.
+    try {
+      await initializeSBOMStatusPending(digest)
+    } catch (err) {
+      console.warn(`initializeSBOMStatusPending failed for digest ${digest}:`, err)
+    }
+
+    return getExternalImageForTeam(teamId, registry, imageName);
+
+  } catch (err) {
+    console.error(`upsertExternalImage error:`, err)
+    throw new Error(`Failed to upsert external image: ${err instanceof Error ? err.message : 'Unknown error'}`)
+  }
+}
+
+export async function listExternalImageTags(teamId: string, registry: string, imageName: string): Promise<string[]> {
+  try {
+    const db = getDB(await getParam("DB_URI"))
+
+    const query = `select image_tag from external_image_team where team_id = $1 and image_name = $2 and registry = $3`
+    const result = await db.query(query, [teamId, imageName, registry])
+
+    return result.rows.map((row) => row.image_tag)
+  } catch (err) {
+    console.error(`listExternalImageTags error:`, err)
+    throw new Error(`Failed to list external image tags: ${err instanceof Error ? err.message : 'Unknown error'}`)
+  }
+}
+
+export async function listExternalImages(teamId: string): Promise<TrackedExternalImage[]> {
+  try {
+    const db = getDB(await getParam("DB_URI"));
+
+    // Single query that gets all external images, their tags, and completion status
+    // Uses EXISTS subqueries to check for completion status across all architectures
+    // Also gets the SBOM status (priority: failed > generating > pending > succeeded) and scan status (priority: failed > running > queued > succeeded)
+    // Note: is_scan_complete requires status='succeeded' to prevent showing stale data during rescans
+    const query = `
+      SELECT DISTINCT
+        eteam.registry,
+        eteam.image_name,
+        eimg.created_at,
+        etag.image_tag,
+        etag.digest,
+        etag.created_at,
+        EXISTS(SELECT 1 FROM external_image_sbom esbom WHERE esbom.digest = etag.digest) as is_sbom_complete,
+        EXISTS(SELECT 1 FROM external_image_scan escan WHERE escan.digest = etag.digest AND escan.status = 'succeeded') as is_scan_complete,
+        (
+          SELECT CASE
+            WHEN EXISTS(SELECT 1 FROM external_image_sbom_status esbom_status WHERE esbom_status.digest = etag.digest AND esbom_status.status = 'failed') THEN 'failed'
+            WHEN EXISTS(SELECT 1 FROM external_image_sbom_status esbom_status WHERE esbom_status.digest = etag.digest AND esbom_status.status = 'generating') THEN 'generating'
+            WHEN EXISTS(SELECT 1 FROM external_image_sbom_status esbom_status WHERE esbom_status.digest = etag.digest AND esbom_status.status = 'pending') THEN 'pending'
+            WHEN EXISTS(SELECT 1 FROM external_image_sbom_status esbom_status WHERE esbom_status.digest = etag.digest AND esbom_status.status = 'succeeded') THEN 'succeeded'
+            -- If SBOM exists but no status row, infer succeeded (for backwards compatibility with SBOMs created before status tracking)
+            WHEN EXISTS(SELECT 1 FROM external_image_sbom esbom WHERE esbom.digest = etag.digest) THEN 'succeeded'
+            ELSE NULL
+          END
+        ) as sbom_status,
+        (
+          SELECT CASE
+            WHEN EXISTS(SELECT 1 FROM external_image_scan escan WHERE escan.digest = etag.digest AND escan.status = 'failed') THEN 'failed'
+            WHEN EXISTS(SELECT 1 FROM external_image_scan escan WHERE escan.digest = etag.digest AND escan.status = 'running') THEN 'running'
+            WHEN EXISTS(SELECT 1 FROM external_image_scan escan WHERE escan.digest = etag.digest AND escan.status = 'queued') THEN 'queued'
+            WHEN EXISTS(SELECT 1 FROM external_image_scan escan WHERE escan.digest = etag.digest AND escan.status = 'succeeded') THEN 'succeeded'
+            ELSE NULL
+          END
+        ) as scan_status
+      FROM external_image_team eteam
+        INNER JOIN external_image eimg ON eteam.registry = eimg.registry AND eteam.image_name = eimg.image_name
+        LEFT JOIN external_image_tag etag ON eteam.registry = etag.registry AND eteam.image_name = etag.image_name AND eteam.image_tag = etag.image_tag
+      WHERE eteam.team_id = $1
+      ORDER BY eimg.created_at DESC, etag.created_at DESC
+    `
+    const result = await db.query(query, [teamId])
+
+    // Group results by image (registry + image_name)
+    const imageMap = new Map<string, TrackedExternalImage>()
+
+    for (const row of result.rows) {
+      const imageKey = `${row.registry}/${row.image_name}`
+
+      if (!imageMap.has(imageKey)) {
+        imageMap.set(imageKey, {
+          registry: row.registry,
+          imageName: row.image_name,
+          imageTags: [],
+          createdAt: row.created_at,
+          hasX8664: false,
+          hasArm64: false,
+          tagCompletionStatus: {}
+        })
+      }
+
+      // image_tag can be null because of the LEFT JOIN
+      if (row.image_tag) {
+        const image = imageMap.get(imageKey)!
+
+        // Add tag if not already present
+        if (!image.imageTags.includes(row.image_tag)) {
+          image.imageTags.push(row.image_tag)
+        }
+
+        // Set completion status for this tag
+        image.tagCompletionStatus[row.image_tag] = {
+          digest: row.digest,
+          isSbomComplete: row.is_sbom_complete,
+          isScanComplete: row.is_scan_complete,
+          isSignatureComplete: false,
+          sbomStatus: row.sbom_status,
+          scanStatus: row.scan_status
+        }
+      }
+    }
+
+    return Array.from(imageMap.values())
+  } catch (err) {
+    console.error(`listExternalImages error:`, err)
+    throw new Error(`Failed to list external images: ${err instanceof Error ? err.message : 'Unknown error'}`)
+  }
+}
+
+
+export async function encryptPassword(password: string): Promise<string> {
+  const secretEncoded = process.env.EXTERNAL_REGISTRY_ENCRYPTION_SECRET;
+  if (!secretEncoded) {
+    throw new Error("EXTERNAL_REGISTRY_ENCRYPTION_SECRET environment variable is required");
+  }
+
+  const secret = Buffer.from(secretEncoded, 'base64').toString('utf-8');
+
+  // Generate a random IV for each encryption
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+
+  // Create a 32-byte key from the secret using SHA-256
+  const keyBuffer = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(secret));
+
+  // Import the key for AES-GCM
+  const key = await crypto.subtle.importKey(
+    "raw",
+    keyBuffer,
+    { name: "AES-GCM" },
+    false,
+    ["encrypt"]
+  );
+
+  // Encrypt the password
+  const encrypted = await crypto.subtle.encrypt(
+    {
+      name: "AES-GCM",
+      iv: iv,
+    },
+    key,
+    new TextEncoder().encode(password)
+  );
+
+  // Combine IV and encrypted data, then base64 encode
+  const combined = new Uint8Array(iv.length + encrypted.byteLength);
+  combined.set(iv);
+  combined.set(new Uint8Array(encrypted), iv.length);
+
+  return Buffer.from(combined).toString('base64');
+}
+
+export async function decryptPassword(encryptedPassword: string): Promise<string> {
+  const secretEncoded = process.env.EXTERNAL_REGISTRY_ENCRYPTION_SECRET;
+  if (!secretEncoded) {
+    throw new Error("EXTERNAL_REGISTRY_ENCRYPTION_SECRET environment variable is required");
+  }
+
+  const secret = Buffer.from(secretEncoded, 'base64').toString('utf-8');
+
+  // Decode the base64 combined data
+  const combined = Buffer.from(encryptedPassword, 'base64');
+
+  // Extract IV (first 12 bytes) and encrypted data
+  const iv = combined.slice(0, 12);
+  const encrypted = combined.slice(12);
+
+  // Create a 32-byte key from the secret using SHA-256
+  const keyBuffer = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(secret));
+
+  // Import the key for AES-GCM
+  const key = await crypto.subtle.importKey(
+    "raw",
+    keyBuffer,
+    { name: "AES-GCM" },
+    false,
+    ["decrypt"]
+  );
+
+  // Decrypt the password
+  const decrypted = await crypto.subtle.decrypt(
+    {
+      name: "AES-GCM",
+      iv: iv,
+    },
+    key,
+    encrypted
+  );
+
+  return new TextDecoder().decode(decrypted);
+}
+
+/**
+ * Get stored credentials for an external image from the database.
+ * Returns decrypted credentials if found, or null if no credentials exist.
+ *
+ * @param teamId - The team ID to filter credentials by (prevents cross-team access)
+ * @param registry - The registry (e.g., "docker.io", "ghcr.io")
+ * @param imageName - The image name (e.g., "library/nginx")
+ */
+export async function getExternalImageCredentials(teamId: string, registry: string, imageName: string): Promise<{ username: string, password: string } | null> {
+  const db = getDB(await getParam("DB_URI"))
+
+  const query = `
+    SELECT username, password
+    FROM external_image_credential
+    WHERE team_id = $1 AND registry = $2 AND image_name = $3
+    LIMIT 1
+  `
+  const result = await db.query(query, [teamId, registry, imageName])
+
+  if (result.rows.length === 0 || !result.rows[0].username || !result.rows[0].password) {
+    return null
+  }
+
+  const decryptedPassword = await decryptPassword(result.rows[0].password)
+
+  return {
+    username: result.rows[0].username,
+    password: decryptedPassword,
+  }
+}
+
+export const getExternalImageSBOM = traceFunction('lib.externalimage.getExternalImageSBOM', async (digest: string): Promise<{ sbom: string, source: string } | null> => {
+  try {
+    const db = getDB(await getParam("DB_URI"))
+
+    const query = `select sbom, source from external_image_sbom where digest = $1`
+    const result = await db.query(query, [digest])
+
+    if (result.rows.length === 0) {
+      return null
+    }
+
+    return {
+      sbom: result.rows[0].sbom,
+      source: result.rows[0].source,
+    }
+  } catch (err) {
+    console.error(`getExternalImageSBOM error:`, err)
+    throw err;
+  }
+},
+  {
+    getTags: (digest: string) => ({
+      'args.digest': digest,
+    })
+  })
+
+/**
+ * Gets the digest for a specific tag of an external image.
+ * This is used when you need the exact digest for a particular tag,
+ * rather than the most recently created tag's digest.
+ *
+ * @param teamId - The team ID to validate access against
+ * @param registry - The registry hostname (e.g., "index.docker.io")
+ * @param imageName - The image name (e.g., "library/busybox")
+ * @param imageTag - The specific tag (e.g., "musl", "1.30")
+ * @returns The digest for the specific tag, or null if not found
+ */
+export const getExternalImageDigestForTag = traceFunction('lib.externalimage.getExternalImageDigestForTag', async (teamId: string, registry: string, imageName: string, imageTag: string): Promise<string | null> => {
+  try {
+    const db = getDB(await getParam("DB_URI"))
+
+    const query = `select t.digest
+      from external_image_tag t
+      inner join external_image_team et on et.team_id = $1 and et.registry = t.registry and et.image_name = t.image_name and et.image_tag = t.image_tag
+      where t.registry = $2 and t.image_name = $3 and t.image_tag = $4`
+    const result = await db.query(query, [teamId, registry, imageName, imageTag])
+
+    if (result.rows.length === 0) {
+      return null
+    }
+
+    return result.rows[0].digest
+  } catch (err) {
+    console.error(`getExternalImageDigestForTag error:`, err)
+    throw err;
+  }
+},
+  {
+    getTags: (teamId: string, registry: string, imageName: string, imageTag: string) => ({
+      'args.team_id': teamId,
+      'args.registry': registry,
+      'args.image_name': imageName,
+      'args.image_tag': imageTag,
+    })
+  });
+
+/**
+ * Verify if a team has access to a specific digest.
+ * This checks if the digest belongs to any image tag that the team has tracked.
+ * @param teamId - The team ID to validate access
+ * @param digest - The digest to check
+ * @returns true if the team has access to this digest, false otherwise
+ */
+export const teamOwnsDigest = traceFunction('lib.externalimage.teamOwnsDigest', async (teamId: string, digest: string): Promise<boolean> => {
+  try {
+    const db = getDB(await getParam("DB_URI"))
+
+    // Check if the digest belongs to any tag that the team has access to
+    const query = `select 1
+      from external_image_tag t
+      inner join external_image_team et on et.team_id = $1 and et.registry = t.registry and et.image_name = t.image_name and et.image_tag = t.image_tag
+      where t.digest = $2
+      limit 1`
+    const result = await db.query(query, [teamId, digest])
+
+    return result.rows.length > 0
+  } catch (err) {
+    console.error(`teamOwnsDigest error:`, err)
+    throw err;
+  }
+},
+  {
+    getTags: (teamId: string, digest: string) => ({
+      'args.team_id': teamId,
+      'args.digest': digest,
+    })
+  });
+
+export type ExternalImageScanData = {
+  scanResult: string | null
+  scanCreatedAt: string
+  digestFirstSeenAt: string | null
+  imageSizeBytes: number
+  status: string
+  scanStatusMessage: string | null
+  scanStatusUpdatedAt: Date | null
+  scanAttemptedAt: Date | null
+  scanCompletedAt: Date | null
+  updatedAt: Date | null
+  imageDigest: string | null
+}
+
+/**
+ * Unified function to retrieve scan results with scan status metadata.
+ * Uses LEFT JOIN with external_image_sbom so scan rows are visible even when
+ * no SBOM row exists yet (e.g. race conditions, data integrity issues), ensuring
+ * status-checking code sees queued/running scans and does not allow duplicate enqueues.
+ *
+ * @param digest - The image digest
+ * @param arch - The architecture (x86_64 or aarch64)
+ * @param format - The format: 'raw' for raw_result or 'parsed' for parsed_results_details
+ * @returns Scan result with metadata including scan status fields; SBOM-derived fields may be null when no SBOM row exists. Throws on failure.
+ */
+export const getExternalImageScan = traceFunction('lib.externalimage.getExternalImageScan', async (digest: string, arch: string, format: 'raw' | 'parsed'): Promise<ExternalImageScanData | null> => {
+  try {
+    const db = getDB(await getParam("DB_URI"))
+
+    let query: string
+    if (format === 'raw') {
+      query = `select escan.raw_result as scan_result, escan.created_at as scan_created_at, esbom.created_at as sbom_created_at, esbom.image_size_bytes as image_size_bytes,
+        escan.status, escan.scan_status_message, escan.scan_status_updated_at, escan.scan_attempted_at, escan.scan_completed_at, escan.updated_at, esbom.image_digest
+        from external_image_scan escan
+        left join external_image_sbom esbom on escan.digest = esbom.digest and escan.arch = esbom.arch
+        where escan.digest = $1 and escan.arch = $2`
+    } else {
+      // Use parsed_results_details (full structure with descriptor, fixed_counts, vulnerability_details)
+      query = `select escan.parsed_results_details as scan_result, escan.created_at as scan_created_at, esbom.created_at as sbom_created_at, esbom.image_size_bytes as image_size_bytes,
+        escan.status, escan.scan_status_message, escan.scan_status_updated_at, escan.scan_attempted_at, escan.scan_completed_at, escan.updated_at, esbom.image_digest
+        from external_image_scan escan
+        left join external_image_sbom esbom on escan.digest = esbom.digest and escan.arch = esbom.arch
+        where escan.digest = $1 and escan.arch = $2`
+    }
+
+    const result = await db.query(query, [digest, arch])
+
+    if (result.rows.length === 0) {
+      return null
+    }
+
+    const row = result.rows[0]
+    return {
+      scanResult: row.scan_result,
+      scanCreatedAt: row.scan_created_at,
+      digestFirstSeenAt: row.sbom_created_at ?? null,
+      imageSizeBytes: row.image_size_bytes != null ? parseInt(String(row.image_size_bytes), 10) : 0,
+      status: row.status,
+      scanStatusMessage: row.scan_status_message,
+      scanStatusUpdatedAt: row.scan_status_updated_at,
+      scanAttemptedAt: row.scan_attempted_at,
+      scanCompletedAt: row.scan_completed_at,
+      updatedAt: row.updated_at,
+      imageDigest: row.image_digest ?? null,
+    }
+  } catch (err) {
+    console.error(`getExternalImageScan error:`, err)
+    throw new Error('Failed to retrieve scan results.')
+  }
+},
+  {
+    getTags: (digest: string, arch: string, format: 'raw' | 'parsed') => ({
+      'args.digest': digest,
+      'args.arch': arch,
+      'args.format': format,
+    })
+  });
+
+
+export const getExternalImageSbom = traceFunction('lib.externalimage.getExternalImageSbom', async (digest: string): Promise<string | null> => {
+  try {
+    const db = getDB(await getParam("DB_URI"))
+
+    const query = `select sbom from external_image_sbom where digest = $1`
+    const result = await db.query(query, [digest])
+
+    if (result.rows.length === 0) {
+      return null
+    }
+
+    return result.rows[0].sbom
+  } catch (err) {
+    console.error(`getExternalImageSbom error:`, err)
+    throw err;
+  }
+},
+  {
+    getTags: (digest: string) => ({
+      'args.digest': digest,
+    })
+  })
+
+export async function unlinkExternalImage(teamId: string, registry: string, imageName: string) {
+  console.log(`unlinkExternalImage: ${teamId} ${registry} ${imageName}`)
+  try {
+    const db = getDB(await getParam("DB_URI"))
+
+    const query = `delete from external_image_team where team_id = $1 and registry = $2 and image_name = $3`
+    await db.query(query, [teamId, registry, imageName])
+  } catch (err) {
+    console.error(`unlinkExternalImage error:`, err)
+    throw err;
+  }
+}
+
+export async function getExternalImageForTeam(teamId: string, registry: string, imageName: string): Promise<TrackedExternalImage> {
+  console.log(`getExternalImageForTeam: ${registry} ${imageName} ${teamId}`)
+  try {
+    const db = getDB(await getParam("DB_URI"))
+
+    // Single query that gets image info, all tags, and completion status by registry, imageName, and imageTag
+    // Also gets the SBOM status (priority: failed > generating > pending > succeeded) and scan status (priority: failed > running > queued > succeeded)
+    // Note: is_scan_complete requires status='succeeded' to prevent showing stale data during rescans
+    const query = `
+      SELECT DISTINCT
+        eteam.registry,
+        eteam.image_name,
+        eimg.created_at,
+        etag.image_tag,
+        etag.digest,
+        etag.created_at,
+        EXISTS(SELECT 1 FROM external_image_sbom esbom WHERE esbom.digest = etag.digest) as is_sbom_complete,
+        EXISTS(SELECT 1 FROM external_image_scan escan WHERE escan.digest = etag.digest AND escan.status = 'succeeded') as is_scan_complete,
+        (
+          SELECT CASE
+            WHEN EXISTS(SELECT 1 FROM external_image_sbom_status esbom_status WHERE esbom_status.digest = etag.digest AND esbom_status.status = 'failed') THEN 'failed'
+            WHEN EXISTS(SELECT 1 FROM external_image_sbom_status esbom_status WHERE esbom_status.digest = etag.digest AND esbom_status.status = 'generating') THEN 'generating'
+            WHEN EXISTS(SELECT 1 FROM external_image_sbom_status esbom_status WHERE esbom_status.digest = etag.digest AND esbom_status.status = 'pending') THEN 'pending'
+            WHEN EXISTS(SELECT 1 FROM external_image_sbom_status esbom_status WHERE esbom_status.digest = etag.digest AND esbom_status.status = 'succeeded') THEN 'succeeded'
+            -- If SBOM exists but no status row, infer succeeded (for backwards compatibility with SBOMs created before status tracking)
+            WHEN EXISTS(SELECT 1 FROM external_image_sbom esbom WHERE esbom.digest = etag.digest) THEN 'succeeded'
+            ELSE NULL
+          END
+        ) as sbom_status,
+        (
+          SELECT CASE
+            WHEN EXISTS(SELECT 1 FROM external_image_scan escan WHERE escan.digest = etag.digest AND escan.status = 'failed') THEN 'failed'
+            WHEN EXISTS(SELECT 1 FROM external_image_scan escan WHERE escan.digest = etag.digest AND escan.status = 'running') THEN 'running'
+            WHEN EXISTS(SELECT 1 FROM external_image_scan escan WHERE escan.digest = etag.digest AND escan.status = 'queued') THEN 'queued'
+            WHEN EXISTS(SELECT 1 FROM external_image_scan escan WHERE escan.digest = etag.digest AND escan.status = 'succeeded') THEN 'succeeded'
+            ELSE NULL
+          END
+        ) as scan_status
+      FROM external_image_tag etag
+        INNER JOIN external_image_team eteam ON etag.registry = eteam.registry
+          AND etag.image_name = eteam.image_name
+          AND etag.image_tag = eteam.image_tag
+        INNER JOIN external_image eimg ON etag.registry = eimg.registry AND etag.image_name = eimg.image_name
+      WHERE etag.registry = $1 AND etag.image_name = $2 AND eteam.team_id = $3
+      ORDER BY etag.created_at DESC
+    `
+    const result = await db.query(query, [registry, imageName, teamId])
+
+    if (result.rows.length === 0) {
+      throw new Error(`External image not found for ${registry}/${imageName}`)
+    }
+
+    // Build the image object from the first row (all rows have same registry/image_name/created_at)
+    const firstRow = result.rows[0]
+    const image: TrackedExternalImage = {
+      registry: firstRow.registry,
+      imageName: firstRow.image_name,
+      imageTags: [],
+      createdAt: firstRow.created_at,
+      hasX8664: false,
+      hasArm64: false,
+      tagCompletionStatus: {}
+    }
+
+    // Process all rows to build tags and completion status
+    for (const row of result.rows) {
+      // Add tag if not already present
+      if (!image.imageTags.includes(row.image_tag)) {
+        image.imageTags.push(row.image_tag)
+      }
+
+      // Set completion status for this tag
+      image.tagCompletionStatus[row.image_tag] = {
+        digest: row.digest,
+        isSbomComplete: row.is_sbom_complete,
+        isScanComplete: row.is_scan_complete,
+        isSignatureComplete: false,
+        sbomStatus: row.sbom_status,
+        scanStatus: row.scan_status
+      }
+    }
+
+    return image
+  } catch (err) {
+    console.error(`getExternalImageForTeam error:`, err)
+    throw err;
+  }
+}
+
+export async function getExternalImageLastScannedAt(digest: string): Promise<string | null> {
+  try {
+    const db = getDB(await getParam("DB_URI"))
+
+    const query = `select max(created_at) as last_scanned_at from external_image_scan where digest = $1`
+    const result = await db.query(query, [digest])
+
+    if (result.rows.length === 0 || !result.rows[0].last_scanned_at) {
+      return null
+    }
+
+    const parsedDate = parseUTCTimestamp(result.rows[0].last_scanned_at);
+    if (!parsedDate || isNaN(parsedDate.getTime())) {
+      console.warn(`Invalid timestamp value for digest ${digest}: ${result.rows[0].last_scanned_at}`);
+      return null;
+    }
+    return parsedDate.toISOString()
+  } catch (err) {
+    console.error(`getExternalImageLastScannedAt error:`, err)
+    throw err;
+  }
+}
+
+export async function getExternalImagePlatforms(digest: string): Promise<string[]> {
+  try {
+    const db = getDB(await getParam("DB_URI"))
+
+    const query = `select distinct arch from external_image_scan where digest = $1 order by arch`
+    const result = await db.query(query, [digest])
+
+    const platforms = result.rows.map((row) => {
+      const arch = row.arch
+      if (arch === 'x86_64') {
+        return 'linux/amd64'
+      } else if (arch === 'aarch64') {
+        return 'linux/arm64'
+      } else {
+        return `linux/${arch}`
+      }
+    })
+
+    return platforms
+  } catch (err) {
+    console.error(`getExternalImagePlatforms error:`, err)
+    throw err;
+  }
+}
+
+// SBOM and Scan status types and functions
+/**
+ * SBOM status represents the state of SBOM generation for an external image.
+ * Tracked separately from scan status in the external_image_sbom_status table.
+ *
+ * Status progression:
+ * 1. pending: Image tracked, SBOM generation job not yet started
+ * 2. generating: SBOM generation in progress (downloading from registry)
+ * 3. succeeded: SBOM generated successfully
+ * 4. failed: SBOM generation failed (see statusMessage for details)
+ */
+export type SBOMStatus = 'pending' | 'generating' | 'succeeded' | 'failed'
+
+/**
+ * Scan status represents the state of vulnerability scanning for an external image.
+ * Tracked in the external_image_scan table. Scan can only start after SBOM generation succeeds.
+ *
+ * Status progression:
+ * 1. queued: SBOM generated, waiting for vulnerability scan to start
+ * 2. running: Vulnerability scan actively executing
+ * 3. succeeded: Scan completed successfully with results
+ * 4. failed: Scan failed with error (see scanStatusMessage for details)
+ */
+export type ScanStatus = 'queued' | 'running' | 'succeeded' | 'failed'
+
+export interface ScanStatusEntry {
+  digest: string
+  arch: string
+  status: ScanStatus
+  scanStatusMessage: string | null
+  createdAt: Date
+  updatedAt: Date | null
+  scanAttemptedAt: Date | null
+  scanCompletedAt: Date | null
+  scanStatusUpdatedAt: Date | null
+  imageDigest: string | null  // per-architecture manifest digest (from SBOM table)
+}
+
+export interface SBOMStatusEntry {
+  digest: string
+  status: SBOMStatus
+  statusMessage: string | null
+  createdAt: Date
+  updatedAt: Date | null
+  statusUpdatedAt: Date | null
+}
+
+/**
+ * Reset scan status to queued for a digest.
+ * This clears the scan_status_message and sets status to 'queued' so a rescan can run.
+ * Note: scan_attempted_at is set when the scan actually starts (SetScanStatusRunning in Go).
+ *
+ * @param digest - The image digest to reset scan status for
+ */
+export async function resetScanStatus(digest: string): Promise<void> {
+  const db = getDB(await getParam("DB_URI"))
+  const now = new Date()
+
+  // Only reset scan status for architectures that have SBOMs
+  // This prevents resetting status for architectures the image doesn't support
+  const resetQuery = `
+    UPDATE external_image_scan eis
+    SET scan_status_message = NULL, status = 'queued', updated_at = $2, scan_status_updated_at = $2
+    WHERE eis.digest = $1
+      AND EXISTS (
+        SELECT 1 FROM external_image_sbom esbom
+        WHERE esbom.digest = eis.digest AND esbom.arch = eis.arch
+      )
+  `
+  await db.query(resetQuery, [digest, now])
+}
+
+/**
+ * Update the digest for an existing tag.
+ * This is used during rescan when the registry returns a new digest for a tag.
+ *
+ * @param registry - The registry (e.g., "docker.io", "ghcr.io")
+ * @param imageName - The image name (e.g., "library/nginx")
+ * @param imageTag - The image tag (e.g., "latest")
+ * @param digest - The new digest from the registry
+ */
+export async function updateTagDigest(registry: string, imageName: string, imageTag: string, digest: string): Promise<void> {
+  const db = getDB(await getParam("DB_URI"))
+
+  // Set next check/scan times to 4 hours from now to prevent duplicate work
+  // from the background monitor picking up this tag immediately
+  const inFourHours = new Date(Date.now() + 4 * 60 * 60 * 1000)
+
+  const query = `
+    UPDATE external_image_tag
+    SET digest = $4, next_check_digest_at = $5, next_scan_at = $5
+    WHERE registry = $1 AND image_name = $2 AND image_tag = $3
+  `
+  const result = await db.query(query, [registry, imageName, imageTag, digest, inFourHours])
+
+  if (result.rowCount === 0) {
+    throw new Error(`Tag not found: ${registry}/${imageName}:${imageTag}`)
+  }
+}
+
+
+/**
+ * Initialize SBOM status as 'pending' for a digest.
+ * Uses ON CONFLICT DO NOTHING to avoid overwriting existing status.
+ * This should be called when an image is first tracked and SBOM work is enqueued.
+ *
+ * @param digest - The image digest to initialize status for
+ */
+export async function initializeSBOMStatusPending(digest: string): Promise<void> {
+  const db = getDB(await getParam("DB_URI"))
+  const now = new Date()
+
+  const query = `
+    INSERT INTO external_image_sbom_status (digest, created_at, status, updated_at, status_updated_at)
+    VALUES ($1, $2, 'pending', $2, $2)
+    ON CONFLICT (digest) DO NOTHING
+  `
+
+  await db.query(query, [digest, now])
+}
+
+/**
+ * Get the SBOM status for a digest from the external_image_sbom_status table.
+ *
+ * @param digest - The image digest to check
+ * @returns SBOM status entry or null if not found
+ */
+export async function getSBOMStatus(digest: string): Promise<SBOMStatusEntry | null> {
+  const db = getDB(await getParam("DB_URI"))
+
+  const query = `
+    SELECT
+      digest, status, status_message,
+      created_at, updated_at, status_updated_at
+    FROM external_image_sbom_status
+    WHERE digest = $1
+  `
+
+  const result = await db.query(query, [digest])
+
+  if (result.rows.length === 0) {
+    return null
+  }
+
+  const row = result.rows[0]
+  return {
+    digest: row.digest,
+    status: row.status as SBOMStatus,
+    statusMessage: row.status_message,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    statusUpdatedAt: row.status_updated_at,
+  }
+}
+
+/**
+ * Get the earliest scan_attempted_at timestamp for a digest.
+ *
+ * @param digest - The image digest to check
+ * @returns The earliest scan_attempted_at timestamp, or null if not found
+ */
+export async function getScanAttemptedAt(digest: string): Promise<Date | null> {
+  const db = getDB(await getParam("DB_URI"))
+
+  const query = `
+    SELECT MIN(scan_attempted_at) as scan_attempted_at
+    FROM external_image_scan
+    WHERE digest = $1
+  `
+  const result = await db.query(query, [digest])
+
+  if (result.rows.length === 0 || !result.rows[0].scan_attempted_at) {
+    return null
+  }
+
+  return result.rows[0].scan_attempted_at
+}
+
+export interface ImageRefTag {
+  registry: string;
+  repository: string;
+  tag: string;
+}
+
+export interface BatchScanResult {
+  digest: string;
+  scanResult: string | null;
+  scanCreatedAt: string | null;
+  digestFirstSeenAt: string | null;
+  imageSizeBytes: number;
+  hasAccess: boolean;
+  scanStatus: string | null;
+  scanStatusMessage: string | null;
+  scanStatusUpdatedAt: string | null;
+  sbomStatus: string | null;
+  sbomStatusMessage: string | null;
+  sbomStatusUpdatedAt: string | null;
+}
+
+export interface BatchSbomResult {
+  digest: string;
+  arch: string | null;
+  sbom: string | null;
+  source: string | null;
+  sbomCreatedAt: string | null;
+  imageSizeBytes: number;
+  hasAccess: boolean;
+}
+
+/**
+ * Batch query to get scan results for multiple image digests.
+ * Only returns results for digests owned by the given team (via
+ * external_image_team join on external_image_tag).
+ *
+ * @param teamId - Team ID for access validation
+ * @param digests - Array of image digests to query
+ * @param arch - Target architecture (x86_64 or aarch64)
+ * @param format - Scan result format ('raw' or 'parsed')
+ * @returns Map of digest to BatchScanResult (includes scan data, metadata, and access status)
+ */
+export const getBatchExternalImageScans = traceFunction('lib.externalimage.getBatchExternalImageScans', async (
+  teamId: string,
+  digests: string[],
+  arch: string,
+  format: 'raw' | 'parsed',
+): Promise<Map<string, BatchScanResult>> => {
+  try {
+    const db = getDB(await getParam("DB_URI"))
+
+    if (digests.length === 0) {
+      return new Map()
+    }
+
+    // Select the appropriate result column based on format
+    // parsed format uses parsed_results_details (full structure with descriptor, fixed_counts, vulnerability_details)
+    const resultColumn = format === 'raw' ? 'escan.raw_result' : 'escan.parsed_results_details'
+
+    // Phase 0: Determine which of the requested digests the team owns.
+    // This must be checked from external_image_tag + external_image_team directly,
+    // not inferred from scan query results — a digest the team owns may have no
+    // scan row yet (SBOM still pending/generating).
+    const ownershipQuery = `
+      SELECT DISTINCT etag.digest
+      FROM external_image_tag etag
+        INNER JOIN external_image_team eteam
+          ON eteam.team_id = $1
+          AND eteam.registry = etag.registry
+          AND eteam.image_name = etag.image_name
+          AND eteam.image_tag = etag.image_tag
+      WHERE etag.digest = ANY($2)
+    `
+    const ownershipResult = await db.query(ownershipQuery, [teamId, digests])
+    const ownedDigests = new Set(ownershipResult.rows.map((r: { digest: string }) => r.digest))
+
+    // Build a map of "digest" -> scan result
+    const resultMap = new Map<string, BatchScanResult>()
+
+    // Phase 1: Get scan results (with SBOM metadata and SBOM status) for owned digests only
+    const ownedDigestList = [...ownedDigests]
+    if (ownedDigestList.length > 0) {
+      const scanQuery = `
+        SELECT
+          escan.digest,
+          ${resultColumn} as scan_result,
+          escan.created_at as scan_created_at,
+          esbom.created_at as digest_first_seen_at,
+          esbom.image_size_bytes,
+          escan.status as scan_status,
+          escan.scan_status_message as scan_status_message,
+          escan.scan_status_updated_at as scan_status_updated_at,
+          esbom_status.status as sbom_status,
+          esbom_status.status_message as sbom_status_message,
+          esbom_status.status_updated_at as sbom_status_updated_at
+        FROM external_image_scan escan
+          LEFT JOIN external_image_sbom esbom
+            ON esbom.digest = escan.digest
+            AND esbom.arch = escan.arch
+          LEFT JOIN external_image_sbom_status esbom_status
+            ON esbom_status.digest = escan.digest
+        WHERE
+          escan.arch = $1
+          AND escan.digest = ANY($2)
+      `
+
+      const scanResult = await db.query(scanQuery, [arch, ownedDigestList])
+
+      // Process scan results
+      for (const row of scanResult.rows) {
+        resultMap.set(row.digest, {
+          digest: row.digest,
+          scanResult: row.scan_result,
+          scanCreatedAt: row.scan_created_at,
+          digestFirstSeenAt: row.digest_first_seen_at,
+          imageSizeBytes: parseInt(row.image_size_bytes || '0'),
+          hasAccess: true,
+          scanStatus: row.scan_status,
+          scanStatusMessage: row.scan_status_message,
+          scanStatusUpdatedAt: row.scan_status_updated_at,
+          sbomStatus: row.sbom_status,
+          sbomStatusMessage: row.sbom_status_message,
+          sbomStatusUpdatedAt: row.sbom_status_updated_at,
+        })
+      }
+    }
+
+    // Phase 2: Get SBOM status for owned digests that don't have scan entries yet (pending/generating SBOM)
+    const ownedDigestsWithoutScans = ownedDigestList.filter(d => !resultMap.has(d))
+    if (ownedDigestsWithoutScans.length > 0) {
+      const sbomStatusQuery = `
+        SELECT
+          esbom_status.digest,
+          esbom_status.status as sbom_status,
+          esbom_status.status_message as sbom_status_message,
+          esbom_status.status_updated_at as sbom_status_updated_at
+        FROM external_image_sbom_status esbom_status
+        WHERE
+          esbom_status.digest = ANY($1)
+      `
+      const sbomStatusResult = await db.query(sbomStatusQuery, [ownedDigestsWithoutScans])
+
+      // Add SBOM status entries for digests without scan data yet
+      for (const row of sbomStatusResult.rows) {
+        resultMap.set(row.digest, {
+          digest: row.digest,
+          scanResult: null,
+          scanCreatedAt: null,
+          digestFirstSeenAt: null,
+          imageSizeBytes: 0,
+          hasAccess: true,
+          scanStatus: null,
+          scanStatusMessage: null,
+          scanStatusUpdatedAt: null,
+          sbomStatus: row.sbom_status,
+          sbomStatusMessage: row.sbom_status_message,
+          sbomStatusUpdatedAt: row.sbom_status_updated_at,
+        })
+      }
+    }
+
+    // For image tags not found in the result (no access or doesn't exist),
+    // add them with hasAccess: false
+    for (const digest of digests) {
+      if (!resultMap.has(digest)) {
+        resultMap.set(digest, {
+          digest: digest,
+          scanResult: null,
+          scanCreatedAt: null,
+          digestFirstSeenAt: null,
+          imageSizeBytes: 0,
+          hasAccess: false,
+          scanStatus: null,
+          scanStatusMessage: null,
+          scanStatusUpdatedAt: null,
+          sbomStatus: null,
+          sbomStatusMessage: null,
+          sbomStatusUpdatedAt: null,
+        })
+      }
+    }
+
+    return resultMap
+  } catch (err) {
+    console.error(`getBatchExternalImageScans error:`, err)
+    throw err;
+  }
+},
+  {
+    getTags: (teamId: string, digests: string[], arch: string, format: 'raw' | 'parsed') => ({
+      'args.team_id': teamId,
+      'args.digests.length': digests.length,
+      'args.arch': arch,
+      'args.format': format,
+    })
+  })
+
+/**
+ * Batch query to get SBOM data for multiple image digests.
+ * Only returns results for digests owned by the given team (via
+ * external_image_team join on external_image_tag).
+ *
+ * @param teamId - Team ID for access validation
+ * @param digests - Array of image digests to query
+ * @param arch - Target architecture (x86_64 or aarch64)
+ * @returns Map of digest to BatchSbomResult (includes SBOM data, metadata, and access status)
+ */
+export const getBatchExternalSboms = traceFunction('lib.externalimage.getBatchExternalSboms', async (
+  teamId: string,
+  digests: string[],
+  arch: string
+): Promise<Map<string, BatchSbomResult>> => {
+  try {
+    const db = getDB(await getParam("DB_URI"))
+
+    if (digests.length === 0) {
+      return new Map()
+    }
+
+    // Single query that:
+    // 1. Queries external_image_sbom for SBOM data
+    // 2. Filters by architecture and digest array
+    // 3. Validates team access via external_image_team join
+    // 4. Returns SBOM data and metadata for all requested digests in one query
+
+    const query = `
+      SELECT
+        esbom.digest,
+        esbom.arch,
+        esbom.sbom,
+        esbom.source,
+        esbom.created_at as sbom_created_at,
+        esbom.image_size_bytes
+      FROM external_image_sbom esbom
+        INNER JOIN external_image_tag etag
+          ON etag.digest = esbom.digest
+        INNER JOIN external_image_team eteam
+          ON eteam.team_id = $1
+          AND eteam.registry = etag.registry
+          AND eteam.image_name = etag.image_name
+          AND eteam.image_tag = etag.image_tag
+      WHERE
+        esbom.arch = $2
+        AND esbom.digest = ANY($3)
+    `
+
+    const result = await db.query(query, [teamId, arch, digests])
+
+    // Build a map of "digest" -> SBOM result
+    const resultMap = new Map<string, BatchSbomResult>()
+
+    for (const row of result.rows) {
+      resultMap.set(row.digest, {
+        digest: row.digest,
+        arch: row.arch,
+        sbom: row.sbom,
+        source: row.source,
+        sbomCreatedAt: row.sbom_created_at,
+        imageSizeBytes: parseInt(row.image_size_bytes || '0'),
+        hasAccess: true,
+      })
+    }
+
+    // For image digests not found in the result (no access or doesn't exist),
+    // add them with hasAccess: false
+    for (const digest of digests) {
+      if (!resultMap.has(digest)) {
+        resultMap.set(digest, {
+          digest: digest,
+          arch: null,
+          sbom: null,
+          source: null,
+          sbomCreatedAt: null,
+          imageSizeBytes: 0,
+          hasAccess: false,
+        })
+      }
+    }
+
+    return resultMap
+  } catch (err) {
+    console.error(`getBatchExternalSboms error:`, err)
+    throw err;
+  }
+},
+  {
+    getTags: (teamId: string, digests: string[], arch: string) => ({
+      'args.team_id': teamId,
+      'args.digests.length': digests.length,
+      'args.arch': arch,
+    })
+  })
+
+/**
+ * Batch query to get digests for multiple image reference tags.
+ * Returns an array of digests in the same order as the input imageTags array.
+ * For images that are not found or not accessible to the team, returns undefined.
+ *
+ * @param teamId - Team ID for access validation
+ * @param imageTags - Array of image references (registry, repository, tag)
+ * @returns Array of digests (undefined for not found/inaccessible images)
+ */
+export const getBatchDigestsForTags = traceFunction('lib.externalimage.getBatchDigestsForTags', async (
+  teamId: string,
+  imageTags: ImageRefTag[]
+): Promise<(string | undefined)[]> => {
+  try {
+    const db = getDB(await getParam("DB_URI"))
+
+    if (imageTags.length === 0) {
+      return []
+    }
+
+    // Build arrays for the query
+    const registries = imageTags.map(t => t.registry)
+    const imageNames = imageTags.map(t => t.repository)
+    const tags = imageTags.map(t => t.tag)
+
+    // Single query that:
+    // 1. Uses the primary key (registry, image_name, image_tag) for efficient lookup
+    // 2. Validates team access via external_image_team join
+    // 3. Returns digest for each accessible image tag
+    const query = `
+      SELECT
+        etag.registry,
+        etag.image_name,
+        etag.image_tag,
+        etag.digest
+      FROM external_image_tag etag
+      INNER JOIN external_image_team eteam
+        ON eteam.team_id = $1
+        AND eteam.registry = etag.registry
+        AND eteam.image_name = etag.image_name
+        AND eteam.image_tag = etag.image_tag
+      WHERE (etag.registry, etag.image_name, etag.image_tag) IN (
+        SELECT unnest($2::text[]), unnest($3::text[]), unnest($4::text[])
+      )
+    `
+
+    const result = await db.query(query, [teamId, registries, imageNames, tags])
+
+    // Build a map of "registry/repository:tag" -> digest
+    const resultMap = new Map<string, string>()
+
+    for (const row of result.rows) {
+      const key = `${row.registry}/${row.image_name}:${row.image_tag}`
+      resultMap.set(key, row.digest)
+    }
+
+    const resultArray = []
+
+    // For image tags not found in the result (no access or doesn't exist),
+    // add them with undefined digest
+    for (const imgTag of imageTags) {
+      const key = `${imgTag.registry}/${imgTag.repository}:${imgTag.tag}`
+      resultArray.push(resultMap.get(key));
+    }
+
+    return resultArray
+  } catch (err) {
+    console.error(`getDigestsForImageRefTags error:`, err)
+    throw err;
+  }
+},
+  {
+    getTags: (teamId: string, imageTags: ImageRefTag[]) => ({
+      'args.team_id': teamId,
+      'args.image_tags.length': imageTags.length,
+    })
+  })

--- a/securebuild-api/lib/externalimage/registry.test.ts
+++ b/securebuild-api/lib/externalimage/registry.test.ts
@@ -1,0 +1,181 @@
+import { parseImageRef, getImageDigest } from './registry';
+import { getManifest } from '@snyk/docker-registry-v2-client';
+
+// Mock the Snyk client
+jest.mock('@snyk/docker-registry-v2-client');
+
+describe('parseImageRef', () => {
+  test('should parse docker.io/centrifugo/centrifugo:v6.2.2 correctly', () => {
+    const imageUrl = 'docker.io/centrifugo/centrifugo:v6.2.2';
+    const result = parseImageRef(imageUrl);
+
+    expect(result).toEqual({
+      registry: 'index.docker.io',
+      repository: 'centrifugo/centrifugo',
+      tag: 'v6.2.2'
+    });
+  });
+
+  // Additional test cases for better coverage
+  test('should handle simple Docker Hub image', () => {
+    const result = parseImageRef('nginx:latest');
+    expect(result).toEqual({
+      registry: 'index.docker.io',
+      repository: 'library/nginx',
+      tag: 'latest'
+    });
+  });
+
+  test('should handle image without tag', () => {
+    const result = parseImageRef('nginx');
+    expect(result).toEqual({
+      registry: 'index.docker.io',
+      repository: 'library/nginx',
+      tag: 'latest'
+    });
+  });
+
+  test('should handle private registry', () => {
+    const result = parseImageRef('myregistry.com/myimage:v1.0');
+    expect(result).toEqual({
+      registry: 'myregistry.com',
+      repository: 'myimage',
+      tag: 'v1.0'
+    });
+  });
+
+  test('should handle registry with port', () => {
+    const result = parseImageRef('localhost:5000/myimage:v1.0');
+    expect(result).toEqual({
+      registry: 'localhost:5000',
+      repository: 'myimage',
+      tag: 'v1.0'
+    });
+  });
+
+  test('should handle replicated proxy with content sha', () => {
+    const result = parseImageRef('ec-e2e-proxy.testcluster.net/anonymous/kotsadm/kurl-proxy:v1.125.0-amd64@sha256:569dde755affbb15e55c3941ee19080b4c106e4853596d4f7d975fca92909402');
+    expect(result).toEqual({
+      registry: 'ec-e2e-proxy.testcluster.net',
+      repository: 'anonymous/kotsadm/kurl-proxy',
+      tag: 'v1.125.0-amd64',
+      contentSha: 'sha256:569dde755affbb15e55c3941ee19080b4c106e4853596d4f7d975fca92909402'
+    });
+  });
+
+  test('should handle ubuntu with content sha', () => {
+    const result = parseImageRef('ubuntu@sha256:abc123def456');
+    expect(result).toEqual({
+      registry: 'index.docker.io',
+      repository: 'library/ubuntu',
+      tag: 'latest',
+      contentSha: 'sha256:abc123def456'
+    });
+  });
+
+  test('should handle content sha without tag', () => {
+    const result = parseImageRef('nginx@sha256:123456789abc');
+    expect(result).toEqual({
+      registry: 'index.docker.io',
+      repository: 'library/nginx',
+      tag: 'latest',
+      contentSha: 'sha256:123456789abc'
+    });
+  });
+});
+
+describe('getImageDigest OCI support', () => {
+  const mockedGetManifest = getManifest as jest.MockedFunction<typeof getManifest>;
+  
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation();
+    jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('should pass OCI Accept headers to getManifest', async () => {
+    // Setup: Mock a successful response
+    mockedGetManifest.mockResolvedValue({
+      schemaVersion: 2,
+      mediaType: 'application/vnd.oci.image.manifest.v1+json',
+      config: { mediaType: 'any', size: 1, digest: 'any' },
+      layers: [],
+      manifestDigest: 'sha256:test123'
+    });
+
+    // Act: Call getImageDigest
+    await getImageDigest({
+      registry: 'ghcr.io',
+      repository: 'test/image',
+      tag: 'v1'
+    });
+
+    // Assert: Verify OCI headers were included
+    expect(mockedGetManifest).toHaveBeenCalledWith(
+      'ghcr.io',
+      'test/image',
+      'v1',
+      undefined,
+      undefined,
+      {
+        acceptManifest: expect.stringMatching(/application\/vnd\.oci\.image\.manifest\.v1\+json.*application\/vnd\.oci\.image\.index\.v1\+json/)
+      },
+      undefined
+    );
+  });
+
+  test('should fail without OCI headers when registry requires them', async () => {
+    // Setup: Mock that simulates OCI-only registry behavior
+    mockedGetManifest.mockImplementation(async (reg, repo, ref, u, p, options) => {
+      if (!options?.acceptManifest?.includes('application/vnd.oci.image.manifest.v1+json')) {
+        throw new Error('OCI index found, but Accept header does not support OCI indexes');
+      }
+      return {
+        schemaVersion: 2,
+        mediaType: 'application/vnd.oci.image.manifest.v1+json',
+        config: { mediaType: 'any', size: 1, digest: 'any' },
+        layers: [],
+        manifestDigest: 'sha256:success'
+      };
+    });
+
+    // Act & Assert: Should succeed with our OCI headers
+    const digest = await getImageDigest({
+      registry: 'ghcr.io',
+      repository: 'test/image',
+      tag: 'v1'
+    });
+
+    expect(digest).toBe('sha256:success');
+  });
+
+  test('should use http protocol for local registries', async () => {
+    mockedGetManifest.mockResolvedValue({
+      schemaVersion: 2,
+      mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+      config: { mediaType: 'any', size: 1, digest: 'any' },
+      layers: [],
+      manifestDigest: 'sha256:local123'
+    });
+
+    await getImageDigest({
+      registry: 'localhost:5555',
+      repository: 'test/image',
+      tag: 'v1'
+    });
+
+    expect(mockedGetManifest).toHaveBeenCalledWith(
+      'localhost:5555',
+      'test/image',
+      'v1',
+      undefined,
+      undefined,
+      expect.objectContaining({ protocol: 'http:' }),
+      undefined
+    );
+  });
+});

--- a/securebuild-api/lib/externalimage/registry.ts
+++ b/securebuild-api/lib/externalimage/registry.ts
@@ -1,0 +1,287 @@
+
+import { getManifest } from '@snyk/docker-registry-v2-client';
+import { ECRClient, GetAuthorizationTokenCommand } from '@aws-sdk/client-ecr';
+import { ECRPUBLICClient, GetAuthorizationTokenCommand as GetAuthorizationTokenCommandPublic } from '@aws-sdk/client-ecr-public';
+
+interface ImageRef {
+  registry: string;
+  repository: string;
+  tag: string;
+  contentSha?: string;
+}
+
+interface Credentials {
+  username?: string;
+  password?: string;
+}
+
+function isDockerHub(registry: string): boolean {
+  return registry === 'docker.io' || registry === 'index.docker.io';
+}
+
+// Check if registry is a private ECR endpoint
+function isPrivateECRRegistry(registry: string): boolean {
+  return registry.includes('.dkr.ecr.') && registry.endsWith('.amazonaws.com');
+}
+
+// Check if registry is AWS ECR Public
+function isPublicECRRegistry(registry: string): boolean {
+  return registry === 'public.ecr.aws';
+}
+
+// Check if registry is any type of ECR (private or public)
+function isECRRegistry(registry: string): boolean {
+  return isPrivateECRRegistry(registry) || isPublicECRRegistry(registry);
+}
+
+// Parse ECR endpoint to extract registry ID and region
+function parseECREndpoint(endpoint: string): { registryId: string; region: string } {
+  const parts = endpoint.split('.');
+  if (parts.length < 6 || parts[1] !== 'dkr' || parts[2] !== 'ecr') {
+    throw new Error(`Invalid ECR endpoint format: ${endpoint}`);
+  }
+  return { registryId: parts[0], region: parts[3] };
+}
+
+// Exchange AWS credentials for ECR Public authorization token
+async function getPublicECRCredentials(accessKeyId: string, secretAccessKey: string): Promise<Credentials> {
+  const client = new ECRPUBLICClient({
+    region: 'us-east-1',
+    credentials: {
+      accessKeyId,
+      secretAccessKey,
+    },
+  });
+
+  const command = new GetAuthorizationTokenCommandPublic({});
+  const response = await client.send(command);
+
+  // ECR Public returns authorizationData as an object (not an array)
+  if (!response.authorizationData?.authorizationToken) {
+    throw new Error('No authorization token returned for ECR Public');
+  }
+
+  const decoded = Buffer.from(response.authorizationData.authorizationToken, 'base64').toString('utf-8');
+  const colonIndex = decoded.indexOf(':');
+  if (colonIndex === -1) {
+    throw new Error('Invalid ECR Public token format');
+  }
+  const username = decoded.substring(0, colonIndex);
+  const password = decoded.substring(colonIndex + 1);
+
+  return { username, password };
+}
+
+// Exchange AWS credentials for private ECR authorization token
+async function getPrivateECRCredentials(registry: string, accessKeyId: string, secretAccessKey: string): Promise<Credentials> {
+  const { registryId, region } = parseECREndpoint(registry);
+
+  const client = new ECRClient({
+    region,
+    credentials: {
+      accessKeyId,
+      secretAccessKey,
+    },
+  });
+
+  const command = new GetAuthorizationTokenCommand({
+    registryIds: [registryId],
+  });
+
+  const response = await client.send(command);
+
+  // Private ECR returns authorizationData as an array
+  if (!response.authorizationData || response.authorizationData.length === 0) {
+    throw new Error(`No authorization data returned for private ECR registry ${registry}`);
+  }
+
+  const authToken = response.authorizationData[0]?.authorizationToken;
+  if (!authToken) {
+    throw new Error(`No authorization token in private ECR response for ${registry}`);
+  }
+
+  const decoded = Buffer.from(authToken, 'base64').toString('utf-8');
+  const colonIndex = decoded.indexOf(':');
+  if (colonIndex === -1) {
+    throw new Error('Invalid ECR token format');
+  }
+  const username = decoded.substring(0, colonIndex);
+  const password = decoded.substring(colonIndex + 1);
+
+  return { username, password };
+}
+
+// Exchange AWS credentials for ECR token (wrapper that handles both private and public ECR)
+async function getECRCredentials(registry: string, accessKeyId: string, secretAccessKey: string): Promise<Credentials> {
+  if (isPublicECRRegistry(registry)) {
+    return getPublicECRCredentials(accessKeyId, secretAccessKey);
+  } else {
+    return getPrivateECRCredentials(registry, accessKeyId, secretAccessKey);
+  }
+}
+
+// Get credentials for a registry, exchanging AWS creds for ECR token if needed
+async function getCredentialsForRegistry(registry: string, credentials?: Credentials): Promise<Credentials | undefined> {
+  // If image-specific credentials are provided, use them (even if partial - let auth fail naturally)
+  if (credentials?.username || credentials?.password) {
+    // For ECR registries with complete credentials, exchange AWS credentials for ECR token
+    // Skip if username is "AWS" (already an ECR token)
+    if (isECRRegistry(registry) && credentials.username && credentials.password && credentials.username !== 'AWS') {
+      return getECRCredentials(registry, credentials.username, credentials.password);
+    }
+    return credentials;
+  }
+
+  // Fallback: Use default AWS credentials for public ECR to avoid rate limiting
+  // Only applies when NO image-specific credentials were provided
+  if (isPublicECRRegistry(registry)) {
+    const defaultAccessKeyId = process.env.AWS_ECR_PUBLIC_ACCESS_KEY_ID;
+    const defaultSecretKey = process.env.AWS_ECR_PUBLIC_SECRET_ACCESS_KEY;
+
+    if (defaultAccessKeyId && defaultSecretKey) {
+      console.log('Using default AWS credentials for ECR Public (higher rate limits)');
+      return getECRCredentials(registry, defaultAccessKeyId, defaultSecretKey);
+    }
+  }
+
+  return undefined;
+}
+
+// Check if the first part of a path looks like a registry (has a dot or colon)
+function looksLikeRegistry(part: string): boolean {
+  return part.includes('.') || part.includes(':');
+}
+
+export function parseImageRef(imageUrl: string): ImageRef {
+  let registry = 'index.docker.io';
+  let repository: string;
+  let tag = 'latest';
+  let contentSha: string | undefined;
+
+  // Handle content digest (SHA) if present
+  if (imageUrl.includes('@')) {
+    const atIndex = imageUrl.indexOf('@');
+    contentSha = imageUrl.substring(atIndex + 1);
+    imageUrl = imageUrl.substring(0, atIndex);
+  }
+
+  // Handle tag if present (last colon that's not part of a port)
+  const lastColonIndex = imageUrl.lastIndexOf(':');
+  if (lastColonIndex !== -1) {
+    const afterColon = imageUrl.substring(lastColonIndex + 1);
+    // If afterColon doesn't contain a slash, it's a tag (not a port in registry:port/repo)
+    if (!afterColon.includes('/')) {
+      tag = afterColon;
+      imageUrl = imageUrl.substring(0, lastColonIndex);
+    }
+  }
+
+  // Now split by slash and check if first part is a registry
+  const parts = imageUrl.split('/');
+
+  if (parts.length >= 2 && looksLikeRegistry(parts[0])) {
+    // First part is a registry (e.g., "gcr.io/repo" or "registry:5000/repo")
+    registry = parts[0];
+    repository = parts.slice(1).join('/');
+
+    // Normalize docker.io to index.docker.io
+    if (registry === 'docker.io') {
+      registry = 'index.docker.io';
+    }
+
+    // For Docker Hub, add "library/" prefix for official images (single-part names)
+    if (isDockerHub(registry) && !repository.includes('/')) {
+      repository = `library/${repository}`;
+    }
+  } else if (parts.length === 1 && looksLikeRegistry(parts[0])) {
+    // Just a registry hostname with no repo path - invalid input
+    throw new Error(`Invalid image reference: "${imageUrl}" appears to be a registry hostname. Please include the repository path (e.g., "${imageUrl}/repo/image:tag")`);
+  } else {
+    // No registry specified, use Docker Hub
+    repository = imageUrl;
+
+    // For Docker Hub, add "library/" prefix for official images (single-part names)
+    if (!repository.includes('/')) {
+      repository = `library/${repository}`;
+    }
+  }
+
+  return { registry, repository, tag, contentSha };
+}
+
+// Check if registry is a local address that should use HTTP instead of HTTPS.
+// Local registries (e.g. a Testcontainers registry:3.0.0 on localhost) typically
+// run without TLS, so the registry client must use the http: protocol.
+function isLocalRegistry(registry: string): boolean {
+  const host = registry.split(':')[0];
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1';
+}
+
+export async function getImageDigest(parsed: ImageRef, credentials?: Credentials, hideLogs?: boolean): Promise<string> {
+  console.log(`Getting digest(s) for ${parsed.registry}/${parsed.repository}:${parsed.tag}`);
+
+  try {
+    // Get the manifest reference (SHA or tag)
+    const manifestRef = parsed.contentSha || parsed.tag;
+    console.log(`Fetching manifest for ${parsed.repository}:${manifestRef} from ${parsed.registry}`);
+
+    // Get appropriate credentials (exchange AWS creds for ECR token if needed)
+    const resolvedCredentials = await getCredentialsForRegistry(parsed.registry, credentials);
+    const username = resolvedCredentials?.username;
+    const password = resolvedCredentials?.password;
+
+    if (!hideLogs) {
+      if (username && password) {
+        console.log('Using username/password authentication');
+      } else {
+        console.log('Using anonymous access');
+      }
+    }
+
+    // Local registries run without TLS; instruct the registry client to use HTTP.
+    const requestOptions: Record<string, unknown> = {
+      acceptManifest: [
+        'application/vnd.docker.distribution.manifest.v2+json',
+        'application/vnd.docker.distribution.manifest.list.v2+json',
+        'application/vnd.oci.image.manifest.v1+json',
+        'application/vnd.oci.image.index.v1+json'
+      ].join(', ')
+    };
+    if (isLocalRegistry(parsed.registry)) {
+      requestOptions.protocol = 'http:';
+    }
+
+    // Get the manifest using Snyk client
+    const manifest = await getManifest(
+      parsed.registry,
+      parsed.repository,
+      manifestRef,
+      username,
+      password,
+      requestOptions,
+      undefined
+    );
+    
+    // the index digest is the most inclusive digest that contains all the platform digests
+    if (manifest.indexDigest) {
+      if (!hideLogs) {
+        console.log(`Retrieved index digest: ${manifest.indexDigest}`);
+      }
+      return manifest.indexDigest;
+    }
+    
+    // fallback to the manifest digest if the index digest is not available
+    if (manifest.manifestDigest) {
+      if (!hideLogs) {
+        console.log(`Retrieved digest: ${manifest.manifestDigest}`);
+      }
+      return manifest.manifestDigest;
+    }
+
+    throw new Error('Unable to determine manifest digest');
+  } catch (error) {
+    console.error(`getImageDigest error:`, error);
+    throw new Error(`Failed to get image digest for ${parsed.registry}/${parsed.repository}:${parsed.tag}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+

--- a/securebuild-api/lib/observability/tracing.ts
+++ b/securebuild-api/lib/observability/tracing.ts
@@ -1,0 +1,172 @@
+import type { Span, Tracer } from 'dd-trace';
+
+type Tags = Record<string, unknown>;
+
+type TraceOptions = {
+  resource?: string;
+  tags?: Tags;
+};
+
+type TraceActionOptions<T extends (...args: any[]) => any> = TraceOptions & {
+  getTags?: (...args: Parameters<T>) => Tags | undefined;
+  onResult?: (span: Span, args: Parameters<T>, result: Awaited<ReturnType<T>>) => void;
+};
+
+// Type for a function that has been wrapped with tracing (always returns a Promise)
+type TracedFunction<T extends (...args: any[]) => any> = (
+  ...args: Parameters<T>
+) => Promise<Awaited<ReturnType<T>>>;
+
+function applyTags(span?: Span, tags?: Tags) {
+  if (!span || !tags) return;
+  for (const [key, value] of Object.entries(tags)) {
+    span.setTag(key, value as any);
+  }
+}
+
+// Lazy-load tracer only when tracing is enabled
+// Using undefined to distinguish between "not loaded yet" and "loaded but null"
+let tracerCache: Tracer | null | undefined = undefined;
+
+function getTracer(): Tracer | null {
+  // Return cached result if already loaded (prevents race conditions and multiple initializations)
+  if (tracerCache !== undefined) {
+    return tracerCache;
+  }
+
+  // Check if tracing is enabled at runtime (consistent with datadog/tracer.ts and instrumentation.ts)
+  const rawFlag = String(process.env.DD_ENABLED || '').toLowerCase();
+  const isEnabled = rawFlag === 'true' || rawFlag === '1';
+
+  if (!isEnabled) {
+    tracerCache = null;
+    return null;
+  }
+
+  // Lazy load the tracer module only when needed
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const tracerModule = require('@/datadog/tracer');
+    const tracer = tracerModule.default || tracerModule;
+
+    if (tracer && typeof (tracer as any).trace === 'function') {
+      tracerCache = tracer as Tracer;
+      return tracerCache;
+    }
+  } catch (err) {
+    console.warn('Failed to load tracer:', err);
+  }
+
+  tracerCache = null;
+  return null;
+}
+
+/**
+ * Get the currently active span from the tracer's scope.
+ * This can be used to pass span context to database calls.
+ */
+export function getActiveSpan(): Span | undefined {
+  const activeTracer = getTracer();
+  if (!activeTracer || !activeTracer.scope) {
+    return undefined;
+  }
+  const active = activeTracer.scope().active();
+  return active || undefined;
+}
+
+export async function withTrace<T>(
+  name: string,
+  fn: (span?: Span) => Promise<T> | T,
+  options?: TraceOptions,
+): Promise<T> {
+  const activeTracer = getTracer();
+  if (!activeTracer) {
+    return fn(undefined);
+  }
+
+  return activeTracer.trace(name, { resource: options?.resource }, async (span?: Span) => {
+    if (span) {
+      span.setTag('component', 'application');
+      applyTags(span, options?.tags);
+    }
+    try {
+      const result = await fn(span);
+      return result;
+    } catch (error) {
+      if (span) {
+        span.setTag('error', error as any);
+      }
+      throw error;
+    }
+  });
+}
+
+export function traceServerAction<T extends (...args: any[]) => any>(
+  name: string,
+  fn: T,
+  options?: TraceActionOptions<T>,
+): TracedFunction<T>;
+
+export function traceServerAction<T extends (...args: any[]) => any>(
+  fn: T,
+  options?: TraceActionOptions<T>,
+): TracedFunction<T>;
+
+export function traceServerAction<T extends (...args: any[]) => any>(
+  nameOrFn: string | T,
+  fnOrOptions?: T | TraceActionOptions<T>,
+  maybeOptions?: TraceActionOptions<T>,
+): TracedFunction<T> {
+  let name: string;
+  let fn: T;
+  let options: TraceActionOptions<T> | undefined;
+
+  if (typeof nameOrFn === 'string') {
+    name = nameOrFn;
+    fn = fnOrOptions as T;
+    options = maybeOptions;
+  } else {
+    fn = nameOrFn;
+    options = fnOrOptions as TraceActionOptions<T> | undefined;
+    name = fn.name || 'anonymous';
+  }
+
+  const spanName = name.startsWith('server.action.') ? name : `server.action.${name}`;
+
+  const traced: TracedFunction<T> = async (...args: Parameters<T>) => {
+    const baseTags = options?.getTags?.(...args);
+    return withTrace(spanName, async (span) => {
+      if (span) {
+        span.setTag('component', 'server-action');
+      }
+      applyTags(span, baseTags);
+      const result = await fn(...args);
+      if (span && options?.onResult) {
+        options.onResult(span, args, result as Awaited<ReturnType<T>>);
+      }
+      return result;
+    }, { resource: options?.resource });
+  };
+
+  return traced;
+}
+
+export function traceFunction<T extends (...args: any[]) => any>(
+  name: string,
+  fn: T,
+  options?: TraceActionOptions<T>,
+): TracedFunction<T> {
+  const traced: TracedFunction<T> = async (...args: Parameters<T>) => {
+    const baseTags = options?.getTags?.(...args);
+    return withTrace(name, async (span) => {
+      applyTags(span, baseTags);
+      const result = await fn(...args);
+      if (span && options?.onResult) {
+        options.onResult(span, args, result as Awaited<ReturnType<T>>);
+      }
+      return result;
+    }, options);
+  };
+
+  return traced;
+}

--- a/securebuild-api/lib/sbom/merger.test.ts
+++ b/securebuild-api/lib/sbom/merger.test.ts
@@ -1,0 +1,554 @@
+import { mergeSBOMs, SPDXDocument, SPDXPackage, SPDXRelationship } from './merger';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('SBOM Merger', () => {
+  // Helper function to create a basic SPDX document
+  const createBasicSPDXDocument = (
+    name: string,
+    packages: SPDXPackage[] = [],
+    relationships: SPDXRelationship[] = []
+  ): SPDXDocument => ({
+    SPDXID: 'SPDXRef-DOCUMENT',
+    name,
+    dataLicense: 'CC0-1.0',
+    creationInfo: {
+      created: '2024-01-01T00:00:00Z',
+      creators: ['Tool: test-creator'],
+    },
+    spdxVersion: 'SPDX-2.3',
+    documentNamespace: `https://test.com/${name}`,
+    packages,
+    relationships,
+  });
+
+  // Helper function to create a basic package
+  const createBasicPackage = (
+    name: string,
+    version: string = '1.0.0',
+    spdxId: string = `SPDXRef-${name}`
+  ): SPDXPackage => ({
+    SPDXID: spdxId,
+    name,
+    versionInfo: version,
+    downloadLocation: 'NOASSERTION',
+    filesAnalyzed: false,
+    licenseConcluded: 'NOASSERTION',
+    licenseDeclared: 'NOASSERTION',
+    copyrightText: 'NOASSERTION',
+  });
+
+  describe('mergeSBOMs', () => {
+    it('should return single SBOM when only one is provided', () => {
+      const doc1 = createBasicSPDXDocument('test-doc');
+      const sbomString = JSON.stringify(doc1);
+
+      const result = mergeSBOMs([sbomString]);
+
+      expect(result).toEqual(sbomString);
+    });
+
+    it('should throw error when no SBOMs are provided', () => {
+      expect(() => mergeSBOMs([])).toThrow('No SBOMs provided for merging');
+    });
+
+    it('should throw error when invalid JSON is provided', () => {
+      const validJson = JSON.stringify(createBasicSPDXDocument('valid'));
+      const invalidJson = '{ "name": "test"';
+
+      expect(() => mergeSBOMs([validJson, invalidJson])).toThrow();
+    });
+
+    it('should merge two simple SBOMs successfully', () => {
+      const pkg1 = createBasicPackage('package1', '1.0.0');
+      const pkg2 = createBasicPackage('package2', '2.0.0');
+
+      const doc1 = createBasicSPDXDocument('doc1', [pkg1]);
+      const doc2 = createBasicSPDXDocument('doc2', [pkg2]);
+
+      const result = mergeSBOMs(
+        [JSON.stringify(doc1), JSON.stringify(doc2)],
+      );
+
+      const merged = JSON.parse(result) as SPDXDocument;
+
+      expect(merged.name).toBe('Combined SBOM');
+      expect(merged.packages).toHaveLength(2);
+      expect(merged.packages.map(p => p.name)).toContain('package1');
+      expect(merged.packages.map(p => p.name)).toContain('package2');
+    });
+
+    it('should deduplicate identical packages', () => {
+      const pkg1 = createBasicPackage('duplicate-package', '1.0.0');
+      const pkg2 = createBasicPackage('duplicate-package', '1.0.0');
+
+      const doc1 = createBasicSPDXDocument('doc1', [pkg1]);
+      const doc2 = createBasicSPDXDocument('doc2', [pkg2]);
+
+      const result = mergeSBOMs(
+        [JSON.stringify(doc1), JSON.stringify(doc2)],
+      );
+
+      const merged = JSON.parse(result) as SPDXDocument;
+
+      expect(merged.packages).toHaveLength(1);
+      expect(merged.packages[0].name).toBe('duplicate-package');
+    });
+
+    it('should merge packages with same name but different versions', () => {
+      const pkg1 = createBasicPackage('same-name', '1.0.0');
+      const pkg2 = createBasicPackage('same-name', '2.0.0');
+
+      const doc1 = createBasicSPDXDocument('doc1', [pkg1]);
+      const doc2 = createBasicSPDXDocument('doc2', [pkg2]);
+
+      const result = mergeSBOMs(
+        [JSON.stringify(doc1), JSON.stringify(doc2)],
+      );
+
+      const merged = JSON.parse(result) as SPDXDocument;
+
+      expect(merged.packages).toHaveLength(2);
+      const packageNames = merged.packages.map(p => `${p.name}:${p.versionInfo}`);
+      expect(packageNames).toContain('same-name:1.0.0');
+      expect(packageNames).toContain('same-name:2.0.0');
+    });
+
+    it('should merge external references from duplicate packages', () => {
+      const pkg1 = createBasicPackage('test-package', '1.0.0');
+      pkg1.externalRefs = [
+        {
+          referenceCategory: 'PACKAGE-MANAGER',
+          referenceType: 'purl',
+          referenceLocator: 'pkg:npm/test-package@1.0.0',
+        }
+      ];
+
+      const pkg2 = createBasicPackage('test-package', '1.0.0');
+      pkg2.externalRefs = [
+        {
+          referenceCategory: 'PACKAGE-MANAGER',
+          referenceType: 'purl',
+          referenceLocator: 'pkg:npm/test-package@1.0.0',
+        },
+        {
+          referenceCategory: 'OTHER',
+          referenceType: 'website',
+          referenceLocator: 'https://example.com',
+        }
+      ];
+
+      const doc1 = createBasicSPDXDocument('doc1', [pkg1]);
+      const doc2 = createBasicSPDXDocument('doc2', [pkg2]);
+
+      const result = mergeSBOMs(
+        [JSON.stringify(doc1), JSON.stringify(doc2)],
+      );
+
+      const merged = JSON.parse(result) as SPDXDocument;
+
+      expect(merged.packages).toHaveLength(1);
+      expect(merged.packages[0].externalRefs).toHaveLength(2);
+    });
+
+    it('should handle packages with different SPDX IDs correctly', () => {
+      const pkg1 = createBasicPackage('package1', '1.0.0', 'SPDXRef-Package-1');
+      const pkg2 = createBasicPackage('package2', '2.0.0', 'SPDXRef-Package-2');
+
+      const doc1 = createBasicSPDXDocument('doc1', [pkg1]);
+      const doc2 = createBasicSPDXDocument('doc2', [pkg2]);
+
+      const result = mergeSBOMs(
+        [JSON.stringify(doc1), JSON.stringify(doc2)],
+      );
+
+      const merged = JSON.parse(result) as SPDXDocument;
+
+      expect(merged.packages).toHaveLength(2);
+      expect(merged.packages[0].SPDXID).toMatch(/^SPDXRef-Doc\d+-/);
+      expect(merged.packages[1].SPDXID).toMatch(/^SPDXRef-Doc\d+-/);
+      expect(merged.packages[0].SPDXID).not.toEqual(merged.packages[1].SPDXID);
+    });
+
+    it('should merge relationships with updated SPDX IDs', () => {
+      const pkg1 = createBasicPackage('package1', '1.0.0', 'SPDXRef-Package1');
+      const rel1: SPDXRelationship = {
+        spdxElementId: 'SPDXRef-DOCUMENT',
+        relationshipType: 'DESCRIBES',
+        relatedSpdxElement: 'SPDXRef-Package1',
+      };
+
+      const doc1 = createBasicSPDXDocument('doc1', [pkg1], [rel1]);
+      const doc2 = createBasicSPDXDocument('doc2', []);
+
+      const result = mergeSBOMs(
+        [JSON.stringify(doc1), JSON.stringify(doc2)],
+      );
+
+      const merged = JSON.parse(result) as SPDXDocument;
+
+      expect(merged.relationships).toHaveLength(1);
+      expect(merged.relationships[0].relationshipType).toBe('DESCRIBES');
+      expect(merged.relationships[0].relatedSpdxElement).toMatch(/^SPDXRef-Doc\d+-Package1$/);
+    });
+
+    it('should handle license information merging', () => {
+      const pkg1 = createBasicPackage('test-package', '1.0.0');
+      pkg1.licenseConcluded = 'MIT';
+      pkg1.licenseDeclared = 'NOASSERTION';
+
+      const pkg2 = createBasicPackage('test-package', '1.0.0');
+      pkg2.licenseConcluded = 'NOASSERTION';
+      pkg2.licenseDeclared = 'Apache-2.0';
+
+      const doc1 = createBasicSPDXDocument('doc1', [pkg1]);
+      const doc2 = createBasicSPDXDocument('doc2', [pkg2]);
+
+      const result = mergeSBOMs(
+        [JSON.stringify(doc1), JSON.stringify(doc2)],
+      );
+
+      const merged = JSON.parse(result) as SPDXDocument;
+
+      expect(merged.packages).toHaveLength(1);
+      expect(merged.packages[0].licenseConcluded).toBe('MIT');
+      expect(merged.packages[0].licenseDeclared).toBe('Apache-2.0');
+    });
+
+    it('should create external document references', () => {
+      const doc1 = createBasicSPDXDocument('doc1');
+      const doc2 = createBasicSPDXDocument('doc2');
+
+      const result = mergeSBOMs(
+        [JSON.stringify(doc1), JSON.stringify(doc2)],
+      );
+
+      const merged = JSON.parse(result) as SPDXDocument;
+
+      expect(merged.externalDocumentRefs).toHaveLength(2);
+      expect(merged.externalDocumentRefs?.[0].externalDocumentId).toMatch(/^DocumentRef-Doc\d+$/);
+      expect(merged.externalDocumentRefs?.[1].externalDocumentId).toMatch(/^DocumentRef-Doc\d+$/);
+    });
+
+    it('should handle checksums merging', () => {
+      const pkg1 = createBasicPackage('test-package', '1.0.0');
+      pkg1.checksums = [
+        { algorithm: 'SHA1', checksumValue: 'abc123' }
+      ];
+
+      const pkg2 = createBasicPackage('test-package', '1.0.0');
+      pkg2.checksums = [
+        { algorithm: 'SHA256', checksumValue: 'def456' }
+      ];
+
+      const doc1 = createBasicSPDXDocument('doc1', [pkg1]);
+      const doc2 = createBasicSPDXDocument('doc2', [pkg2]);
+
+      const result = mergeSBOMs(
+        [JSON.stringify(doc1), JSON.stringify(doc2)],
+      );
+
+      const merged = JSON.parse(result) as SPDXDocument;
+
+      expect(merged.packages).toHaveLength(1);
+      expect(merged.packages[0].checksums).toHaveLength(2);
+      expect(merged.packages[0].checksums).toContainEqual({ algorithm: 'SHA1', checksumValue: 'abc123' });
+      expect(merged.packages[0].checksums).toContainEqual({ algorithm: 'SHA256', checksumValue: 'def456' });
+    });
+
+    it('should not duplicate identical checksums', () => {
+      const pkg1 = createBasicPackage('test-package', '1.0.0');
+      pkg1.checksums = [
+        { algorithm: 'SHA1', checksumValue: 'abc123' }
+      ];
+
+      const pkg2 = createBasicPackage('test-package', '1.0.0');
+      pkg2.checksums = [
+        { algorithm: 'SHA1', checksumValue: 'abc123' }
+      ];
+
+      const doc1 = createBasicSPDXDocument('doc1', [pkg1]);
+      const doc2 = createBasicSPDXDocument('doc2', [pkg2]);
+
+      const result = mergeSBOMs(
+        [JSON.stringify(doc1), JSON.stringify(doc2)],
+      );
+
+      const merged = JSON.parse(result) as SPDXDocument;
+
+      expect(merged.packages).toHaveLength(1);
+      expect(merged.packages[0].checksums).toHaveLength(1);
+      expect(merged.packages[0].checksums?.[0]).toEqual({ algorithm: 'SHA1', checksumValue: 'abc123' });
+    });
+
+    it('should handle package manager external references for deduplication', () => {
+      const pkg1 = createBasicPackage('lodash', '4.17.21');
+      pkg1.externalRefs = [
+        {
+          referenceCategory: 'PACKAGE-MANAGER',
+          referenceType: 'purl',
+          referenceLocator: 'pkg:npm/lodash@4.17.21',
+        }
+      ];
+
+      const pkg2 = createBasicPackage('lodash', '4.17.21');
+      pkg2.externalRefs = [
+        {
+          referenceCategory: 'PACKAGE-MANAGER',
+          referenceType: 'purl',
+          referenceLocator: 'pkg:npm/lodash@4.17.21',
+        }
+      ];
+
+      const doc1 = createBasicSPDXDocument('doc1', [pkg1]);
+      const doc2 = createBasicSPDXDocument('doc2', [pkg2]);
+
+      const result = mergeSBOMs(
+        [JSON.stringify(doc1), JSON.stringify(doc2)],
+      );
+
+      const merged = JSON.parse(result) as SPDXDocument;
+
+      expect(merged.packages).toHaveLength(1);
+      expect(merged.packages[0].name).toBe('lodash');
+      expect(merged.packages[0].versionInfo).toBe('4.17.21');
+    });
+
+    it('should preserve document describes relationships', () => {
+      const pkg1 = createBasicPackage('package1', '1.0.0');
+      const pkg2 = createBasicPackage('package2', '2.0.0');
+
+      const doc1 = createBasicSPDXDocument('doc1', [pkg1]);
+      const doc2 = createBasicSPDXDocument('doc2', [pkg2]);
+
+      const result = mergeSBOMs(
+        [JSON.stringify(doc1), JSON.stringify(doc2)],
+      );
+
+      const merged = JSON.parse(result) as SPDXDocument;
+
+      expect(merged.documentDescribes).toHaveLength(2);
+      expect(merged.documentDescribes?.every(id => id.startsWith('SPDXRef-Doc'))).toBe(true);
+    });
+
+    it('should generate valid creation info for merged document', () => {
+      const doc1 = createBasicSPDXDocument('doc1');
+      const doc2 = createBasicSPDXDocument('doc2');
+
+      const result = mergeSBOMs(
+        [JSON.stringify(doc1), JSON.stringify(doc2)],
+      );
+
+      const merged = JSON.parse(result) as SPDXDocument;
+
+      expect(merged.creationInfo.creators).toEqual(['Tool: SecureBuild SBOM Merger']);
+      expect(merged.creationInfo.created).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+      expect(merged.documentNamespace).toMatch(/^https:\/\/securebuild\.io\/merged-sbom\/\d+$/);
+    });
+
+    it('should handle complex merging scenario with many packages', () => {
+      const packages1 = [
+        createBasicPackage('react', '18.2.0'),
+        createBasicPackage('lodash', '4.17.21'),
+        createBasicPackage('express', '4.18.2'),
+      ];
+
+      const packages2 = [
+        createBasicPackage('lodash', '4.17.21'), // duplicate
+        createBasicPackage('axios', '1.4.0'),
+        createBasicPackage('moment', '2.29.4'),
+      ];
+
+      const packages3 = [
+        createBasicPackage('react', '18.3.0'), // different version
+        createBasicPackage('typescript', '5.1.6'),
+      ];
+
+      const doc1 = createBasicSPDXDocument('doc1', packages1);
+      const doc2 = createBasicSPDXDocument('doc2', packages2);
+      const doc3 = createBasicSPDXDocument('doc3', packages3);
+
+      const result = mergeSBOMs(
+        [JSON.stringify(doc1), JSON.stringify(doc2), JSON.stringify(doc3)],
+      );
+
+      const merged = JSON.parse(result) as SPDXDocument;
+
+      expect(merged.packages).toHaveLength(7); // 8 total - 1 duplicate lodash
+
+      const packageIdentifiers = merged.packages.map(p => `${p.name}:${p.versionInfo}`);
+      expect(packageIdentifiers).toContain('react:18.2.0');
+      expect(packageIdentifiers).toContain('react:18.3.0');
+      expect(packageIdentifiers).toContain('lodash:4.17.21');
+      expect(packageIdentifiers).toContain('express:4.18.2');
+      expect(packageIdentifiers).toContain('axios:1.4.0');
+      expect(packageIdentifiers).toContain('moment:2.29.4');
+      expect(packageIdentifiers).toContain('typescript:5.1.6');
+
+      // Should only have one lodash package
+      const lodashPackages = merged.packages.filter(p => p.name === 'lodash');
+      expect(lodashPackages).toHaveLength(1);
+    });
+
+    it('should merge real test SBOMs from testdata directory', () => {
+      // Read the test SBOM files
+      const testDataDir = path.join(__dirname, 'testdata');
+      const alpineSbomPath = path.join(testDataDir, 'alpine-latest.sbom');
+      const helloWorldSbomPath = path.join(testDataDir, 'hello-world-latest.sbom');
+
+      const alpineSbom = fs.readFileSync(alpineSbomPath, 'utf8');
+      const helloWorldSbom = fs.readFileSync(helloWorldSbomPath, 'utf8');
+
+      // Merge the SBOMs
+      const result = mergeSBOMs(
+        [alpineSbom, helloWorldSbom],
+      );
+
+      const merged = JSON.parse(result) as SPDXDocument;
+
+      // Validate the merged document structure
+      expect(merged.name).toBe('Combined SBOM');
+      expect(merged.SPDXID).toBe('SPDXRef-DOCUMENT');
+      expect(merged.spdxVersion).toBe('SPDX-2.3');
+      expect(merged.dataLicense).toBe('CC0-1.0');
+
+      // Validate that packages from both SBOMs are present
+      expect(merged.packages.length).toBeGreaterThan(0);
+
+      // The alpine SBOM should contribute packages like these common Alpine Linux packages
+      const mergedPackageNames = merged.packages.map(p => p.name);
+      expect(mergedPackageNames).toContain('alpine-baselayout');
+      expect(mergedPackageNames).toContain('busybox');
+      expect(mergedPackageNames).toContain('musl');
+      expect(mergedPackageNames).toContain('ca-certificates-bundle');
+      expect(mergedPackageNames).toContain('scanelf');
+      expect(mergedPackageNames).toContain('ssl_client');
+      expect(mergedPackageNames).toContain('zlib');
+      expect(mergedPackageNames).toContain('index.docker.io/library/alpine');
+
+      // the hello-world SBOM should contribute the hello-world image package (it's very small)
+      expect(mergedPackageNames).toContain('index.docker.io/library/hello-world');
+
+      // Validate that SPDX IDs have been updated with doc prefixes
+      const packageIds = merged.packages.map(p => p.SPDXID);
+      expect(packageIds.every(id => id.startsWith('SPDXRef-Doc'))).toBe(true);
+
+      // Validate external document references are created
+      expect(merged.externalDocumentRefs).toHaveLength(2);
+      expect(merged.externalDocumentRefs?.[0].externalDocumentId).toMatch(/^DocumentRef-Doc\d+$/);
+      expect(merged.externalDocumentRefs?.[1].externalDocumentId).toMatch(/^DocumentRef-Doc\d+$/);
+
+      // Validate creation info
+      expect(merged.creationInfo.creators).toEqual(['Tool: SecureBuild SBOM Merger']);
+      expect(merged.creationInfo.created).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+      expect(merged.documentNamespace).toMatch(/^https:\/\/securebuild\.io\/merged-sbom\/\d+$/);
+
+      // Validate documentDescribes contains references to packages from both documents
+      expect(merged.documentDescribes?.length).toBeGreaterThan(0);
+      expect(merged.documentDescribes?.every(id => id.startsWith('SPDXRef-Doc'))).toBe(true);
+
+      console.log(`Merged SBOM contains ${merged.packages.length} packages from both alpine and hello-world images`);
+    });
+
+    it('should merge four real SBOMs with proper deduplication', () => {
+      // Read SBOM files - use alpine-latest twice to force deduplication
+      const testDataDir = path.join(__dirname, 'testdata');
+      const alpineLatestSbomPath = path.join(testDataDir, 'alpine-latest.sbom');
+      const alpine321SbomPath = path.join(testDataDir, 'alpine-321.sbom');
+      const helloWorldSbomPath = path.join(testDataDir, 'hello-world-latest.sbom');
+
+      const alpineLatestSbom = fs.readFileSync(alpineLatestSbomPath, 'utf8');
+      const alpine321Sbom = fs.readFileSync(alpine321SbomPath, 'utf8');
+      const helloWorldSbom = fs.readFileSync(helloWorldSbomPath, 'utf8');
+
+      // Parse original SBOMs to count packages before merging
+      const alpineLatestDoc = JSON.parse(alpineLatestSbom) as SPDXDocument;
+      const alpine321Doc = JSON.parse(alpine321Sbom) as SPDXDocument;
+      const helloWorldDoc = JSON.parse(helloWorldSbom) as SPDXDocument;
+
+      // Use alpine-latest SBOM twice to demonstrate deduplication
+      const totalOriginalPackages = alpineLatestDoc.packages.length + alpineLatestDoc.packages.length + alpine321Doc.packages.length + helloWorldDoc.packages.length;
+
+      // Merge all four SBOMs (alpine-latest is included twice to force deduplication)
+      const result = mergeSBOMs(
+        [alpineLatestSbom, alpineLatestSbom, alpine321Sbom, helloWorldSbom],
+      );
+
+      const merged = JSON.parse(result) as SPDXDocument;
+
+      // Validate the merged document structure
+      expect(merged.name).toBe('Combined SBOM');
+      expect(merged.SPDXID).toBe('SPDXRef-DOCUMENT');
+      expect(merged.spdxVersion).toBe('SPDX-2.3');
+      expect(merged.dataLicense).toBe('CC0-1.0');
+
+      // Validate that packages from all SBOMs are present (the sum should be greater than any individual SBOM)
+      expect(merged.packages.length).toBeGreaterThan(alpineLatestDoc.packages.length);
+      expect(merged.packages.length).toBeGreaterThan(alpine321Doc.packages.length);
+      expect(merged.packages.length).toBeGreaterThan(helloWorldDoc.packages.length);
+
+      // Since alpine-latest is included twice, deduplication should occur
+      // The merged SBOM should have fewer packages than the sum of all four
+      expect(merged.packages.length).toBeLessThan(totalOriginalPackages);
+
+      // Validate that common Alpine packages are present
+      const mergedPackageNames = merged.packages.map(p => p.name);
+      expect(mergedPackageNames).toContain('alpine-baselayout');
+      expect(mergedPackageNames).toContain('busybox');
+      expect(mergedPackageNames).toContain('musl');
+      expect(mergedPackageNames).toContain('ca-certificates-bundle');
+
+      // Validate that all three image packages are present
+      expect(mergedPackageNames).toContain('index.docker.io/library/alpine');
+      expect(mergedPackageNames).toContain('index.docker.io/library/hello-world');
+
+      // Validate that SPDX IDs have been updated with doc prefixes
+      const packageIds = merged.packages.map(p => p.SPDXID);
+      expect(packageIds.every(id => id.startsWith('SPDXRef-Doc'))).toBe(true);
+
+      // Validate external document references are created for all three documents
+      expect(merged.externalDocumentRefs).toHaveLength(3);
+      expect(merged.externalDocumentRefs?.every(ref =>
+        ref.externalDocumentId.match(/^DocumentRef-Doc\d+$/)
+      )).toBe(true);
+
+      // Validate creation info
+      expect(merged.creationInfo.creators).toEqual(['Tool: SecureBuild SBOM Merger']);
+      expect(merged.creationInfo.created).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+      expect(merged.documentNamespace).toMatch(/^https:\/\/securebuild\.io\/merged-sbom\/\d+$/);
+
+      // Check for specific packages that should definitely be deduplicated
+      // These packages exist in alpine-latest (which we included twice) and should appear exactly once
+      const alpineLatestPackageNames = alpineLatestDoc.packages.map(p => p.name);
+      const packagesToCheck = ['alpine-baselayout', 'busybox', 'musl']; // Known to exist in alpine-latest
+
+      packagesToCheck.forEach(packageName => {
+        if (alpineLatestPackageNames.includes(packageName)) {
+          const packagesWithName = merged.packages.filter(p => p.name === packageName);
+
+          // Should have at least 1 instance (from alpine-latest deduplication)
+          expect(packagesWithName.length).toBeGreaterThanOrEqual(1);
+
+          // Should have at most 2 instances (from alpine-latest and alpine-321)
+          expect(packagesWithName.length).toBeLessThanOrEqual(2);
+
+          // If alpine-321 has a different version of the same package, we might have 2 total
+          // But the alpine-latest duplicates should definitely be merged into 1
+          const fromAlpineLatest = merged.packages.filter(p =>
+            p.name === packageName && p.SPDXID.startsWith('SPDXRef-Doc0-')
+          );
+          expect(fromAlpineLatest).toHaveLength(1); // Exactly one from the first alpine-latest
+
+          // Should NOT have any from the duplicate alpine-latest (Doc1)
+          const fromDuplicateAlpineLatest = merged.packages.filter(p =>
+            p.name === packageName && p.SPDXID.startsWith('SPDXRef-Doc1-')
+          );
+          expect(fromDuplicateAlpineLatest).toHaveLength(0); // Should be deduplicated
+        }
+      });
+
+      console.log(`Merged SBOM contains ${merged.packages.length} packages from alpine:latest-1 (${alpineLatestDoc.packages.length}), alpine:latest-2 (${alpineLatestDoc.packages.length}), alpine:3.21 (${alpine321Doc.packages.length}), and hello-world (${helloWorldDoc.packages.length})`);
+      console.log(`Deduplication saved ${totalOriginalPackages - merged.packages.length} duplicate packages`);
+    });
+  });
+});

--- a/securebuild-api/lib/sbom/merger.ts
+++ b/securebuild-api/lib/sbom/merger.ts
@@ -1,0 +1,410 @@
+/**
+ * SBOM Merger - Merges multiple SPDX SBOM documents into a single combined document
+ */
+
+import { createHash } from 'crypto';
+
+export interface ExtractedLicensingInfo {
+  licenseId: string;
+  extractedText: string;
+  name?: string;
+  crossRefs?: string[];
+  comment?: string;
+}
+
+export interface SPDXDocument {
+  SPDXID: string;
+  name: string;
+  dataLicense: string;
+  creationInfo: CreationInfo;
+  packages: SPDXPackage[];
+  relationships: SPDXRelationship[];
+  documentNamespace: string;
+  spdxVersion: string;
+  documentDescribes?: string[];
+  externalDocumentRefs?: ExternalDocumentRef[];
+  files?: SPDXFile[];
+  snippets?: SPDXSnippet[];
+  annotations?: SPDXAnnotation[];
+  hasExtractedLicensingInfos?: ExtractedLicensingInfo[];
+  // reviewInformation is deprecated in SPDX 2.3
+}
+
+export interface CreationInfo {
+  created: string;
+  creators: string[];
+  licenseListVersion?: string;
+}
+
+export interface SPDXPackage {
+  SPDXID: string;
+  name: string;
+  downloadLocation: string;
+  filesAnalyzed: boolean;
+  externalRefs?: ExternalRef[];
+  licenseConcluded?: string;
+  licenseDeclared?: string;
+  copyrightText?: string;
+  versionInfo?: string;
+  supplier?: string;
+  originator?: string;
+  packageFileName?: string;
+  packageVerificationCode?: VerificationCode;
+  checksums?: CheckSum[];
+  homepage?: string;
+  sourceInfo?: string;
+  summary?: string;
+  description?: string;
+  comment?: string;
+  attributionTexts?: string[];
+}
+
+export interface ExternalRef {
+  referenceCategory: string;
+  referenceType: string;
+  referenceLocator: string;
+  comment?: string;
+}
+
+export interface VerificationCode {
+  packageVerificationCodeValue: string;
+  packageVerificationCodeExcludedFiles?: string[];
+}
+
+export interface CheckSum {
+  algorithm: string;
+  checksumValue: string;
+}
+
+export interface SPDXRelationship {
+  spdxElementId: string;
+  relationshipType: string;
+  relatedSpdxElement: string;
+  comment?: string;
+}
+
+export interface ExternalDocumentRef {
+  externalDocumentId: string;
+  spdxDocument: string;
+  checksum: CheckSum;
+}
+
+export interface SPDXFile {
+  SPDXID: string;
+  fileName: string;
+  checksums?: CheckSum[];
+  licenseConcluded?: string;
+  copyrightText?: string;
+  comment?: string;
+}
+
+export interface SPDXSnippet {
+  SPDXID: string;
+  snippetFromFile: string;
+  ranges?: SPDXSnippetRange[];
+  licenseConcluded?: string;
+  copyrightText?: string;
+  comment?: string;
+  name?: string;
+  snippetAttributionTexts?: string[];
+}
+
+export interface SPDXSnippetRange {
+  startPointer: SPDXSnippetPointer;
+  endPointer: SPDXSnippetPointer;
+}
+
+export interface SPDXSnippetPointer {
+  offset?: number;
+  lineNumber?: number;
+  reference: string;
+}
+
+export interface SPDXAnnotation {
+  spdxElementId: string;
+  annotationType: string;
+  annotator: string;
+  annotationDate: string;
+  annotationComment: string;
+}
+
+/**
+ * Merges multiple SBOM JSON strings into a single combined SBOM
+ */
+export function mergeSBOMs(sbomStrings: string[]): string {
+  if (sbomStrings.length === 0) {
+    throw new Error('No SBOMs provided for merging');
+  }
+
+  if (sbomStrings.length === 1) {
+    // Single SBOM, return as-is
+    return sbomStrings[0];
+  }
+
+  console.log(`Merging ${sbomStrings.length} SBOMs`);
+
+  const sbomDocs: SPDXDocument[] = [];
+  
+  // Parse all SBOM documents
+  for (let i = 0; i < sbomStrings.length; i++) {
+    try {
+      const doc = JSON.parse(sbomStrings[i]) as SPDXDocument;
+      sbomDocs.push(doc);
+    } catch (error) {
+      console.warn(`Failed to parse SBOM document ${i}:`, error);
+      throw new Error(`Failed to parse SBOM document ${i}: ${error}`);
+    }
+  }
+
+  // Create merged document
+  const merged = createMergedDocument(sbomDocs);
+
+  // Convert back to JSON
+  const mergedJSON = JSON.stringify(merged, null, 2);
+
+  console.log(`Successfully merged SBOMs - Total packages: ${merged.packages.length}, Total relationships: ${merged.relationships.length}`);
+
+  return mergedJSON;
+}
+
+/**
+ * Creates a new merged SPDX document from multiple input documents
+ */
+function createMergedDocument(docs: SPDXDocument[]): SPDXDocument {
+  const now = new Date().toISOString();
+  
+  const merged: SPDXDocument = {
+    SPDXID: 'SPDXRef-DOCUMENT',
+    name: 'Combined SBOM',
+    dataLicense: 'CC0-1.0',
+    creationInfo: {
+      created: now,
+      creators: ['Tool: SecureBuild SBOM Merger'],
+    },
+    spdxVersion: 'SPDX-2.3',
+    documentNamespace: `https://securebuild.io/merged-sbom/${Date.now()}`,
+    packages: [],
+    relationships: [],
+    documentDescribes: [],
+    externalDocumentRefs: [],
+    files: [],
+    snippets: [],
+    annotations: [],
+    hasExtractedLicensingInfos: [],
+  };
+
+  const packageMap = new Map<string, SPDXPackage>(); // key: packageId, value: package
+  const relationshipSet = new Map<string, SPDXRelationship>(); // key: serialized relationship, value: relationship
+  const externalDocRefs = new Map<string, ExternalDocumentRef>();
+  const allFiles = new Map<string, SPDXFile>();
+  const allSnippets = new Map<string, SPDXSnippet>();
+  const allAnnotations = new Map<string, SPDXAnnotation>();
+  const allExtractedLicensingInfo = new Map<string, ExtractedLicensingInfo>();
+  const spdxIdMapping = new Map<string, string>(); // Maps original SPDX IDs to final merged SPDX IDs
+
+  // Merge packages, avoiding duplicates
+  docs.forEach((doc, docIndex) => {
+    const docPrefix = `Doc${docIndex}`;
+    
+    // Add external document reference
+    if (doc.documentNamespace) {
+      // Generate a proper checksum based on the document namespace
+      const hash = createHash('sha1').update(doc.documentNamespace).digest('hex');
+      
+      externalDocRefs.set(doc.documentNamespace, {
+        externalDocumentId: `DocumentRef-${docPrefix}`,
+        spdxDocument: doc.documentNamespace,
+        checksum: {
+          algorithm: 'SHA1',
+          checksumValue: hash,
+        },
+      });
+    }
+
+    doc.packages.forEach(pkg => {
+      // First, create the package with prefixed SPDX ID
+      const newPkg = {
+        ...pkg,
+        SPDXID: `SPDXRef-${docPrefix}-${pkg.SPDXID.replace(/^SPDXRef-/, '')}`,
+      };
+      
+      // Create a unique package identifier based on name, version, and transformed SPDX ID
+      const packageKey = createPackageKey(newPkg);
+      
+      const existingPkg = packageMap.get(packageKey);
+      if (existingPkg) {
+        // Package already exists, merge external refs and other metadata
+        const mergedPkg = mergePackages(existingPkg, newPkg);
+        packageMap.set(packageKey, mergedPkg);
+        
+        // Map the new package's SPDX ID to the existing package's SPDX ID
+        spdxIdMapping.set(newPkg.SPDXID, existingPkg.SPDXID);
+      } else {
+        // New package, add to map
+        packageMap.set(packageKey, newPkg);
+        // Map the package's SPDX ID to itself (no change)
+        spdxIdMapping.set(newPkg.SPDXID, newPkg.SPDXID);
+      }
+    });
+
+    // Merge relationships with updated SPDX IDs
+    doc.relationships.forEach(rel => {
+      const newRel: SPDXRelationship = {
+        spdxElementId: resolveFinalSPDXID(rel.spdxElementId, docPrefix, doc.SPDXID, spdxIdMapping),
+        relationshipType: rel.relationshipType,
+        relatedSpdxElement: resolveFinalSPDXID(rel.relatedSpdxElement, docPrefix, doc.SPDXID, spdxIdMapping),
+        comment: rel.comment,
+      };
+      
+      const relKey = `${newRel.spdxElementId}-${newRel.relationshipType}-${newRel.relatedSpdxElement}`;
+      relationshipSet.set(relKey, newRel);
+    });
+
+    // Merge other collections
+    doc.files?.forEach(file => {
+      const newFile = {
+        ...file,
+        SPDXID: `SPDXRef-${docPrefix}-${file.SPDXID.replace(/^SPDXRef-/, '')}`,
+      };
+      allFiles.set(newFile.SPDXID, newFile);
+    });
+
+    doc.snippets?.forEach(snippet => {
+      const newSnippet = {
+        ...snippet,
+        SPDXID: `SPDXRef-${docPrefix}-${snippet.SPDXID.replace(/^SPDXRef-/, '')}`,
+      };
+      allSnippets.set(newSnippet.SPDXID, newSnippet);
+    });
+
+    doc.annotations?.forEach(annotation => {
+      const newAnnotation = {
+        ...annotation,
+        spdxElementId: updateSPDXID(annotation.spdxElementId, docPrefix, doc.SPDXID),
+      };
+      allAnnotations.set(`${newAnnotation.spdxElementId}-${newAnnotation.annotationDate}`, newAnnotation);
+    });
+
+    // Merge extracted licensing info, deduplicating by licenseId (case-insensitive)
+    doc.hasExtractedLicensingInfos?.forEach((licenseInfo: ExtractedLicensingInfo) => {
+      // Use lowercase licenseId as key for case-insensitive deduplication
+      const normalizedKey = licenseInfo.licenseId.toLowerCase();
+      
+      // Only add if we haven't seen this license (case-insensitive) before
+      if (!allExtractedLicensingInfo.has(normalizedKey)) {
+        allExtractedLicensingInfo.set(normalizedKey, licenseInfo);
+      }
+    });
+
+    // reviewInformation is deprecated in SPDX 2.3
+  });
+
+  // Convert maps back to arrays
+  merged.packages = Array.from(packageMap.values());
+  merged.relationships = Array.from(relationshipSet.values());
+  merged.externalDocumentRefs = Array.from(externalDocRefs.values());
+  merged.files = Array.from(allFiles.values());
+  merged.snippets = Array.from(allSnippets.values());
+  merged.annotations = Array.from(allAnnotations.values());
+  merged.hasExtractedLicensingInfos = Array.from(allExtractedLicensingInfo.values());
+
+  // Add document describes relationships for the merged packages
+  merged.documentDescribes = merged.packages
+    .filter(pkg => pkg.SPDXID !== 'SPDXRef-DOCUMENT')
+    .map(pkg => pkg.SPDXID);
+
+  return merged;
+}
+
+/**
+ * Creates a unique key for a package based on its identifying characteristics
+ */
+function createPackageKey(pkg: SPDXPackage): string {
+  // Use name, version, and primary external ref (like package manager info) as key
+  let key = `${pkg.name}:${pkg.versionInfo || ''}`;
+  
+  // Add primary external reference for more specificity
+  const primaryRef = pkg.externalRefs?.find(ref => 
+    ref.referenceCategory === 'PACKAGE-MANAGER' || ref.referenceCategory === 'PACKAGE_MANAGER'
+  );
+  
+  if (primaryRef) {
+    key += `:${primaryRef.referenceType}:${primaryRef.referenceLocator}`;
+  }
+  
+  return key;
+}
+
+/**
+ * Merges two packages with the same key, combining their metadata
+ */
+function mergePackages(existing: SPDXPackage, newPkg: SPDXPackage): SPDXPackage {
+  const merged = { ...existing };
+  
+  // Merge external references, avoiding duplicates
+  const existingRefKeys = new Set(
+    existing.externalRefs?.map(ref => `${ref.referenceCategory}:${ref.referenceType}:${ref.referenceLocator}`) || []
+  );
+  
+  const newRefs = newPkg.externalRefs?.filter(ref => {
+    const key = `${ref.referenceCategory}:${ref.referenceType}:${ref.referenceLocator}`;
+    return !existingRefKeys.has(key);
+  }) || [];
+  
+  merged.externalRefs = [...(existing.externalRefs || []), ...newRefs];
+  
+  // Merge checksums
+  const existingChecksumKeys = new Set(
+    existing.checksums?.map(checksum => `${checksum.algorithm}:${checksum.checksumValue}`) || []
+  );
+  
+  const newChecksums = newPkg.checksums?.filter(checksum => {
+    const key = `${checksum.algorithm}:${checksum.checksumValue}`;
+    return !existingChecksumKeys.has(key);
+  }) || [];
+  
+  merged.checksums = [...(existing.checksums || []), ...newChecksums];
+  
+  // Prefer more specific license information
+  if (merged.licenseConcluded === 'NOASSERTION' && newPkg.licenseConcluded !== 'NOASSERTION') {
+    merged.licenseConcluded = newPkg.licenseConcluded;
+  }
+  if (merged.licenseDeclared === 'NOASSERTION' && newPkg.licenseDeclared !== 'NOASSERTION') {
+    merged.licenseDeclared = newPkg.licenseDeclared;
+  }
+  
+  return merged;
+}
+
+/**
+ * Resolves the final SPDX ID after applying document prefix and deduplication mapping
+ */
+function resolveFinalSPDXID(id: string, docPrefix: string, originalDocID: string, spdxIdMapping: Map<string, string>): string {
+  // First apply document prefix transformation
+  const prefixedId = updateSPDXID(id, docPrefix, originalDocID);
+  
+  // Then check if this ID has been mapped due to package deduplication
+  return spdxIdMapping.get(prefixedId) || prefixedId;
+}
+
+/**
+ * Updates SPDX IDs with document prefix, handling special cases
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function updateSPDXID(id: string, docPrefix: string, originalDocID: string): string {
+  if (id === 'SPDXRef-DOCUMENT') {
+    // For relationships, we should reference the main document, not create a DocumentRef-
+    // DocumentRef- prefixes are for external document references, not SPDX elements
+    return 'SPDXRef-DOCUMENT';
+  }
+  
+  if (id.startsWith('DocumentRef-')) {
+    return id; // Already a document reference
+  }
+  
+  if (id.startsWith('SPDXRef-')) {
+    return `SPDXRef-${docPrefix}-${id.replace(/^SPDXRef-/, '')}`;
+  }
+  
+  return `SPDXRef-${docPrefix}-${id}`;
+}

--- a/securebuild-api/lib/sbom/testdata/alpine-321.sbom
+++ b/securebuild-api/lib/sbom/testdata/alpine-321.sbom
@@ -1,0 +1,3386 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "index.docker.io/library/alpine",
+  "documentNamespace": "https://anchore.com/syft/image/index.docker.io/library/alpine-9ca6b105-ae55-4f5b-8175-68f2277f4ace",
+  "creationInfo": {
+    "licenseListVersion": "3.25",
+    "creators": [
+      "Organization: Anchore, Inc",
+      "Tool: syft-1.29.0"
+    ],
+    "created": "2025-07-24T18:02:08Z"
+  },
+  "packages": [
+    {
+      "name": "alpine-baselayout",
+      "SPDXID": "SPDXRef-Package-apk-alpine-baselayout-ae8e0365519d83ef",
+      "versionInfo": "3.6.8-r1",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://git.alpinelinux.org/cgit/aports/tree/main/alpine-baselayout",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "6a22bff30e2aed347029eeb9d51c810613705455"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "GPL-2.0-only",
+      "copyrightText": "NOASSERTION",
+      "description": "Alpine base dir structure and init scripts",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-baselayout:alpine-baselayout:3.6.8-r1:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-baselayout:alpine_baselayout:3.6.8-r1:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_baselayout:alpine-baselayout:3.6.8-r1:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_baselayout:alpine_baselayout:3.6.8-r1:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine:alpine-baselayout:3.6.8-r1:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine:alpine_baselayout:3.6.8-r1:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/alpine-baselayout@3.6.8-r1?arch=aarch64&distro=alpine-3.21.4"
+        }
+      ]
+    },
+    {
+      "name": "alpine-baselayout-data",
+      "SPDXID": "SPDXRef-Package-apk-alpine-baselayout-data-3b9e263c8960bb64",
+      "versionInfo": "3.6.8-r1",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://git.alpinelinux.org/cgit/aports/tree/main/alpine-baselayout",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "6a7d69893b8bca00a39ad9a06c6a7e2833593ad0"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "GPL-2.0-only",
+      "copyrightText": "NOASSERTION",
+      "description": "Alpine base dir structure and init scripts",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-baselayout-data:alpine-baselayout-data:3.6.8-r1:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-baselayout-data:alpine_baselayout_data:3.6.8-r1:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_baselayout_data:alpine-baselayout-data:3.6.8-r1:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_baselayout_data:alpine_baselayout_data:3.6.8-r1:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-baselayout:alpine-baselayout-data:3.6.8-r1:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-baselayout:alpine_baselayout_data:3.6.8-r1:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_baselayout:alpine-baselayout-data:3.6.8-r1:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_baselayout:alpine_baselayout_data:3.6.8-r1:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine:alpine-baselayout-data:3.6.8-r1:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine:alpine_baselayout_data:3.6.8-r1:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/alpine-baselayout-data@3.6.8-r1?arch=aarch64&distro=alpine-3.21.4&upstream=alpine-baselayout"
+        }
+      ]
+    },
+    {
+      "name": "alpine-keys",
+      "SPDXID": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "versionInfo": "2.5-r0",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://alpinelinux.org",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "a8ff80bf0aed8588400518f92c3a6afc4febbd50"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "description": "Public keys for Alpine Linux packages",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-keys:alpine-keys:2.5-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-keys:alpine_keys:2.5-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_keys:alpine-keys:2.5-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_keys:alpine_keys:2.5-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine:alpine-keys:2.5-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine:alpine_keys:2.5-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/alpine-keys@2.5-r0?arch=aarch64&distro=alpine-3.21.4"
+        }
+      ]
+    },
+    {
+      "name": "alpine-release",
+      "SPDXID": "SPDXRef-Package-apk-alpine-release-92ebbdd8cf0515d4",
+      "versionInfo": "3.21.4-r0",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://alpinelinux.org",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "162187f6682682f84669e1512b977cf7a05d7495"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "description": "Alpine release data",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-release:alpine-release:3.21.4-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-release:alpine_release:3.21.4-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_release:alpine-release:3.21.4-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_release:alpine_release:3.21.4-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine:alpine-release:3.21.4-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine:alpine_release:3.21.4-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/alpine-release@3.21.4-r0?arch=aarch64&distro=alpine-3.21.4&upstream=alpine-base"
+        }
+      ]
+    },
+    {
+      "name": "apk-tools",
+      "SPDXID": "SPDXRef-Package-apk-apk-tools-8886ee4b32d096d8",
+      "versionInfo": "2.14.6-r3",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://gitlab.alpinelinux.org/alpine/apk-tools",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "8e9597449bca1ef1ae247adf21bc32b883e4812d"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "GPL-2.0-only",
+      "copyrightText": "NOASSERTION",
+      "description": "Alpine Package Keeper - package manager for alpine",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:apk-tools:apk-tools:2.14.6-r3:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:apk-tools:apk_tools:2.14.6-r3:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:apk_tools:apk-tools:2.14.6-r3:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:apk_tools:apk_tools:2.14.6-r3:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:apk:apk-tools:2.14.6-r3:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:apk:apk_tools:2.14.6-r3:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/apk-tools@2.14.6-r3?arch=aarch64&distro=alpine-3.21.4"
+        }
+      ]
+    },
+    {
+      "name": "busybox",
+      "SPDXID": "SPDXRef-Package-apk-busybox-715dd05656485a98",
+      "versionInfo": "1.37.0-r12",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "https://busybox.net/",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "e3149195371bf4b984fb45f836c001ad4b059a55"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "GPL-2.0-only",
+      "copyrightText": "NOASSERTION",
+      "description": "Size optimized toolbox of many common UNIX utilities",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:busybox:busybox:1.37.0-r12:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/busybox@1.37.0-r12?arch=aarch64&distro=alpine-3.21.4"
+        }
+      ]
+    },
+    {
+      "name": "busybox-binsh",
+      "SPDXID": "SPDXRef-Package-apk-busybox-binsh-d6267b7ca32e9850",
+      "versionInfo": "1.37.0-r12",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "https://busybox.net/",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "2b0172a02d059ffa832e492ed8fb87d7afc86da2"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "GPL-2.0-only",
+      "copyrightText": "NOASSERTION",
+      "description": "busybox ash /bin/sh",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:busybox-binsh:busybox-binsh:1.37.0-r12:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:busybox-binsh:busybox_binsh:1.37.0-r12:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:busybox_binsh:busybox-binsh:1.37.0-r12:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:busybox_binsh:busybox_binsh:1.37.0-r12:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:busybox:busybox-binsh:1.37.0-r12:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:busybox:busybox_binsh:1.37.0-r12:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/busybox-binsh@1.37.0-r12?arch=aarch64&distro=alpine-3.21.4&upstream=busybox"
+        }
+      ]
+    },
+    {
+      "name": "ca-certificates-bundle",
+      "SPDXID": "SPDXRef-Package-apk-ca-certificates-bundle-2c5bc535d95fd1ea",
+      "versionInfo": "20250619-r0",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "6f0301f84aa838ef5fb0809d4fb6c473dcdd820a"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "(MPL-2.0 AND MIT)",
+      "copyrightText": "NOASSERTION",
+      "description": "Pre generated bundle of Mozilla certificates",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca-certificates-bundle:ca-certificates-bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca-certificates-bundle:ca_certificates_bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca_certificates_bundle:ca-certificates-bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca_certificates_bundle:ca_certificates_bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca-certificates:ca-certificates-bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca-certificates:ca_certificates_bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca_certificates:ca-certificates-bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca_certificates:ca_certificates_bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:mozilla:ca-certificates-bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:mozilla:ca_certificates_bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca:ca-certificates-bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca:ca_certificates_bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/ca-certificates-bundle@20250619-r0?arch=aarch64&distro=alpine-3.21.4&upstream=ca-certificates"
+        }
+      ]
+    },
+    {
+      "name": "libcrypto3",
+      "SPDXID": "SPDXRef-Package-apk-libcrypto3-58902fb0bf492b44",
+      "versionInfo": "3.3.4-r0",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://www.openssl.org/",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "03dfa72b916336f6562239c9c00c19b6b1d116fe"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "Apache-2.0",
+      "copyrightText": "NOASSERTION",
+      "description": "Crypto library from openssl",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libcrypto3:libcrypto3:3.3.4-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libcrypto3:libcrypto:3.3.4-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libcrypto:libcrypto3:3.3.4-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libcrypto:libcrypto:3.3.4-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/libcrypto3@3.3.4-r0?arch=aarch64&distro=alpine-3.21.4&upstream=openssl"
+        }
+      ]
+    },
+    {
+      "name": "libssl3",
+      "SPDXID": "SPDXRef-Package-apk-libssl3-1111ec29887aaaab",
+      "versionInfo": "3.3.4-r0",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://www.openssl.org/",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "1bd430f16481e626715aff6de575afeb9c6342d4"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "Apache-2.0",
+      "copyrightText": "NOASSERTION",
+      "description": "SSL shared libraries",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libssl3:libssl3:3.3.4-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libssl3:libssl:3.3.4-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libssl:libssl3:3.3.4-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libssl:libssl:3.3.4-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/libssl3@3.3.4-r0?arch=aarch64&distro=alpine-3.21.4&upstream=openssl"
+        }
+      ]
+    },
+    {
+      "name": "musl",
+      "SPDXID": "SPDXRef-Package-apk-musl-491d519ac5d8007a",
+      "versionInfo": "1.2.5-r9",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://musl.libc.org/",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "48bf948d2d60a53afeea4ddccac7912a7cbabaa9"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "description": "the musl c library (libc) implementation",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl-libc:musl:1.2.5-r9:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl_libc:musl:1.2.5-r9:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl:musl:1.2.5-r9:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/musl@1.2.5-r9?arch=aarch64&distro=alpine-3.21.4"
+        }
+      ]
+    },
+    {
+      "name": "musl-utils",
+      "SPDXID": "SPDXRef-Package-apk-musl-utils-5a97f076d1e012eb",
+      "versionInfo": "1.2.5-r9",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://musl.libc.org/",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "d9a2ff1da97d442720ce9b4c563057dd68f31655"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "(MIT AND BSD-2-Clause AND GPL-2.0-or-later)",
+      "copyrightText": "NOASSERTION",
+      "description": "the musl c library (libc) implementation",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl-utils:musl-utils:1.2.5-r9:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl-utils:musl_utils:1.2.5-r9:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl_utils:musl-utils:1.2.5-r9:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl_utils:musl_utils:1.2.5-r9:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl-libc:musl-utils:1.2.5-r9:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl-libc:musl_utils:1.2.5-r9:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl:musl-utils:1.2.5-r9:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl:musl_utils:1.2.5-r9:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/musl-utils@1.2.5-r9?arch=aarch64&distro=alpine-3.21.4&upstream=musl"
+        }
+      ]
+    },
+    {
+      "name": "scanelf",
+      "SPDXID": "SPDXRef-Package-apk-scanelf-b8497fa22ec08daf",
+      "versionInfo": "1.3.8-r1",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://wiki.gentoo.org/wiki/Hardened/PaX_Utilities",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "97669c18daf48e669d0aefdfd8b51e2c46eef974"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "GPL-2.0-only",
+      "copyrightText": "NOASSERTION",
+      "description": "Scan ELF binaries for stuff",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:scanelf:scanelf:1.3.8-r1:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/scanelf@1.3.8-r1?arch=aarch64&distro=alpine-3.21.4&upstream=pax-utils"
+        }
+      ]
+    },
+    {
+      "name": "ssl_client",
+      "SPDXID": "SPDXRef-Package-apk-ssl-client-062360195221b84a",
+      "versionInfo": "1.37.0-r12",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "https://busybox.net/",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "d2a4988dbdf40b9f850c870ff3317e5f831cd82d"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "GPL-2.0-only",
+      "copyrightText": "NOASSERTION",
+      "description": "External ssl_client for busybox wget",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ssl-client:ssl-client:1.37.0-r12:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ssl-client:ssl_client:1.37.0-r12:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ssl_client:ssl-client:1.37.0-r12:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ssl_client:ssl_client:1.37.0-r12:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ssl:ssl-client:1.37.0-r12:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ssl:ssl_client:1.37.0-r12:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/ssl_client@1.37.0-r12?arch=aarch64&distro=alpine-3.21.4&upstream=busybox"
+        }
+      ]
+    },
+    {
+      "name": "zlib",
+      "SPDXID": "SPDXRef-Package-apk-zlib-f1d3ff3e048dfd34",
+      "versionInfo": "1.3.1-r2",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://zlib.net/",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "3c2569d2763dbe92f094d46e7d17ab0ae4bcfbf0"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "Zlib",
+      "copyrightText": "NOASSERTION",
+      "description": "A compression/decompression Library",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:zlib:zlib:1.3.1-r2:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/zlib@1.3.1-r2?arch=aarch64&distro=alpine-3.21.4"
+        }
+      ]
+    },
+    {
+      "name": "index.docker.io/library/alpine",
+      "SPDXID": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "versionInfo": "sha256:b6a6be0ff92ab6db8acd94f5d1b7a6c2f0f5d10ce3c24af348d333ac6da80685",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d4fdbfc39faf24a67747e8e5d0cccdd149ecf4998140746617fd71384c23f23c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:oci/index.docker.io%2Flibrary%2Falpine@sha256%3Ad4fdbfc39faf24a67747e8e5d0cccdd149ecf4998140746617fd71384c23f23c?arch=arm64"
+        }
+      ],
+      "primaryPackagePurpose": "CONTAINER"
+    }
+  ],
+  "files": [
+    {
+      "fileName": "bin/busybox",
+      "SPDXID": "SPDXRef-File-bin-busybox-57dd05afded986ed",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2d37db52c635456123896015980d370f699f857d"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "47a73e1bab69d71367333bf164b23089ba40b6af6df3be344c19c1594faaeed5"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/alpine-release",
+      "SPDXID": "SPDXRef-File-etc-alpine-release-97886576ae4ec112",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "27b21dd30f3c63349634c03027de8204878d8897"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9d3f3e852aa8060c69e26d79fd19ccbfba06c7181a0c27184603049bbf56fa90"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/apk/keys/alpine-devel@lists.alpinelinux.org-524d27bb.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-524d27bb.rsa.pub-d7a9fd55c4a4b497",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "053a92f87fd4532850bb31f0881978efe0532ae5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1bb2a846c0ea4ca9d0e7862f970863857fc33c32f5506098c636a62a726a847b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/apk/keys/alpine-devel@lists.alpinelinux.org-58199dcc.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-58199dcc.rsa.pub-a2197d8c33037556",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "39ac5d72c6ba018a0f74b8b453894edc9db07b5f"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "73867d92083f2f8ab899a26ccda7ef63dfaa0032a938620eda605558958a8041"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/apk/keys/alpine-devel@lists.alpinelinux.org-616a9724.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616a9724.rsa.pub-b029e365a64c7d3e",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "23d0f2ea1af269c2f66165e0f8a944e96bf011de"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "10877cce0a935e46ad88cb79e174a2491680508eccda08e92bf04fb9bf37fbc1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/apk/keys/alpine-devel@lists.alpinelinux.org-616adfeb.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616adfeb.rsa.pub-3ed7a813cd3dddfe",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "de1241307014aae3dba798e900f163408d98d6f4"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ebe717d228555aa58133c202314a451f81e71f174781fd7ff8d8970d6cfa60da"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/apk/keys/alpine-devel@lists.alpinelinux.org-616ae350.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616ae350.rsa.pub-3b9c5eb334763759",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "57f6b93fda4a4496fab62844ddef0eeb168f80b5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d11f6b21c61b4274e182eb888883a8ba8acdbf820dcc7a6d82a7d9fc2fd2836d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/busybox-paths.d/busybox",
+      "SPDXID": "SPDXRef-File-etc-busybox-paths.d-busybox-c97630d265a6ea79",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "af9972dab927fb4bfcbf574de8cf870492a66657"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e12e0822f5c6426b62f07799a0fc20394241535c5bc2cc8f10c8a25088b8defa"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/crontabs/root",
+      "SPDXID": "SPDXRef-File-etc-crontabs-root-9e523647cf8a4da2",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bdf9356a9516238c8b2468613517749098b17ef6"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "575d810a9fae5f2f0671c9b2c0ce973e46c7207fbe5cb8d1b0d1836a6a0470e3"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/fstab",
+      "SPDXID": "SPDXRef-File-etc-fstab-ced284d0d64001d8",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d50ee135ef10a434b9df582ea8276b5c1ce803fa"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a3efca2e8d62785c87517283092b4c800d88612b6f3f06b80a4c2f39d8e68841"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/group",
+      "SPDXID": "SPDXRef-File-etc-group-74efac05633d507d",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d8eb64e0cdfd7cfd998e4a1bbb49c2f45be5448d"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6fb6ab5a5526e6f4896b70c7e3c350fd475158a1f0d7b5fc0f3f9bd57f1c3be8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/hostname",
+      "SPDXID": "SPDXRef-File-etc-hostname-5c8adc93fd9deb64",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ea75706155cffed0a1bd43ddba4543da27d73a67"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d906aecb61d076a967d9ffe8821c7b04b063f72df9d9e35b33ef36b1c0d98f16"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/hosts",
+      "SPDXID": "SPDXRef-File-etc-hosts-ccae4bbaa8d619bc",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "043eb324a653456caa1a73e2e2d49f77792bb0c5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e3998dbe02b51dada33de87ae43d18a93ab6915b9e34f5a751bf2b9b25a55492"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/inittab",
+      "SPDXID": "SPDXRef-File-etc-inittab-84d5f73407607fc4",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ce9586d2acf1d9462765259a21ccc4f96a402151"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7326d8ad56bf5fea63b1ca516a747ff6e6723e25ae84a93c31620b03de6c001d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/issue",
+      "SPDXID": "SPDXRef-File-etc-issue-a7715d5e6251b2b5",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b633a5673b303ba7a6058a5141500e11c73088fe"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "37845ca0ecba5e6d8b67aa798fc520848ae517410d9873a878d07844a3d655c0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/logrotate.d/acpid",
+      "SPDXID": "SPDXRef-File-etc-logrotate.d-acpid-37302fd066a70fe5",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4f29720883559a74be03f4de69de2f66113b064b"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d608a3b7715886b5735def0cc50a6359fd364fac2e0e0a459c588c04be471031"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/modprobe.d/aliases.conf",
+      "SPDXID": "SPDXRef-File-etc-modprobe.d-aliases.conf-718c01752edea762",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5946e1e930583552bb7b863eb94bcbb3feef8aa9"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3ebaba946f213670170c7d69949f690a3854553bd0b1560f1d980cba4c83a942"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/modprobe.d/blacklist.conf",
+      "SPDXID": "SPDXRef-File-etc-modprobe.d-blacklist.conf-5b448f0caca4b1c9",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e1376014791376ddee402f8d06dae7b4e9e6f67e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5cd46031fc7dc7186e67c97fd34780597de4ebff51dbe41eba27220fe5e0d866"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/modprobe.d/i386.conf",
+      "SPDXID": "SPDXRef-File-etc-modprobe.d-i386.conf-0ef8011d3f8d87be",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a676b2fe78e7ea897d702b2c2fb2a2659f1eb657"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6c46c4cbfb8b7594f19eb94801a350fa2221ae9ac5239a8819d15555caa76ae8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/modprobe.d/kms.conf",
+      "SPDXID": "SPDXRef-File-etc-modprobe.d-kms.conf-888488417c39f211",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ca76cb9f71980e9bda8db6bf95da759e26b27a88"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "50467fa732f809f3a2bb5738628765c5f895c3a237e1c1ad09f85d41fd9ca7c5"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/modules",
+      "SPDXID": "SPDXRef-File-etc-modules-7bc4a36a8d9c945c",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b68a208d48a91c670c8040a03c95fae12c144f53"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2c881de75a5409c35d2433a24f180b8b02ba478ef2c1c60ea3434a35bcbc335d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/motd",
+      "SPDXID": "SPDXRef-File-etc-motd-1d72e8c1bdd0e2da",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "48b912f610627546cfc30af0f974745a1bf7c30f"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ff044e9be5daa2eee2d3d10a4da72e5477e4c24c16f1792de2c91dae844c0e30"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/network/if-up.d/dad",
+      "SPDXID": "SPDXRef-File-etc-network-if-up.d-dad-6e67a036793afb78",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ddd99bc197c36e8a9aab9463aaeebda44a7a8029"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2fd20d1bc67d9ee711990002b24f156635a73f56b8935b2f76592938817fa4e7"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/nsswitch.conf",
+      "SPDXID": "SPDXRef-File-etc-nsswitch.conf-13076e2af83aec12",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f4306c327bf44767da8da4e3a13bf40bdd4d3aaa"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0afd94c183d30a348b45057f6bf468e121aa448a7641109addb5bb8e282f514d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/passwd",
+      "SPDXID": "SPDXRef-File-etc-passwd-8902434e4f609dac",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "afe6cba27664032062c7f1cb812783b1ecf6d99b"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "31a94f06f17bc3b9085fccab1d0fa6ee9e79c4a1e4d91f617fa5de95863be015"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/profile",
+      "SPDXID": "SPDXRef-File-etc-profile-b676d93fabfa8232",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "54dd1d99ac0383798113f96307ee9b52b0bb0f37"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "87e8643d3ce156de0c09370d4d39446f30bd00d264bea248abc191c4d7b9df3e"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/profile.d/20locale.sh",
+      "SPDXID": "SPDXRef-File-etc-profile.d-20locale.sh-e25fc7cb3a2c9d27",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "96adbd950ccf992085295990f9bbe667f0cf4c4e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "284a6ef56ab97a13a777c6b01ae14f2cc3d2b7a29c19e750e622e70cc3c73186"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/profile.d/README",
+      "SPDXID": "SPDXRef-File-etc-profile.d-README-e2aae816b53288fe",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "df9396b02cf3be70767e6171eb691baa6d40c759"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b73284f27fe2da9ae1902b1fe9596c3ffc61a154e2805a034184f0468f8b09b0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/profile.d/color_prompt.sh.disabled",
+      "SPDXID": "SPDXRef-File-etc-profile.d-color-prompt.sh.disabled-cf811321bf1cdd15",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d5733d99d7b5676f6d58c19a3a47a8bc3fe6e2e5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ba24425c6864a5d17fa0fdaf914c4d21419e47c4d62080c33830af059fe46617"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/protocols",
+      "SPDXID": "SPDXRef-File-etc-protocols-a197a39daac61457",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d5f9654539089b96f1b1956848d783527da6fb47"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4959498abbadaa1e50894a266f8d0d94500101cfe5b5f09dcad82e9d5bdfab46"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/secfixes.d/alpine",
+      "SPDXID": "SPDXRef-File-etc-secfixes.d-alpine-417fdf215e5d3a68",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "84bafebb911b92fcf7fb9d851e2f61e5815e1923"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "95ff5d0e5c2c9a87b0fa7446ea8786491d26ed8266b4f25c2462ae748fd84449"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/securetty",
+      "SPDXID": "SPDXRef-File-etc-securetty-cfe43a6ddf655252",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0e29ce7fa251a4246033abcdaa339ec5dde84a75"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "713fcea5109728883b9147e822429133fcc8b5e253afd3c2a197b10cd0bc3b4d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/services",
+      "SPDXID": "SPDXRef-File-etc-services-92db078ce3c4d298",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a0d7a229bf049f7fe17e8445226236e4024535d0"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f6183055fd949f9c53d49ee620f85d0150123ea691d25ed1bba0c641b4ee2f48"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/shadow",
+      "SPDXID": "SPDXRef-File-etc-shadow-f9cf4d523005627b",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "fdcce813d9a3aa27fffcf07126d2deabf17cb057"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d5992a27f05f380fc5faeb82a3359e2f230fd1d6ea6517b45892b771a2194ddb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/shells",
+      "SPDXID": "SPDXRef-File-etc-shells-44949c3c2f9906a4",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a239b661da4227a07f6a9183699fd275bdb12640"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "24be6ceb236610df45684c83b06c918ae45635be55f69975e43676b7595bbc5f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/ssl/certs/ca-certificates.crt",
+      "SPDXID": "SPDXRef-File-etc-ssl-certs-ca-certificates.crt-3a3648be1ae4aa3b",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4b79f0a91ec436b29eae65f74bb5c3a40cda11a7"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8cf3f2d5222508ca469c78a347764ee1b1fab10a903172612c489ebcca05c91c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/ssl/ct_log_list.cnf",
+      "SPDXID": "SPDXRef-File-etc-ssl-ct-log-list.cnf-7fe7ffef67874e15",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a2587c4e97408b64274e5e052b74e3754892c13a"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f1c1803d13d1d0b755b13b23c28bd4e20e07baf9f2b744c9337ba5866aa0ec3b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/ssl/ct_log_list.cnf.dist",
+      "SPDXID": "SPDXRef-File-etc-ssl-ct-log-list.cnf.dist-812d964a9aff29ab",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a2587c4e97408b64274e5e052b74e3754892c13a"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f1c1803d13d1d0b755b13b23c28bd4e20e07baf9f2b744c9337ba5866aa0ec3b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/ssl/openssl.cnf",
+      "SPDXID": "SPDXRef-File-etc-ssl-openssl.cnf-5850a26a9ac32379",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c6aaa437fab0d4186ff361da58952c45447f0181"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3a0c65ff954aff207420846926d31d1b6056be525a0f3d38dff21f5b89f90688"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/ssl/openssl.cnf.dist",
+      "SPDXID": "SPDXRef-File-etc-ssl-openssl.cnf.dist-1ab217ac786d46a3",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c6aaa437fab0d4186ff361da58952c45447f0181"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3a0c65ff954aff207420846926d31d1b6056be525a0f3d38dff21f5b89f90688"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/sysctl.conf",
+      "SPDXID": "SPDXRef-File-etc-sysctl.conf-1d3b5834a21e4be3",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e2ea73ded7e7371664204b148569fb5e88b0f7a8"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8bba47da45bc8715c69ac904a60410eabffaa7bbbef640f9c1368ab9c48493d0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "etc/udhcpc/udhcpc.conf",
+      "SPDXID": "SPDXRef-File-etc-udhcpc-udhcpc.conf-dbfe8705c43697cd",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9bc069e434228e6ca441848bfb7a6bac23fa148a"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5b372209e01cda07c87b8afa6d1ab3d7e8daf18a1f2332d744203a6dc289eb1a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "lib/apk/db/installed",
+      "SPDXID": "SPDXRef-File-lib-apk-db-installed-6d57d03c775eb7da",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "eff19f6169bdcb17c9fb9da011d091721fecd4d8"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bca34ce6496572a04f290f30f176beead50a9934734de730fcc894c6142f11ff"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "lib/ld-musl-aarch64.so.1",
+      "SPDXID": "SPDXRef-File-lib-ld-musl-aarch64.so.1-07ff52db657fce41",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "51bed13fa3d972dcd6b4b99fdec763d1776c9874"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c51792635038f3fcfb27f44f977181c5bb043150a0d3074e0db7e3b3477a0ce0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "sbin/apk",
+      "SPDXID": "SPDXRef-File-sbin-apk-bedd243f7b5fe3e8",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e2b8062e83ae160d323e0a734d8b2b64dbd35176"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "56a21ec2ce8e95506b005aaa5cb04144e0522fde6f03f7516ccd8e9bc9d0a2b1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "sbin/ldconfig",
+      "SPDXID": "SPDXRef-File-sbin-ldconfig-c7628d4f78d6262f",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2a36b6f8f3992b112450e66ac128c2ea499a103e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b4a2c06db38742e8c42c3c9838b285a7d8cdac6c091ff3df5ff9a15f1e41b9c7"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/bin/getconf",
+      "SPDXID": "SPDXRef-File-usr-bin-getconf-3d1e2456eb624323",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8b0150350512182197a4b6d783ca45f2b280657d"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3a33ca407feaa033b06828d9942b0d673a5a99ca14c7ad6d38ebd7dc709d07dd"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/bin/getent",
+      "SPDXID": "SPDXRef-File-usr-bin-getent-255b1683b05b4de0",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3895ba5d0731ad58bf955565bb56280551e582d9"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "472bcf4ad76bcb13374853e3487a1f4b0ab268e843d990397b01e1eda0ee2666"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/bin/iconv",
+      "SPDXID": "SPDXRef-File-usr-bin-iconv-6b4ef702141bdc63",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2df219127081da4eee6d3b187cc58f63babd4ce6"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7edd98d6855c01d5a2e071c59b5af761cee8f4e2a0f39f6ef39620e9a787c67f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/bin/ldd",
+      "SPDXID": "SPDXRef-File-usr-bin-ldd-8a09b5e7acdabcc7",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "afe298b72fc708b978a7876f3edf2409bd66841d"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5f115be8562262bcc50ec469e25c0af2fda3bad72a960c6aa3488acd7a7da8cf"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/bin/scanelf",
+      "SPDXID": "SPDXRef-File-usr-bin-scanelf-01e03cb9603bce37",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4c546a8c796437a13b6f934cbd3bab16fd3708e7"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3bb2e4d515a085f46555dfaef8b266f6cb480f57ed79202d6f9caa5595e6a220"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/bin/ssl_client",
+      "SPDXID": "SPDXRef-File-usr-bin-ssl-client-d88862dbee42e01a",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2ebeed18926a8d4e301e7cfde0d454557ace8521"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bdea140ea35a407e40b703a3f79bfd57102e88e1c1e5e6b0e5aa98c27f211bc9"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/lib/engines-3/afalg.so",
+      "SPDXID": "SPDXRef-File-usr-lib-engines-3-afalg.so-b93698475092e37b",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "979d048f33a9e1ad7c2f16c9a6631f3506cf383a"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "aa8e4472f7d085265bec74852d8a4604e73b812979415d4dcd339b4d94fd67f2"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/lib/engines-3/capi.so",
+      "SPDXID": "SPDXRef-File-usr-lib-engines-3-capi.so-1ac312d891f4573f",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4e21b6f429dc3594ed37d3d22fbf4b6f2952d34e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "03ad7399b22407ad66fe82be9db68b3ce5e22282f1430448f4b4225e56437716"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/lib/engines-3/loader_attic.so",
+      "SPDXID": "SPDXRef-File-usr-lib-engines-3-loader-attic.so-6092498cf1e2fb6d",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e28af7bc8317aafd37ffccd01835046e0da0671b"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f34f71c3c8721d04711f228295cac72d90bffe3e83540f38022a9338b5ef4169"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/lib/engines-3/padlock.so",
+      "SPDXID": "SPDXRef-File-usr-lib-engines-3-padlock.so-624747b6448ade6d",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f82ee111f217c0d84c8f7bf6dbb3e74f6e08a415"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ad3b7f1af731b9928910581bd51714df89e0917c9d2fcd37c4b06951f2cd05b7"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/lib/libapk.so.2.14.0",
+      "SPDXID": "SPDXRef-File-usr-lib-libapk.so.2.14.0-f48d8c3c326885a6",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1e172f02b49302e45dafe68820c55251dcf72e48"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6e9f7d06e53406a4fd29b7b4fcb3d7658574eb055d9118629c3c1ca9c8fbf453"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/lib/libcrypto.so.3",
+      "SPDXID": "SPDXRef-File-usr-lib-libcrypto.so.3-58310c958b626082",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1e76e315330009486588319c181bb1dff67d9cbd"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "764f5c8917404bf44afe1cc0dd9f5c6915695bbe4534005ebde6b32f02dfee98"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/lib/libssl.so.3",
+      "SPDXID": "SPDXRef-File-usr-lib-libssl.so.3-dba3d620d22fabd9",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f3ac24b9721f6e12eb45e55d88e895f115fe0d5e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1183efc5e5f1d1bc32f8598102656b8034f1f3732a306a54c2ac4e43394ad641"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/lib/libz.so.1.3.1",
+      "SPDXID": "SPDXRef-File-usr-lib-libz.so.1.3.1-d8e5cf31e84a6a8f",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "39de7953356db66a9340a94d7048ccdaabbefeb6"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d7eeeaa727b0c1cf035893b35d164430818abceff671ea402b34dba49824dc93"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/lib/os-release",
+      "SPDXID": "SPDXRef-File-usr-lib-os-release-43039af89be39e83",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "92ae03a6eb807e7d615793d0675d9651e8b84698"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "af510dcfa6d49780ee2f0c7eaa4c50f384475a5cf4845caef52a06c9b5a817ac"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/lib/ossl-modules/legacy.so",
+      "SPDXID": "SPDXRef-File-usr-lib-ossl-modules-legacy.so-57bc8d60e9f82fa0",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a958a80676a1566df44a2deee69dbdeff768da9e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "61f24e0bbd78a8609d3ed04a5256e49feaef1ccb77a200b184e1918cbf6b2d8b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/lib/sysctl.d/00-alpine.conf",
+      "SPDXID": "SPDXRef-File-usr-lib-sysctl.d-00-alpine.conf-09d4636466128e56",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1e9125cd6d7112098a7c446d4f2ee8a269a7aba7"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ee169bea2cb6859420b55ca7a9c23fb68b50adc1d26c951f904dec9e8f767380"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-4a6a0840.rsa.pub-9b2e3c030ab54091",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3af08548ef78cfdedcf349880c2c6a1a48763a0e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9c102bcc376af1498d549b77bdbfa815ae86faa1d2d82f040e616b18ef2df2d4"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-5243ef4b.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-5243ef4b.rsa.pub-655caab9f0a3c201",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bfb616658cc05a872568b0c8e398c482e23b60dd"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ebf31683b56410ecc4c00acd9f6e2839e237a3b62b5ae7ef686705c7ba0396a9"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-524d27bb.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-524d27bb.rsa.pub-d8c25ae0bedee6da",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "053a92f87fd4532850bb31f0881978efe0532ae5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1bb2a846c0ea4ca9d0e7862f970863857fc33c32f5506098c636a62a726a847b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-5261cecb.rsa.pub-6cb1133e08a9a9bf",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3671ae0ec7503b1e193587c1dcdf7b78bc863e42"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "12f899e55a7691225603d6fb3324940fc51cd7f133e7ead788663c2b7eecb00c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58199dcc.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-58199dcc.rsa.pub-9a045dee2ec7d54a",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "39ac5d72c6ba018a0f74b8b453894edc9db07b5f"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "73867d92083f2f8ab899a26ccda7ef63dfaa0032a938620eda605558958a8041"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58cbb476.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-58cbb476.rsa.pub-4c19367bbdb4f77e",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c8fabeb2eeb992c368c77b9707e0d1ecfd7cf905"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9a4cd858d9710963848e6d5f555325dc199d1c952b01cf6e64da2c15deedbd97"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58e4f17d.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-58e4f17d.rsa.pub-69b7ac250e14be8d",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "329643357d0b78b1ef48ec155325e25f1d7534dd"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "780b3ed41786772cbc7b68136546fa3f897f28a23b30c72dde6225319c44cfff"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-5e69ca50.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-5e69ca50.rsa.pub-7726317d450966fc",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "825090fde25bbc0e71a9cb3076316b5afe459e4d"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "59c01c57b446633249f67c04b115dd6787f4378f183dff2bbf65406df93f176d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-60ac2099.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-60ac2099.rsa.pub-c8e9bf3b61e9f31f",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5d4743128353b6396fad2fa2ba793ace21602295"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "db0b49163f07ffba64a5ca198bcf1688610b0bd1f0d8d5afeaf78559d73f2278"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-6165ee59.rsa.pub-5d16d8f089ae2a41",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "95995311236b7a55933642ffa10ce6014f1af7d0"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "207e4696d3c05f7cb05966aee557307151f1f00217af4143c1bcaf33b8df733f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-61666e3f.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-61666e3f.rsa.pub-01cedc29616c5f94",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "58d5ba4b2f3b1e927721d7a6432f298eedf72a6b"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "128d34d4aec39b0daedea8163cd8dc24dff36fd3d848630ab97eeb1d3084bbb3"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616a9724.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616a9724.rsa.pub-1aa6d717b139f099",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "23d0f2ea1af269c2f66165e0f8a944e96bf011de"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "10877cce0a935e46ad88cb79e174a2491680508eccda08e92bf04fb9bf37fbc1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616abc23.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616abc23.rsa.pub-52420c9a91a5715e",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3529ec82670c6d4e20ee3e4968db34b551e91d50"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4a095a9daca86da496a3cd9adcd95ee2197fdbeb84638656d469f05a4d740751"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616ac3bc.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616ac3bc.rsa.pub-6d4a80942bf04f1a",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "55a301064e11c6fe9ba0f2ca17e234f3943ccb61"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0caf5662fde45616d88cfd7021b7bda269a2fcaf311e51c48945a967a609ec0b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616adfeb.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616adfeb.rsa.pub-93ee0a52549cab24",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "de1241307014aae3dba798e900f163408d98d6f4"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ebe717d228555aa58133c202314a451f81e71f174781fd7ff8d8970d6cfa60da"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616ae350.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616ae350.rsa.pub-6d93750d8b10d34a",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "57f6b93fda4a4496fab62844ddef0eeb168f80b5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d11f6b21c61b4274e182eb888883a8ba8acdbf820dcc7a6d82a7d9fc2fd2836d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616db30d.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616db30d.rsa.pub-edbaed66a8500819",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "df02c9adc2906a3aa5e5ad69f50e3953e65710d0"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "40a216cbd163f22e5f16a9e0929de7cde221b9cbae8e36aa368b1e128afe0a31"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-66ba20fe.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-66ba20fe.rsa.pub-56e807ae1e7c4a4b",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7bd0eee2d55893735686932aa47a7c8a66e9153b"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7cf4cb8314e6ccc985b0d7f1aa0c6e0a81e3588f69a41f383af7a63d1ba61793"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    },
+    {
+      "fileName": "usr/share/udhcpc/default.script",
+      "SPDXID": "SPDXRef-File-usr-share-udhcpc-default.script-51f869a78cee020e",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1d6a46dde403f14a22e2692cd84dd24af3805216"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c4e5a7c4783a7a73dec48dee009ee687015d2de7ff86b269679b95bef2c60e13"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:31d48dc5ebd795176e7747f30d646d971d64a6c3e467601c59fb733ef6870fd6"
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-Package-apk-ssl-client-062360195221b84a",
+      "relatedSpdxElement": "SPDXRef-File-usr-bin-ssl-client-d88862dbee42e01a",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libssl3-1111ec29887aaaab",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-libssl.so.3-dba3d620d22fabd9",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-ca-certificates-bundle-2c5bc535d95fd1ea",
+      "relatedSpdxElement": "SPDXRef-File-etc-ssl-certs-ca-certificates.crt-3a3648be1ae4aa3b",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-61666e3f.rsa.pub-01cedc29616c5f94",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616a9724.rsa.pub-1aa6d717b139f099",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616ae350.rsa.pub-3b9c5eb334763759",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616adfeb.rsa.pub-3ed7a813cd3dddfe",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-58cbb476.rsa.pub-4c19367bbdb4f77e",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616abc23.rsa.pub-52420c9a91a5715e",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-66ba20fe.rsa.pub-56e807ae1e7c4a4b",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-6165ee59.rsa.pub-5d16d8f089ae2a41",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-5243ef4b.rsa.pub-655caab9f0a3c201",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-58e4f17d.rsa.pub-69b7ac250e14be8d",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-5261cecb.rsa.pub-6cb1133e08a9a9bf",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616ac3bc.rsa.pub-6d4a80942bf04f1a",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616ae350.rsa.pub-6d93750d8b10d34a",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-5e69ca50.rsa.pub-7726317d450966fc",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616adfeb.rsa.pub-93ee0a52549cab24",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-58199dcc.rsa.pub-9a045dee2ec7d54a",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-4a6a0840.rsa.pub-9b2e3c030ab54091",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-58199dcc.rsa.pub-a2197d8c33037556",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616a9724.rsa.pub-b029e365a64c7d3e",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-60ac2099.rsa.pub-c8e9bf3b61e9f31f",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-524d27bb.rsa.pub-d7a9fd55c4a4b497",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-524d27bb.rsa.pub-d8c25ae0bedee6da",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616db30d.rsa.pub-edbaed66a8500819",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-3b9e263c8960bb64",
+      "relatedSpdxElement": "SPDXRef-File-etc-nsswitch.conf-13076e2af83aec12",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-3b9e263c8960bb64",
+      "relatedSpdxElement": "SPDXRef-File-etc-sysctl.conf-1d3b5834a21e4be3",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-3b9e263c8960bb64",
+      "relatedSpdxElement": "SPDXRef-File-etc-shells-44949c3c2f9906a4",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-3b9e263c8960bb64",
+      "relatedSpdxElement": "SPDXRef-File-etc-hostname-5c8adc93fd9deb64",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-3b9e263c8960bb64",
+      "relatedSpdxElement": "SPDXRef-File-etc-group-74efac05633d507d",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-3b9e263c8960bb64",
+      "relatedSpdxElement": "SPDXRef-File-etc-modules-7bc4a36a8d9c945c",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-3b9e263c8960bb64",
+      "relatedSpdxElement": "SPDXRef-File-etc-inittab-84d5f73407607fc4",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-3b9e263c8960bb64",
+      "relatedSpdxElement": "SPDXRef-File-etc-passwd-8902434e4f609dac",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-3b9e263c8960bb64",
+      "relatedSpdxElement": "SPDXRef-File-etc-services-92db078ce3c4d298",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-3b9e263c8960bb64",
+      "relatedSpdxElement": "SPDXRef-File-etc-protocols-a197a39daac61457",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-3b9e263c8960bb64",
+      "relatedSpdxElement": "SPDXRef-File-etc-profile-b676d93fabfa8232",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-3b9e263c8960bb64",
+      "relatedSpdxElement": "SPDXRef-File-etc-hosts-ccae4bbaa8d619bc",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-3b9e263c8960bb64",
+      "relatedSpdxElement": "SPDXRef-File-etc-fstab-ced284d0d64001d8",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-3b9e263c8960bb64",
+      "relatedSpdxElement": "SPDXRef-File-etc-shadow-f9cf4d523005627b",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-491d519ac5d8007a",
+      "relatedSpdxElement": "SPDXRef-File-lib-ld-musl-aarch64.so.1-07ff52db657fce41",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-58902fb0bf492b44",
+      "relatedSpdxElement": "SPDXRef-File-etc-ssl-openssl.cnf.dist-1ab217ac786d46a3",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-58902fb0bf492b44",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-engines-3-capi.so-1ac312d891f4573f",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-58902fb0bf492b44",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-ossl-modules-legacy.so-57bc8d60e9f82fa0",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-58902fb0bf492b44",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-libcrypto.so.3-58310c958b626082",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-58902fb0bf492b44",
+      "relatedSpdxElement": "SPDXRef-File-etc-ssl-openssl.cnf-5850a26a9ac32379",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-58902fb0bf492b44",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-engines-3-loader-attic.so-6092498cf1e2fb6d",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-58902fb0bf492b44",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-engines-3-padlock.so-624747b6448ade6d",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-58902fb0bf492b44",
+      "relatedSpdxElement": "SPDXRef-File-etc-ssl-ct-log-list.cnf-7fe7ffef67874e15",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-58902fb0bf492b44",
+      "relatedSpdxElement": "SPDXRef-File-etc-ssl-ct-log-list.cnf.dist-812d964a9aff29ab",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-58902fb0bf492b44",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-engines-3-afalg.so-b93698475092e37b",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-utils-5a97f076d1e012eb",
+      "relatedSpdxElement": "SPDXRef-File-usr-bin-getent-255b1683b05b4de0",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-utils-5a97f076d1e012eb",
+      "relatedSpdxElement": "SPDXRef-File-usr-bin-getconf-3d1e2456eb624323",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-utils-5a97f076d1e012eb",
+      "relatedSpdxElement": "SPDXRef-File-usr-bin-iconv-6b4ef702141bdc63",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-utils-5a97f076d1e012eb",
+      "relatedSpdxElement": "SPDXRef-File-usr-bin-ldd-8a09b5e7acdabcc7",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-utils-5a97f076d1e012eb",
+      "relatedSpdxElement": "SPDXRef-File-sbin-ldconfig-c7628d4f78d6262f",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-715dd05656485a98",
+      "relatedSpdxElement": "SPDXRef-File-etc-logrotate.d-acpid-37302fd066a70fe5",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-715dd05656485a98",
+      "relatedSpdxElement": "SPDXRef-File-usr-share-udhcpc-default.script-51f869a78cee020e",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-715dd05656485a98",
+      "relatedSpdxElement": "SPDXRef-File-bin-busybox-57dd05afded986ed",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-715dd05656485a98",
+      "relatedSpdxElement": "SPDXRef-File-etc-network-if-up.d-dad-6e67a036793afb78",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-715dd05656485a98",
+      "relatedSpdxElement": "SPDXRef-File-etc-busybox-paths.d-busybox-c97630d265a6ea79",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-715dd05656485a98",
+      "relatedSpdxElement": "SPDXRef-File-etc-securetty-cfe43a6ddf655252",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-715dd05656485a98",
+      "relatedSpdxElement": "SPDXRef-File-etc-udhcpc-udhcpc.conf-dbfe8705c43697cd",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-apk-tools-8886ee4b32d096d8",
+      "relatedSpdxElement": "SPDXRef-File-sbin-apk-bedd243f7b5fe3e8",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-apk-tools-8886ee4b32d096d8",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-libapk.so.2.14.0-f48d8c3c326885a6",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-release-92ebbdd8cf0515d4",
+      "relatedSpdxElement": "SPDXRef-File-etc-secfixes.d-alpine-417fdf215e5d3a68",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-release-92ebbdd8cf0515d4",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-os-release-43039af89be39e83",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-release-92ebbdd8cf0515d4",
+      "relatedSpdxElement": "SPDXRef-File-etc-alpine-release-97886576ae4ec112",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-release-92ebbdd8cf0515d4",
+      "relatedSpdxElement": "SPDXRef-File-etc-issue-a7715d5e6251b2b5",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-ae8e0365519d83ef",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-sysctl.d-00-alpine.conf-09d4636466128e56",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-ae8e0365519d83ef",
+      "relatedSpdxElement": "SPDXRef-File-etc-modprobe.d-i386.conf-0ef8011d3f8d87be",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-ae8e0365519d83ef",
+      "relatedSpdxElement": "SPDXRef-File-etc-motd-1d72e8c1bdd0e2da",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-ae8e0365519d83ef",
+      "relatedSpdxElement": "SPDXRef-File-etc-modprobe.d-blacklist.conf-5b448f0caca4b1c9",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-ae8e0365519d83ef",
+      "relatedSpdxElement": "SPDXRef-File-etc-modprobe.d-aliases.conf-718c01752edea762",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-ae8e0365519d83ef",
+      "relatedSpdxElement": "SPDXRef-File-etc-modprobe.d-kms.conf-888488417c39f211",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-ae8e0365519d83ef",
+      "relatedSpdxElement": "SPDXRef-File-etc-crontabs-root-9e523647cf8a4da2",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-ae8e0365519d83ef",
+      "relatedSpdxElement": "SPDXRef-File-etc-profile.d-color-prompt.sh.disabled-cf811321bf1cdd15",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-ae8e0365519d83ef",
+      "relatedSpdxElement": "SPDXRef-File-etc-profile.d-20locale.sh-e25fc7cb3a2c9d27",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-ae8e0365519d83ef",
+      "relatedSpdxElement": "SPDXRef-File-etc-profile.d-README-e2aae816b53288fe",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-scanelf-b8497fa22ec08daf",
+      "relatedSpdxElement": "SPDXRef-File-usr-bin-scanelf-01e03cb9603bce37",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-binsh-d6267b7ca32e9850",
+      "relatedSpdxElement": "SPDXRef-File-bin-busybox-57dd05afded986ed",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-zlib-f1d3ff3e048dfd34",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-libz.so.1.3.1-d8e5cf31e84a6a8f",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libssl3-1111ec29887aaaab",
+      "relatedSpdxElement": "SPDXRef-Package-apk-ssl-client-062360195221b84a",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libssl3-1111ec29887aaaab",
+      "relatedSpdxElement": "SPDXRef-Package-apk-apk-tools-8886ee4b32d096d8",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-ca-certificates-bundle-2c5bc535d95fd1ea",
+      "relatedSpdxElement": "SPDXRef-Package-apk-apk-tools-8886ee4b32d096d8",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-Package-apk-alpine-release-92ebbdd8cf0515d4",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-3b9e263c8960bb64",
+      "relatedSpdxElement": "SPDXRef-Package-apk-alpine-baselayout-ae8e0365519d83ef",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-491d519ac5d8007a",
+      "relatedSpdxElement": "SPDXRef-Package-apk-ssl-client-062360195221b84a",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-491d519ac5d8007a",
+      "relatedSpdxElement": "SPDXRef-Package-apk-libssl3-1111ec29887aaaab",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-491d519ac5d8007a",
+      "relatedSpdxElement": "SPDXRef-Package-apk-libcrypto3-58902fb0bf492b44",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-491d519ac5d8007a",
+      "relatedSpdxElement": "SPDXRef-Package-apk-musl-utils-5a97f076d1e012eb",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-491d519ac5d8007a",
+      "relatedSpdxElement": "SPDXRef-Package-apk-busybox-715dd05656485a98",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-491d519ac5d8007a",
+      "relatedSpdxElement": "SPDXRef-Package-apk-apk-tools-8886ee4b32d096d8",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-491d519ac5d8007a",
+      "relatedSpdxElement": "SPDXRef-Package-apk-scanelf-b8497fa22ec08daf",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-491d519ac5d8007a",
+      "relatedSpdxElement": "SPDXRef-Package-apk-zlib-f1d3ff3e048dfd34",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-58902fb0bf492b44",
+      "relatedSpdxElement": "SPDXRef-Package-apk-ssl-client-062360195221b84a",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-58902fb0bf492b44",
+      "relatedSpdxElement": "SPDXRef-Package-apk-libssl3-1111ec29887aaaab",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-58902fb0bf492b44",
+      "relatedSpdxElement": "SPDXRef-Package-apk-apk-tools-8886ee4b32d096d8",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-715dd05656485a98",
+      "relatedSpdxElement": "SPDXRef-Package-apk-busybox-binsh-d6267b7ca32e9850",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-scanelf-b8497fa22ec08daf",
+      "relatedSpdxElement": "SPDXRef-Package-apk-musl-utils-5a97f076d1e012eb",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-binsh-d6267b7ca32e9850",
+      "relatedSpdxElement": "SPDXRef-Package-apk-alpine-baselayout-ae8e0365519d83ef",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-zlib-f1d3ff3e048dfd34",
+      "relatedSpdxElement": "SPDXRef-Package-apk-apk-tools-8886ee4b32d096d8",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-ssl-client-062360195221b84a",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-6d57d03c775eb7da",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libssl3-1111ec29887aaaab",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-6d57d03c775eb7da",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-ca-certificates-bundle-2c5bc535d95fd1ea",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-6d57d03c775eb7da",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-6d57d03c775eb7da",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-3b9e263c8960bb64",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-6d57d03c775eb7da",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-491d519ac5d8007a",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-6d57d03c775eb7da",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-58902fb0bf492b44",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-6d57d03c775eb7da",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-utils-5a97f076d1e012eb",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-6d57d03c775eb7da",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-715dd05656485a98",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-6d57d03c775eb7da",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-apk-tools-8886ee4b32d096d8",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-6d57d03c775eb7da",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-release-92ebbdd8cf0515d4",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-6d57d03c775eb7da",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-ae8e0365519d83ef",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-6d57d03c775eb7da",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-scanelf-b8497fa22ec08daf",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-6d57d03c775eb7da",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-binsh-d6267b7ca32e9850",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-6d57d03c775eb7da",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-zlib-f1d3ff3e048dfd34",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-6d57d03c775eb7da",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-alpine-baselayout-ae8e0365519d83ef",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-alpine-baselayout-data-3b9e263c8960bb64",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-alpine-keys-2c97c79d34d41e44",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-alpine-release-92ebbdd8cf0515d4",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-apk-tools-8886ee4b32d096d8",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-busybox-715dd05656485a98",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-busybox-binsh-d6267b7ca32e9850",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-ca-certificates-bundle-2c5bc535d95fd1ea",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-libcrypto3-58902fb0bf492b44",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-libssl3-1111ec29887aaaab",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-musl-491d519ac5d8007a",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-musl-utils-5a97f076d1e012eb",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-scanelf-b8497fa22ec08daf",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-ssl-client-062360195221b84a",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-zlib-f1d3ff3e048dfd34",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relatedSpdxElement": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relationshipType": "DESCRIBES"
+    }
+  ]
+}

--- a/securebuild-api/lib/sbom/testdata/alpine-latest.sbom
+++ b/securebuild-api/lib/sbom/testdata/alpine-latest.sbom
@@ -1,0 +1,3438 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "index.docker.io/library/alpine",
+  "documentNamespace": "https://anchore.com/syft/image/index.docker.io/library/alpine-82ed2ecd-a72f-4a00-9245-e3aab73dd1c0",
+  "creationInfo": {
+    "licenseListVersion": "3.25",
+    "creators": [
+      "Organization: Anchore, Inc",
+      "Tool: syft-1.28.0"
+    ],
+    "created": "2025-07-23T16:56:29Z"
+  },
+  "packages": [
+    {
+      "name": "alpine-baselayout",
+      "SPDXID": "SPDXRef-Package-apk-alpine-baselayout-9969dc1df7885cb8",
+      "versionInfo": "3.7.0-r0",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://git.alpinelinux.org/cgit/aports/tree/main/alpine-baselayout",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "212ae2d04ac2e5c4c312b43664d0bdf82d4df41e"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "GPL-2.0-only",
+      "copyrightText": "NOASSERTION",
+      "description": "Alpine base dir structure and init scripts",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-baselayout:alpine-baselayout:3.7.0-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-baselayout:alpine_baselayout:3.7.0-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_baselayout:alpine-baselayout:3.7.0-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_baselayout:alpine_baselayout:3.7.0-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine:alpine-baselayout:3.7.0-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine:alpine_baselayout:3.7.0-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/alpine-baselayout@3.7.0-r0?arch=aarch64&distro=alpine-3.22.1"
+        }
+      ]
+    },
+    {
+      "name": "alpine-baselayout-data",
+      "SPDXID": "SPDXRef-Package-apk-alpine-baselayout-data-bee90ff53f14673e",
+      "versionInfo": "3.7.0-r0",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://git.alpinelinux.org/cgit/aports/tree/main/alpine-baselayout",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "6a7d69893b8bca00a39ad9a06c6a7e2833593ad0"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "GPL-2.0-only",
+      "copyrightText": "NOASSERTION",
+      "description": "Alpine base dir structure and init scripts",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-baselayout-data:alpine-baselayout-data:3.7.0-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-baselayout-data:alpine_baselayout_data:3.7.0-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_baselayout_data:alpine-baselayout-data:3.7.0-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_baselayout_data:alpine_baselayout_data:3.7.0-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-baselayout:alpine-baselayout-data:3.7.0-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-baselayout:alpine_baselayout_data:3.7.0-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_baselayout:alpine-baselayout-data:3.7.0-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_baselayout:alpine_baselayout_data:3.7.0-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine:alpine-baselayout-data:3.7.0-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine:alpine_baselayout_data:3.7.0-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/alpine-baselayout-data@3.7.0-r0?arch=aarch64&distro=alpine-3.22.1&upstream=alpine-baselayout"
+        }
+      ]
+    },
+    {
+      "name": "alpine-keys",
+      "SPDXID": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "versionInfo": "2.5-r0",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://alpinelinux.org",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "a8ff80bf0aed8588400518f92c3a6afc4febbd50"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "description": "Public keys for Alpine Linux packages",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-keys:alpine-keys:2.5-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-keys:alpine_keys:2.5-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_keys:alpine-keys:2.5-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_keys:alpine_keys:2.5-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine:alpine-keys:2.5-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine:alpine_keys:2.5-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/alpine-keys@2.5-r0?arch=aarch64&distro=alpine-3.22.1"
+        }
+      ]
+    },
+    {
+      "name": "alpine-release",
+      "SPDXID": "SPDXRef-Package-apk-alpine-release-053b911c290830d5",
+      "versionInfo": "3.22.1-r0",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://alpinelinux.org",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "061a25708da36b187b9d71ae415b350b6f597afa"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "description": "Alpine release data",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-release:alpine-release:3.22.1-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine-release:alpine_release:3.22.1-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_release:alpine-release:3.22.1-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine_release:alpine_release:3.22.1-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine:alpine-release:3.22.1-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:alpine:alpine_release:3.22.1-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/alpine-release@3.22.1-r0?arch=aarch64&distro=alpine-3.22.1&upstream=alpine-base"
+        }
+      ]
+    },
+    {
+      "name": "apk-tools",
+      "SPDXID": "SPDXRef-Package-apk-apk-tools-6dd2f7c1b3d4916b",
+      "versionInfo": "2.14.9-r2",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://gitlab.alpinelinux.org/alpine/apk-tools",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "7dba3eaf30a466c67ddf509286520d746f996bf8"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "GPL-2.0-only",
+      "copyrightText": "NOASSERTION",
+      "description": "Alpine Package Keeper - package manager for alpine",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:apk-tools:apk-tools:2.14.9-r2:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:apk-tools:apk_tools:2.14.9-r2:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:apk_tools:apk-tools:2.14.9-r2:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:apk_tools:apk_tools:2.14.9-r2:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:apk:apk-tools:2.14.9-r2:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:apk:apk_tools:2.14.9-r2:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/apk-tools@2.14.9-r2?arch=aarch64&distro=alpine-3.22.1"
+        }
+      ]
+    },
+    {
+      "name": "busybox",
+      "SPDXID": "SPDXRef-Package-apk-busybox-cfbeef858806724b",
+      "versionInfo": "1.37.0-r18",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "https://busybox.net/",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "54df626826d7337aab2a9096b5baee06e9926015"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "GPL-2.0-only",
+      "copyrightText": "NOASSERTION",
+      "description": "Size optimized toolbox of many common UNIX utilities",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:busybox:busybox:1.37.0-r18:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/busybox@1.37.0-r18?arch=aarch64&distro=alpine-3.22.1"
+        }
+      ]
+    },
+    {
+      "name": "busybox-binsh",
+      "SPDXID": "SPDXRef-Package-apk-busybox-binsh-de1c98d914e8ec9c",
+      "versionInfo": "1.37.0-r18",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "https://busybox.net/",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "c0c54e2f07d471c17c4e8c4cc6efa64d520ca917"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "GPL-2.0-only",
+      "copyrightText": "NOASSERTION",
+      "description": "busybox ash /bin/sh",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:busybox-binsh:busybox-binsh:1.37.0-r18:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:busybox-binsh:busybox_binsh:1.37.0-r18:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:busybox_binsh:busybox-binsh:1.37.0-r18:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:busybox_binsh:busybox_binsh:1.37.0-r18:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:busybox:busybox-binsh:1.37.0-r18:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:busybox:busybox_binsh:1.37.0-r18:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/busybox-binsh@1.37.0-r18?arch=aarch64&distro=alpine-3.22.1&upstream=busybox"
+        }
+      ]
+    },
+    {
+      "name": "ca-certificates-bundle",
+      "SPDXID": "SPDXRef-Package-apk-ca-certificates-bundle-e3592a7874e0f5d6",
+      "versionInfo": "20250619-r0",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "6f0301f84aa838ef5fb0809d4fb6c473dcdd820a"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "(MPL-2.0 AND MIT)",
+      "copyrightText": "NOASSERTION",
+      "description": "Pre generated bundle of Mozilla certificates",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca-certificates-bundle:ca-certificates-bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca-certificates-bundle:ca_certificates_bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca_certificates_bundle:ca-certificates-bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca_certificates_bundle:ca_certificates_bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca-certificates:ca-certificates-bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca-certificates:ca_certificates_bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca_certificates:ca-certificates-bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca_certificates:ca_certificates_bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:mozilla:ca-certificates-bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:mozilla:ca_certificates_bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca:ca-certificates-bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ca:ca_certificates_bundle:20250619-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/ca-certificates-bundle@20250619-r0?arch=aarch64&distro=alpine-3.22.1&upstream=ca-certificates"
+        }
+      ]
+    },
+    {
+      "name": "libapk2",
+      "SPDXID": "SPDXRef-Package-apk-libapk2-4a5d20f9c635b3d3",
+      "versionInfo": "2.14.9-r2",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://gitlab.alpinelinux.org/alpine/apk-tools",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "767ea47174915ffbde295d3a330ca6722dc0ca4f"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "GPL-2.0-only",
+      "copyrightText": "NOASSERTION",
+      "description": "Alpine Package Keeper - package manager for alpine",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libapk2:libapk2:2.14.9-r2:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libapk2:libapk:2.14.9-r2:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libapk:libapk2:2.14.9-r2:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libapk:libapk:2.14.9-r2:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/libapk2@2.14.9-r2?arch=aarch64&distro=alpine-3.22.1&upstream=apk-tools"
+        }
+      ]
+    },
+    {
+      "name": "libcrypto3",
+      "SPDXID": "SPDXRef-Package-apk-libcrypto3-37b125e0a7e327fa",
+      "versionInfo": "3.5.1-r0",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://www.openssl.org/",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "53848e5155e2cd8f5c6284ef83c8a0c2c3ecc62f"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "Apache-2.0",
+      "copyrightText": "NOASSERTION",
+      "description": "Crypto library from openssl",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libcrypto3:libcrypto3:3.5.1-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libcrypto3:libcrypto:3.5.1-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libcrypto:libcrypto3:3.5.1-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libcrypto:libcrypto:3.5.1-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/libcrypto3@3.5.1-r0?arch=aarch64&distro=alpine-3.22.1&upstream=openssl"
+        }
+      ]
+    },
+    {
+      "name": "libssl3",
+      "SPDXID": "SPDXRef-Package-apk-libssl3-3cb125c75d760166",
+      "versionInfo": "3.5.1-r0",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://www.openssl.org/",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "c123638137a1f981600fe99215ed9181cb8dfd52"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "Apache-2.0",
+      "copyrightText": "NOASSERTION",
+      "description": "SSL shared libraries",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libssl3:libssl3:3.5.1-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libssl3:libssl:3.5.1-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libssl:libssl3:3.5.1-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:libssl:libssl:3.5.1-r0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/libssl3@3.5.1-r0?arch=aarch64&distro=alpine-3.22.1&upstream=openssl"
+        }
+      ]
+    },
+    {
+      "name": "musl",
+      "SPDXID": "SPDXRef-Package-apk-musl-61d4ade29f0ae917",
+      "versionInfo": "1.2.5-r10",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://musl.libc.org/",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "c777669e1153141a6180b4afd1625a663d74c322"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "description": "the musl c library (libc) implementation",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl-libc:musl:1.2.5-r10:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl_libc:musl:1.2.5-r10:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl:musl:1.2.5-r10:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/musl@1.2.5-r10?arch=aarch64&distro=alpine-3.22.1"
+        }
+      ]
+    },
+    {
+      "name": "musl-utils",
+      "SPDXID": "SPDXRef-Package-apk-musl-utils-57fa937cf9933488",
+      "versionInfo": "1.2.5-r10",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://musl.libc.org/",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "46b6d17b138cc3d14ee7daf8aeb1b2b75e4617a7"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "(MIT AND BSD-2-Clause AND GPL-2.0-or-later)",
+      "copyrightText": "NOASSERTION",
+      "description": "the musl c library (libc) implementation",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl-utils:musl-utils:1.2.5-r10:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl-utils:musl_utils:1.2.5-r10:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl_utils:musl-utils:1.2.5-r10:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl_utils:musl_utils:1.2.5-r10:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl-libc:musl-utils:1.2.5-r10:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl-libc:musl_utils:1.2.5-r10:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl:musl-utils:1.2.5-r10:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:musl:musl_utils:1.2.5-r10:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/musl-utils@1.2.5-r10?arch=aarch64&distro=alpine-3.22.1&upstream=musl"
+        }
+      ]
+    },
+    {
+      "name": "scanelf",
+      "SPDXID": "SPDXRef-Package-apk-scanelf-b7e9454f4655acca",
+      "versionInfo": "1.3.8-r1",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://wiki.gentoo.org/wiki/Hardened/PaX_Utilities",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "6c37ee49fafe2b78c7b9ba06c583c8566d37f204"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "GPL-2.0-only",
+      "copyrightText": "NOASSERTION",
+      "description": "Scan ELF binaries for stuff",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:scanelf:scanelf:1.3.8-r1:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/scanelf@1.3.8-r1?arch=aarch64&distro=alpine-3.22.1&upstream=pax-utils"
+        }
+      ]
+    },
+    {
+      "name": "ssl_client",
+      "SPDXID": "SPDXRef-Package-apk-ssl-client-ab983d6d9aef1e90",
+      "versionInfo": "1.37.0-r18",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "https://busybox.net/",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "2dc10bfc2fcb565682661c1728807a79175da79e"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "GPL-2.0-only",
+      "copyrightText": "NOASSERTION",
+      "description": "External ssl_client for busybox wget",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ssl-client:ssl-client:1.37.0-r18:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ssl-client:ssl_client:1.37.0-r18:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ssl_client:ssl-client:1.37.0-r18:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ssl_client:ssl_client:1.37.0-r18:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ssl:ssl-client:1.37.0-r18:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:ssl:ssl_client:1.37.0-r18:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/ssl_client@1.37.0-r18?arch=aarch64&distro=alpine-3.22.1&upstream=busybox"
+        }
+      ]
+    },
+    {
+      "name": "zlib",
+      "SPDXID": "SPDXRef-Package-apk-zlib-0a4e8ae587cecf91",
+      "versionInfo": "1.3.1-r2",
+      "supplier": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "originator": "Person: Natanael Copa (ncopa@alpinelinux.org)",
+      "downloadLocation": "https://zlib.net/",
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "f9864387da0607f0f1932782dfcb46bd73b2c42e"
+      },
+      "sourceInfo": "acquired package info from APK DB: /lib/apk/db/installed",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "Zlib",
+      "copyrightText": "NOASSERTION",
+      "description": "A compression/decompression Library",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:zlib:zlib:1.3.1-r2:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/zlib@1.3.1-r2?arch=aarch64&distro=alpine-3.22.1"
+        }
+      ]
+    },
+    {
+      "name": "index.docker.io/library/alpine",
+      "SPDXID": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "versionInfo": "sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3a9b58554e59e223086cefa2cc56bae18123c6e37ad3db9c651e1533a65edbfc"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:oci/index.docker.io%2Flibrary%2Falpine@sha256%3A3a9b58554e59e223086cefa2cc56bae18123c6e37ad3db9c651e1533a65edbfc?arch=arm64"
+        }
+      ],
+      "primaryPackagePurpose": "CONTAINER"
+    }
+  ],
+  "files": [
+    {
+      "fileName": "bin/busybox",
+      "SPDXID": "SPDXRef-File-bin-busybox-c86d12346e508d18",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c3476efa9b5d5044e8e3ed3888e7207cb2322897"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c879bc3e4a24d40158b2d4640f3c0fa75b1637551a44a45ec85e4b453e0ccd31"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/alpine-release",
+      "SPDXID": "SPDXRef-File-etc-alpine-release-89ef448f0ecaee53",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1111215ced905b2cc5bf2b26fcf2baa113fd87d5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "08842eac2718502d9d72a2f89396da3c28fbc73356b2077551bf662c832101f8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/apk/keys/alpine-devel@lists.alpinelinux.org-524d27bb.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-524d27bb.rsa.pub-2069b7216b44737e",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "053a92f87fd4532850bb31f0881978efe0532ae5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1bb2a846c0ea4ca9d0e7862f970863857fc33c32f5506098c636a62a726a847b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/apk/keys/alpine-devel@lists.alpinelinux.org-58199dcc.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-58199dcc.rsa.pub-2578c417555f8c93",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "39ac5d72c6ba018a0f74b8b453894edc9db07b5f"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "73867d92083f2f8ab899a26ccda7ef63dfaa0032a938620eda605558958a8041"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/apk/keys/alpine-devel@lists.alpinelinux.org-616a9724.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616a9724.rsa.pub-2db0fe767df27cbb",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "23d0f2ea1af269c2f66165e0f8a944e96bf011de"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "10877cce0a935e46ad88cb79e174a2491680508eccda08e92bf04fb9bf37fbc1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/apk/keys/alpine-devel@lists.alpinelinux.org-616adfeb.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616adfeb.rsa.pub-d10f33d3eaca8a13",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "de1241307014aae3dba798e900f163408d98d6f4"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ebe717d228555aa58133c202314a451f81e71f174781fd7ff8d8970d6cfa60da"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/apk/keys/alpine-devel@lists.alpinelinux.org-616ae350.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616ae350.rsa.pub-e36c3d0a4f298828",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "57f6b93fda4a4496fab62844ddef0eeb168f80b5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d11f6b21c61b4274e182eb888883a8ba8acdbf820dcc7a6d82a7d9fc2fd2836d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/busybox-paths.d/busybox",
+      "SPDXID": "SPDXRef-File-etc-busybox-paths.d-busybox-562ef61361680608",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "af9972dab927fb4bfcbf574de8cf870492a66657"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e12e0822f5c6426b62f07799a0fc20394241535c5bc2cc8f10c8a25088b8defa"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/crontabs/root",
+      "SPDXID": "SPDXRef-File-etc-crontabs-root-651bf1fdb69561fb",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bdf9356a9516238c8b2468613517749098b17ef6"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "575d810a9fae5f2f0671c9b2c0ce973e46c7207fbe5cb8d1b0d1836a6a0470e3"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/fstab",
+      "SPDXID": "SPDXRef-File-etc-fstab-678c51ecef5fd1f9",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d50ee135ef10a434b9df582ea8276b5c1ce803fa"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a3efca2e8d62785c87517283092b4c800d88612b6f3f06b80a4c2f39d8e68841"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/group",
+      "SPDXID": "SPDXRef-File-etc-group-fcdb480dc68f1008",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d8eb64e0cdfd7cfd998e4a1bbb49c2f45be5448d"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6fb6ab5a5526e6f4896b70c7e3c350fd475158a1f0d7b5fc0f3f9bd57f1c3be8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/hostname",
+      "SPDXID": "SPDXRef-File-etc-hostname-68b6f30bdd45c155",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ea75706155cffed0a1bd43ddba4543da27d73a67"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d906aecb61d076a967d9ffe8821c7b04b063f72df9d9e35b33ef36b1c0d98f16"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/hosts",
+      "SPDXID": "SPDXRef-File-etc-hosts-0857f1c8a623eb39",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "043eb324a653456caa1a73e2e2d49f77792bb0c5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e3998dbe02b51dada33de87ae43d18a93ab6915b9e34f5a751bf2b9b25a55492"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/inittab",
+      "SPDXID": "SPDXRef-File-etc-inittab-aa816f3da6fc3911",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ce9586d2acf1d9462765259a21ccc4f96a402151"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7326d8ad56bf5fea63b1ca516a747ff6e6723e25ae84a93c31620b03de6c001d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/issue",
+      "SPDXID": "SPDXRef-File-etc-issue-72c5216a35497a4c",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "899b1b34c0b62345726735f736a841e959f99414"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9b89537422a64a9a9407d3cafdf58c802375849629b8f43e64f1cfd7f07c782a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/logrotate.d/acpid",
+      "SPDXID": "SPDXRef-File-etc-logrotate.d-acpid-1b15fd38ed1e3ee4",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4f29720883559a74be03f4de69de2f66113b064b"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d608a3b7715886b5735def0cc50a6359fd364fac2e0e0a459c588c04be471031"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/modprobe.d/aliases.conf",
+      "SPDXID": "SPDXRef-File-etc-modprobe.d-aliases.conf-622c57dda4fd03ef",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5946e1e930583552bb7b863eb94bcbb3feef8aa9"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3ebaba946f213670170c7d69949f690a3854553bd0b1560f1d980cba4c83a942"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/modprobe.d/blacklist.conf",
+      "SPDXID": "SPDXRef-File-etc-modprobe.d-blacklist.conf-6d3666b11953134c",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e1376014791376ddee402f8d06dae7b4e9e6f67e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5cd46031fc7dc7186e67c97fd34780597de4ebff51dbe41eba27220fe5e0d866"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/modprobe.d/i386.conf",
+      "SPDXID": "SPDXRef-File-etc-modprobe.d-i386.conf-028d46e3ed8ad23f",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a676b2fe78e7ea897d702b2c2fb2a2659f1eb657"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6c46c4cbfb8b7594f19eb94801a350fa2221ae9ac5239a8819d15555caa76ae8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/modules",
+      "SPDXID": "SPDXRef-File-etc-modules-9dc3825a56b79125",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b68a208d48a91c670c8040a03c95fae12c144f53"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2c881de75a5409c35d2433a24f180b8b02ba478ef2c1c60ea3434a35bcbc335d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/motd",
+      "SPDXID": "SPDXRef-File-etc-motd-897525ee1c1b83a3",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "48b912f610627546cfc30af0f974745a1bf7c30f"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ff044e9be5daa2eee2d3d10a4da72e5477e4c24c16f1792de2c91dae844c0e30"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/network/if-up.d/dad",
+      "SPDXID": "SPDXRef-File-etc-network-if-up.d-dad-995466cf448f7a39",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ddd99bc197c36e8a9aab9463aaeebda44a7a8029"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2fd20d1bc67d9ee711990002b24f156635a73f56b8935b2f76592938817fa4e7"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/nsswitch.conf",
+      "SPDXID": "SPDXRef-File-etc-nsswitch.conf-7fd4dfe2bdef4683",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f4306c327bf44767da8da4e3a13bf40bdd4d3aaa"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0afd94c183d30a348b45057f6bf468e121aa448a7641109addb5bb8e282f514d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/passwd",
+      "SPDXID": "SPDXRef-File-etc-passwd-480427c71989c391",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "afe6cba27664032062c7f1cb812783b1ecf6d99b"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "31a94f06f17bc3b9085fccab1d0fa6ee9e79c4a1e4d91f617fa5de95863be015"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/profile",
+      "SPDXID": "SPDXRef-File-etc-profile-115d1ba50576445f",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "54dd1d99ac0383798113f96307ee9b52b0bb0f37"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "87e8643d3ce156de0c09370d4d39446f30bd00d264bea248abc191c4d7b9df3e"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/profile.d/20locale.sh",
+      "SPDXID": "SPDXRef-File-etc-profile.d-20locale.sh-48a21384ce080a52",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "96adbd950ccf992085295990f9bbe667f0cf4c4e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "284a6ef56ab97a13a777c6b01ae14f2cc3d2b7a29c19e750e622e70cc3c73186"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/profile.d/README",
+      "SPDXID": "SPDXRef-File-etc-profile.d-README-dfdfa591ac94428f",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "df9396b02cf3be70767e6171eb691baa6d40c759"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b73284f27fe2da9ae1902b1fe9596c3ffc61a154e2805a034184f0468f8b09b0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/profile.d/color_prompt.sh.disabled",
+      "SPDXID": "SPDXRef-File-etc-profile.d-color-prompt.sh.disabled-3997eba78c8bdc04",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d5733d99d7b5676f6d58c19a3a47a8bc3fe6e2e5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ba24425c6864a5d17fa0fdaf914c4d21419e47c4d62080c33830af059fe46617"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/protocols",
+      "SPDXID": "SPDXRef-File-etc-protocols-cca687b9aca278d6",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d5f9654539089b96f1b1956848d783527da6fb47"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4959498abbadaa1e50894a266f8d0d94500101cfe5b5f09dcad82e9d5bdfab46"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/secfixes.d/alpine",
+      "SPDXID": "SPDXRef-File-etc-secfixes.d-alpine-694c50caadc712f1",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "eb84e8a11ac9f18fd71f0d34e8155c3d287a3c43"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "808a19d200c575a9bd9898b113ca4538bb142878dd6a8e5f14804ba9ae3f5c38"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/securetty",
+      "SPDXID": "SPDXRef-File-etc-securetty-97034bbdb0ae230f",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0e29ce7fa251a4246033abcdaa339ec5dde84a75"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "713fcea5109728883b9147e822429133fcc8b5e253afd3c2a197b10cd0bc3b4d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/services",
+      "SPDXID": "SPDXRef-File-etc-services-4c8c5475b9e38f09",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a0d7a229bf049f7fe17e8445226236e4024535d0"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f6183055fd949f9c53d49ee620f85d0150123ea691d25ed1bba0c641b4ee2f48"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/shadow",
+      "SPDXID": "SPDXRef-File-etc-shadow-ea7de51a8062ab72",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "fdcce813d9a3aa27fffcf07126d2deabf17cb057"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d5992a27f05f380fc5faeb82a3359e2f230fd1d6ea6517b45892b771a2194ddb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/shells",
+      "SPDXID": "SPDXRef-File-etc-shells-ecee78fceb240709",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a239b661da4227a07f6a9183699fd275bdb12640"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "24be6ceb236610df45684c83b06c918ae45635be55f69975e43676b7595bbc5f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/ssl/certs/ca-certificates.crt",
+      "SPDXID": "SPDXRef-File-etc-ssl-certs-ca-certificates.crt-2be3b8e23eb13222",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4b79f0a91ec436b29eae65f74bb5c3a40cda11a7"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8cf3f2d5222508ca469c78a347764ee1b1fab10a903172612c489ebcca05c91c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/ssl/ct_log_list.cnf",
+      "SPDXID": "SPDXRef-File-etc-ssl-ct-log-list.cnf-bd0c05bc93e8a77c",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a2587c4e97408b64274e5e052b74e3754892c13a"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f1c1803d13d1d0b755b13b23c28bd4e20e07baf9f2b744c9337ba5866aa0ec3b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/ssl/ct_log_list.cnf.dist",
+      "SPDXID": "SPDXRef-File-etc-ssl-ct-log-list.cnf.dist-19b1deab379b0e9e",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a2587c4e97408b64274e5e052b74e3754892c13a"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f1c1803d13d1d0b755b13b23c28bd4e20e07baf9f2b744c9337ba5866aa0ec3b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/ssl/openssl.cnf",
+      "SPDXID": "SPDXRef-File-etc-ssl-openssl.cnf-a105fa1750cfa5d0",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5ff8070dceaa742043d8171f98abe95e5abd02e5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a65a2cb9f4ee8ffdc7ef4f0ac600c0bdafb95b7b1ab457188ac610a62f5ad6b3"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/ssl/openssl.cnf.dist",
+      "SPDXID": "SPDXRef-File-etc-ssl-openssl.cnf.dist-213d3a9ab1401c0a",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5ff8070dceaa742043d8171f98abe95e5abd02e5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a65a2cb9f4ee8ffdc7ef4f0ac600c0bdafb95b7b1ab457188ac610a62f5ad6b3"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/sysctl.conf",
+      "SPDXID": "SPDXRef-File-etc-sysctl.conf-6be9f00b2f17bfc2",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e2ea73ded7e7371664204b148569fb5e88b0f7a8"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8bba47da45bc8715c69ac904a60410eabffaa7bbbef640f9c1368ab9c48493d0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "etc/udhcpc/udhcpc.conf",
+      "SPDXID": "SPDXRef-File-etc-udhcpc-udhcpc.conf-905584afb448460c",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9bc069e434228e6ca441848bfb7a6bac23fa148a"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5b372209e01cda07c87b8afa6d1ab3d7e8daf18a1f2332d744203a6dc289eb1a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "lib/apk/db/installed",
+      "SPDXID": "SPDXRef-File-lib-apk-db-installed-b2475ccf7f79d847",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cd15a7fb4175b927bd81ebcd472d9a7b518ce8cc"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "07b3684dd5c4fd9493911c00c51d4767c446f00c8ea43d50791fa72c267c6d0d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "lib/ld-musl-aarch64.so.1",
+      "SPDXID": "SPDXRef-File-lib-ld-musl-aarch64.so.1-ecf550e0d7c443d8",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5c7f42d5751b563ee93b7cf220cb26ec0242dc9e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "da9c2d18642cf67ade0947b88b6859385c085fdbc6a022f5a8b518d7677e55df"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "sbin/apk",
+      "SPDXID": "SPDXRef-File-sbin-apk-2f97db2857c95821",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3da7c262c85f5640b833105b00921cedc7fc38cf"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bbad6d370fae30eae4deee67464d643f3a487cae0ae0c1c60b585a20014676f8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "sbin/ldconfig",
+      "SPDXID": "SPDXRef-File-sbin-ldconfig-ae5102feea84c48e",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2a36b6f8f3992b112450e66ac128c2ea499a103e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b4a2c06db38742e8c42c3c9838b285a7d8cdac6c091ff3df5ff9a15f1e41b9c7"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/bin/getconf",
+      "SPDXID": "SPDXRef-File-usr-bin-getconf-3b16a35f6792f91a",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "86ae45bbeed544d0b539dd4afdc4b6f8871f5fa3"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a97db0e7b82b367ecc4eb3e79a1c34345df98212712abfb2dc0fc5065eccfee2"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/bin/getent",
+      "SPDXID": "SPDXRef-File-usr-bin-getent-7d8e00bc47181629",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2a06a9b753cb41dd11cb91b6c18e0e35978b1d66"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3f546761ca3af0bea288e0773d45b9595729beccc3a6a9e03cdc64ac7a3574e0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/bin/iconv",
+      "SPDXID": "SPDXRef-File-usr-bin-iconv-ecde00b0ed445286",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "dc4e111f3e3b64194164fc82d33c639e298db39a"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3c0782718d643a0fa05667eaf40c5ad8d637d6165d80ab58ec8ad7c030e959d8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/bin/ldd",
+      "SPDXID": "SPDXRef-File-usr-bin-ldd-1a06d952250cd69e",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "afe298b72fc708b978a7876f3edf2409bd66841d"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5f115be8562262bcc50ec469e25c0af2fda3bad72a960c6aa3488acd7a7da8cf"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/bin/scanelf",
+      "SPDXID": "SPDXRef-File-usr-bin-scanelf-c081f6746cdfd07e",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1ffbccd413271ef94d95de4cab23953c7ccb68c7"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5178c52acd1df6c76260c3bdcc7f1657e3921e688d4ca4ad4da771752a5e42b1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/bin/ssl_client",
+      "SPDXID": "SPDXRef-File-usr-bin-ssl-client-9251b70e2701aa2f",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c5468cdb285d854607e83b8caf358509cc5a00d5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "477a365ad2b059c32f1d0d2323cbcade0cac66cccbb7173ec4ccf5f0e6f86062"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/lib/engines-3/afalg.so",
+      "SPDXID": "SPDXRef-File-usr-lib-engines-3-afalg.so-da9ac96cd609ff52",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "eb34b9892e03eba5cc2dab4276c87c22176b2a7f"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c2c1f96310e84144372505f96c9345aa33eda7508955db428fd34ca6fa6df123"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/lib/engines-3/capi.so",
+      "SPDXID": "SPDXRef-File-usr-lib-engines-3-capi.so-bc46cb4028580ce2",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7a83e91fc99f6437100dc29acb7a64ca701db86a"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9ac355f40676c4c868959f24657b76790739576f056fc3be295c1e5a57da84bb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/lib/engines-3/loader_attic.so",
+      "SPDXID": "SPDXRef-File-usr-lib-engines-3-loader-attic.so-b55d32677e792fd8",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e0cdc9383ee23e0d5dc38e3d6511a718e618ccae"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "325cf47419a8db1647fa3dfcee5297f792c0c49f8efcbc804f6dd9f674c1a1f2"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/lib/engines-3/padlock.so",
+      "SPDXID": "SPDXRef-File-usr-lib-engines-3-padlock.so-c28f7a526b6912cc",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "161f1f1432db35f1ecd52961b0cd67ac01b4c564"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c255dc36cf6ef8d150f3c337445e831acf789c2eaab71ab6a7ccce54df8e91a4"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/lib/libapk.so.2.14.9",
+      "SPDXID": "SPDXRef-File-usr-lib-libapk.so.2.14.9-2815b1f8c3d3a386",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "566235ac1f27c4d21e34ad4e03e8dfbb0e3e8bba"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8a326d446fcd4ce400ab876b6fc7ddf5dbc689cfe790c2e8d9e5d20580262757"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/lib/libcrypto.so.3",
+      "SPDXID": "SPDXRef-File-usr-lib-libcrypto.so.3-848702a5c4273213",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "37a16ca8a00efe11326713d1b4c82ecea74879f9"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "db5fba7b171215ee360a08a8eefef0d0cbdffd71e83b512c1a28b3bdd7e35fb8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/lib/libssl.so.3",
+      "SPDXID": "SPDXRef-File-usr-lib-libssl.so.3-2d213d8159a9b91c",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0102e0c8e438fa0fb61ccaad2a834886b20027c5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4342ae83a82c1eb466563d6ab76d50170b1c00125bfef84cfe62fbe5b4b422c8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/lib/libz.so.1.3.1",
+      "SPDXID": "SPDXRef-File-usr-lib-libz.so.1.3.1-112a4836e25d8a92",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "11d715829e98951e59ee8b60ad09bfdbf5e9d744"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "67fb66ae6b61b2fef8b3b6e2538926720b67737baaaf6711cdd6905352abd6e5"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/lib/os-release",
+      "SPDXID": "SPDXRef-File-usr-lib-os-release-8d7496c4996590ca",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0e9d3cda9a775ca4f7fbe9a9ef970275a7f3bc0b"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2fc5dc3fc3f4d3af126e3fdf9e5889ace04f6b9fa9d4e1bf7e78b78ea78598c8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/lib/ossl-modules/legacy.so",
+      "SPDXID": "SPDXRef-File-usr-lib-ossl-modules-legacy.so-08a3456c0b7b1c1d",
+      "fileTypes": [
+        "APPLICATION",
+        "BINARY"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b33955c3ac75219e28f08b48aee0d8ba8e7391fa"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "af6a78baecb6f938c428e62fe31cdbf43af1099c0dd58f7291f733dad95a9fda"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/lib/sysctl.d/00-alpine.conf",
+      "SPDXID": "SPDXRef-File-usr-lib-sysctl.d-00-alpine.conf-b1074f71e4ec1317",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1e9125cd6d7112098a7c446d4f2ee8a269a7aba7"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ee169bea2cb6859420b55ca7a9c23fb68b50adc1d26c951f904dec9e8f767380"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-4a6a0840.rsa.pub-c9201c42d954b670",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3af08548ef78cfdedcf349880c2c6a1a48763a0e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9c102bcc376af1498d549b77bdbfa815ae86faa1d2d82f040e616b18ef2df2d4"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-5243ef4b.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-5243ef4b.rsa.pub-0223c44b970e6b2c",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bfb616658cc05a872568b0c8e398c482e23b60dd"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ebf31683b56410ecc4c00acd9f6e2839e237a3b62b5ae7ef686705c7ba0396a9"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-524d27bb.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-524d27bb.rsa.pub-ae2783e79ab884e3",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "053a92f87fd4532850bb31f0881978efe0532ae5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1bb2a846c0ea4ca9d0e7862f970863857fc33c32f5506098c636a62a726a847b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-5261cecb.rsa.pub-779bc0638a7336ee",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3671ae0ec7503b1e193587c1dcdf7b78bc863e42"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "12f899e55a7691225603d6fb3324940fc51cd7f133e7ead788663c2b7eecb00c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58199dcc.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-58199dcc.rsa.pub-186141b34a4950d7",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "39ac5d72c6ba018a0f74b8b453894edc9db07b5f"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "73867d92083f2f8ab899a26ccda7ef63dfaa0032a938620eda605558958a8041"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58cbb476.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-58cbb476.rsa.pub-9b39337cb943d997",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c8fabeb2eeb992c368c77b9707e0d1ecfd7cf905"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9a4cd858d9710963848e6d5f555325dc199d1c952b01cf6e64da2c15deedbd97"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58e4f17d.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-58e4f17d.rsa.pub-02d45fa1246a7c00",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "329643357d0b78b1ef48ec155325e25f1d7534dd"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "780b3ed41786772cbc7b68136546fa3f897f28a23b30c72dde6225319c44cfff"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-5e69ca50.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-5e69ca50.rsa.pub-8315d9447fc7b711",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "825090fde25bbc0e71a9cb3076316b5afe459e4d"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "59c01c57b446633249f67c04b115dd6787f4378f183dff2bbf65406df93f176d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-60ac2099.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-60ac2099.rsa.pub-7e1169b4255f929e",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5d4743128353b6396fad2fa2ba793ace21602295"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "db0b49163f07ffba64a5ca198bcf1688610b0bd1f0d8d5afeaf78559d73f2278"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-6165ee59.rsa.pub-8b8786ab65cf308c",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "95995311236b7a55933642ffa10ce6014f1af7d0"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "207e4696d3c05f7cb05966aee557307151f1f00217af4143c1bcaf33b8df733f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-61666e3f.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-61666e3f.rsa.pub-ae57603d0835cb8d",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "58d5ba4b2f3b1e927721d7a6432f298eedf72a6b"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "128d34d4aec39b0daedea8163cd8dc24dff36fd3d848630ab97eeb1d3084bbb3"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616a9724.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616a9724.rsa.pub-660aa767a7868594",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "23d0f2ea1af269c2f66165e0f8a944e96bf011de"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "10877cce0a935e46ad88cb79e174a2491680508eccda08e92bf04fb9bf37fbc1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616abc23.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616abc23.rsa.pub-b589021836bc3533",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3529ec82670c6d4e20ee3e4968db34b551e91d50"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4a095a9daca86da496a3cd9adcd95ee2197fdbeb84638656d469f05a4d740751"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616ac3bc.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616ac3bc.rsa.pub-9125d61360d415cf",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "55a301064e11c6fe9ba0f2ca17e234f3943ccb61"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0caf5662fde45616d88cfd7021b7bda269a2fcaf311e51c48945a967a609ec0b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616adfeb.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616adfeb.rsa.pub-9489c9802068a38d",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "de1241307014aae3dba798e900f163408d98d6f4"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ebe717d228555aa58133c202314a451f81e71f174781fd7ff8d8970d6cfa60da"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616ae350.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616ae350.rsa.pub-2bc6a3d993d64233",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "57f6b93fda4a4496fab62844ddef0eeb168f80b5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d11f6b21c61b4274e182eb888883a8ba8acdbf820dcc7a6d82a7d9fc2fd2836d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616db30d.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616db30d.rsa.pub-528778d9dd2dc754",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "df02c9adc2906a3aa5e5ad69f50e3953e65710d0"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "40a216cbd163f22e5f16a9e0929de7cde221b9cbae8e36aa368b1e128afe0a31"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-66ba20fe.rsa.pub",
+      "SPDXID": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-66ba20fe.rsa.pub-61fc71d4ecd270f2",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7bd0eee2d55893735686932aa47a7c8a66e9153b"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7cf4cb8314e6ccc985b0d7f1aa0c6e0a81e3588f69a41f383af7a63d1ba61793"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    },
+    {
+      "fileName": "usr/share/udhcpc/default.script",
+      "SPDXID": "SPDXRef-File-usr-share-udhcpc-default.script-29bce663b557903f",
+      "fileTypes": [
+        "TEXT"
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "569e3f354139f964b3364c59276ffe0016ee33d9"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1cf94e3918ce389c722f4408490ae7334321a5ca2aec2c945b0c47662aa274a6"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a"
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-release-053b911c290830d5",
+      "relatedSpdxElement": "SPDXRef-File-etc-secfixes.d-alpine-694c50caadc712f1",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-release-053b911c290830d5",
+      "relatedSpdxElement": "SPDXRef-File-etc-issue-72c5216a35497a4c",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-release-053b911c290830d5",
+      "relatedSpdxElement": "SPDXRef-File-etc-alpine-release-89ef448f0ecaee53",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-release-053b911c290830d5",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-os-release-8d7496c4996590ca",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-zlib-0a4e8ae587cecf91",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-libz.so.1.3.1-112a4836e25d8a92",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-37b125e0a7e327fa",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-ossl-modules-legacy.so-08a3456c0b7b1c1d",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-37b125e0a7e327fa",
+      "relatedSpdxElement": "SPDXRef-File-etc-ssl-ct-log-list.cnf.dist-19b1deab379b0e9e",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-37b125e0a7e327fa",
+      "relatedSpdxElement": "SPDXRef-File-etc-ssl-openssl.cnf.dist-213d3a9ab1401c0a",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-37b125e0a7e327fa",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-libcrypto.so.3-848702a5c4273213",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-37b125e0a7e327fa",
+      "relatedSpdxElement": "SPDXRef-File-etc-ssl-openssl.cnf-a105fa1750cfa5d0",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-37b125e0a7e327fa",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-engines-3-loader-attic.so-b55d32677e792fd8",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-37b125e0a7e327fa",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-engines-3-capi.so-bc46cb4028580ce2",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-37b125e0a7e327fa",
+      "relatedSpdxElement": "SPDXRef-File-etc-ssl-ct-log-list.cnf-bd0c05bc93e8a77c",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-37b125e0a7e327fa",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-engines-3-padlock.so-c28f7a526b6912cc",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-37b125e0a7e327fa",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-engines-3-afalg.so-da9ac96cd609ff52",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libssl3-3cb125c75d760166",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-libssl.so.3-2d213d8159a9b91c",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libapk2-4a5d20f9c635b3d3",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-libapk.so.2.14.9-2815b1f8c3d3a386",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-5243ef4b.rsa.pub-0223c44b970e6b2c",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-58e4f17d.rsa.pub-02d45fa1246a7c00",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-58199dcc.rsa.pub-186141b34a4950d7",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-524d27bb.rsa.pub-2069b7216b44737e",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-58199dcc.rsa.pub-2578c417555f8c93",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616ae350.rsa.pub-2bc6a3d993d64233",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616a9724.rsa.pub-2db0fe767df27cbb",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616db30d.rsa.pub-528778d9dd2dc754",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-66ba20fe.rsa.pub-61fc71d4ecd270f2",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616a9724.rsa.pub-660aa767a7868594",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-5261cecb.rsa.pub-779bc0638a7336ee",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-60ac2099.rsa.pub-7e1169b4255f929e",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-5e69ca50.rsa.pub-8315d9447fc7b711",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-6165ee59.rsa.pub-8b8786ab65cf308c",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616ac3bc.rsa.pub-9125d61360d415cf",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616adfeb.rsa.pub-9489c9802068a38d",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-58cbb476.rsa.pub-9b39337cb943d997",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-524d27bb.rsa.pub-ae2783e79ab884e3",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-61666e3f.rsa.pub-ae57603d0835cb8d",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616abc23.rsa.pub-b589021836bc3533",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-4a6a0840.rsa.pub-c9201c42d954b670",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616adfeb.rsa.pub-d10f33d3eaca8a13",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-...alpine-devel-lists.alpinelinux.org-616ae350.rsa.pub-e36c3d0a4f298828",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-utils-57fa937cf9933488",
+      "relatedSpdxElement": "SPDXRef-File-usr-bin-ldd-1a06d952250cd69e",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-utils-57fa937cf9933488",
+      "relatedSpdxElement": "SPDXRef-File-usr-bin-getconf-3b16a35f6792f91a",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-utils-57fa937cf9933488",
+      "relatedSpdxElement": "SPDXRef-File-usr-bin-getent-7d8e00bc47181629",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-utils-57fa937cf9933488",
+      "relatedSpdxElement": "SPDXRef-File-sbin-ldconfig-ae5102feea84c48e",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-utils-57fa937cf9933488",
+      "relatedSpdxElement": "SPDXRef-File-usr-bin-iconv-ecde00b0ed445286",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-61d4ade29f0ae917",
+      "relatedSpdxElement": "SPDXRef-File-lib-ld-musl-aarch64.so.1-ecf550e0d7c443d8",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-apk-tools-6dd2f7c1b3d4916b",
+      "relatedSpdxElement": "SPDXRef-File-sbin-apk-2f97db2857c95821",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-9969dc1df7885cb8",
+      "relatedSpdxElement": "SPDXRef-File-etc-modprobe.d-i386.conf-028d46e3ed8ad23f",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-9969dc1df7885cb8",
+      "relatedSpdxElement": "SPDXRef-File-etc-profile.d-color-prompt.sh.disabled-3997eba78c8bdc04",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-9969dc1df7885cb8",
+      "relatedSpdxElement": "SPDXRef-File-etc-profile.d-20locale.sh-48a21384ce080a52",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-9969dc1df7885cb8",
+      "relatedSpdxElement": "SPDXRef-File-etc-modprobe.d-aliases.conf-622c57dda4fd03ef",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-9969dc1df7885cb8",
+      "relatedSpdxElement": "SPDXRef-File-etc-crontabs-root-651bf1fdb69561fb",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-9969dc1df7885cb8",
+      "relatedSpdxElement": "SPDXRef-File-etc-modprobe.d-blacklist.conf-6d3666b11953134c",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-9969dc1df7885cb8",
+      "relatedSpdxElement": "SPDXRef-File-etc-motd-897525ee1c1b83a3",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-9969dc1df7885cb8",
+      "relatedSpdxElement": "SPDXRef-File-usr-lib-sysctl.d-00-alpine.conf-b1074f71e4ec1317",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-9969dc1df7885cb8",
+      "relatedSpdxElement": "SPDXRef-File-etc-profile.d-README-dfdfa591ac94428f",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-ssl-client-ab983d6d9aef1e90",
+      "relatedSpdxElement": "SPDXRef-File-usr-bin-ssl-client-9251b70e2701aa2f",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-scanelf-b7e9454f4655acca",
+      "relatedSpdxElement": "SPDXRef-File-usr-bin-scanelf-c081f6746cdfd07e",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-bee90ff53f14673e",
+      "relatedSpdxElement": "SPDXRef-File-etc-hosts-0857f1c8a623eb39",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-bee90ff53f14673e",
+      "relatedSpdxElement": "SPDXRef-File-etc-profile-115d1ba50576445f",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-bee90ff53f14673e",
+      "relatedSpdxElement": "SPDXRef-File-etc-passwd-480427c71989c391",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-bee90ff53f14673e",
+      "relatedSpdxElement": "SPDXRef-File-etc-services-4c8c5475b9e38f09",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-bee90ff53f14673e",
+      "relatedSpdxElement": "SPDXRef-File-etc-fstab-678c51ecef5fd1f9",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-bee90ff53f14673e",
+      "relatedSpdxElement": "SPDXRef-File-etc-hostname-68b6f30bdd45c155",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-bee90ff53f14673e",
+      "relatedSpdxElement": "SPDXRef-File-etc-sysctl.conf-6be9f00b2f17bfc2",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-bee90ff53f14673e",
+      "relatedSpdxElement": "SPDXRef-File-etc-nsswitch.conf-7fd4dfe2bdef4683",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-bee90ff53f14673e",
+      "relatedSpdxElement": "SPDXRef-File-etc-modules-9dc3825a56b79125",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-bee90ff53f14673e",
+      "relatedSpdxElement": "SPDXRef-File-etc-inittab-aa816f3da6fc3911",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-bee90ff53f14673e",
+      "relatedSpdxElement": "SPDXRef-File-etc-protocols-cca687b9aca278d6",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-bee90ff53f14673e",
+      "relatedSpdxElement": "SPDXRef-File-etc-shadow-ea7de51a8062ab72",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-bee90ff53f14673e",
+      "relatedSpdxElement": "SPDXRef-File-etc-shells-ecee78fceb240709",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-bee90ff53f14673e",
+      "relatedSpdxElement": "SPDXRef-File-etc-group-fcdb480dc68f1008",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-cfbeef858806724b",
+      "relatedSpdxElement": "SPDXRef-File-etc-logrotate.d-acpid-1b15fd38ed1e3ee4",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-cfbeef858806724b",
+      "relatedSpdxElement": "SPDXRef-File-usr-share-udhcpc-default.script-29bce663b557903f",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-cfbeef858806724b",
+      "relatedSpdxElement": "SPDXRef-File-etc-busybox-paths.d-busybox-562ef61361680608",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-cfbeef858806724b",
+      "relatedSpdxElement": "SPDXRef-File-etc-udhcpc-udhcpc.conf-905584afb448460c",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-cfbeef858806724b",
+      "relatedSpdxElement": "SPDXRef-File-etc-securetty-97034bbdb0ae230f",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-cfbeef858806724b",
+      "relatedSpdxElement": "SPDXRef-File-etc-network-if-up.d-dad-995466cf448f7a39",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-cfbeef858806724b",
+      "relatedSpdxElement": "SPDXRef-File-bin-busybox-c86d12346e508d18",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-binsh-de1c98d914e8ec9c",
+      "relatedSpdxElement": "SPDXRef-File-bin-busybox-c86d12346e508d18",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-ca-certificates-bundle-e3592a7874e0f5d6",
+      "relatedSpdxElement": "SPDXRef-File-etc-ssl-certs-ca-certificates.crt-2be3b8e23eb13222",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-zlib-0a4e8ae587cecf91",
+      "relatedSpdxElement": "SPDXRef-Package-apk-libapk2-4a5d20f9c635b3d3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-zlib-0a4e8ae587cecf91",
+      "relatedSpdxElement": "SPDXRef-Package-apk-apk-tools-6dd2f7c1b3d4916b",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-37b125e0a7e327fa",
+      "relatedSpdxElement": "SPDXRef-Package-apk-libssl3-3cb125c75d760166",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-37b125e0a7e327fa",
+      "relatedSpdxElement": "SPDXRef-Package-apk-libapk2-4a5d20f9c635b3d3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-37b125e0a7e327fa",
+      "relatedSpdxElement": "SPDXRef-Package-apk-apk-tools-6dd2f7c1b3d4916b",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-37b125e0a7e327fa",
+      "relatedSpdxElement": "SPDXRef-Package-apk-ssl-client-ab983d6d9aef1e90",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libssl3-3cb125c75d760166",
+      "relatedSpdxElement": "SPDXRef-Package-apk-libapk2-4a5d20f9c635b3d3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libssl3-3cb125c75d760166",
+      "relatedSpdxElement": "SPDXRef-Package-apk-ssl-client-ab983d6d9aef1e90",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libapk2-4a5d20f9c635b3d3",
+      "relatedSpdxElement": "SPDXRef-Package-apk-apk-tools-6dd2f7c1b3d4916b",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-Package-apk-alpine-release-053b911c290830d5",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-61d4ade29f0ae917",
+      "relatedSpdxElement": "SPDXRef-Package-apk-zlib-0a4e8ae587cecf91",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-61d4ade29f0ae917",
+      "relatedSpdxElement": "SPDXRef-Package-apk-libcrypto3-37b125e0a7e327fa",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-61d4ade29f0ae917",
+      "relatedSpdxElement": "SPDXRef-Package-apk-libssl3-3cb125c75d760166",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-61d4ade29f0ae917",
+      "relatedSpdxElement": "SPDXRef-Package-apk-libapk2-4a5d20f9c635b3d3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-61d4ade29f0ae917",
+      "relatedSpdxElement": "SPDXRef-Package-apk-musl-utils-57fa937cf9933488",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-61d4ade29f0ae917",
+      "relatedSpdxElement": "SPDXRef-Package-apk-apk-tools-6dd2f7c1b3d4916b",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-61d4ade29f0ae917",
+      "relatedSpdxElement": "SPDXRef-Package-apk-ssl-client-ab983d6d9aef1e90",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-61d4ade29f0ae917",
+      "relatedSpdxElement": "SPDXRef-Package-apk-scanelf-b7e9454f4655acca",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-61d4ade29f0ae917",
+      "relatedSpdxElement": "SPDXRef-Package-apk-busybox-cfbeef858806724b",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-scanelf-b7e9454f4655acca",
+      "relatedSpdxElement": "SPDXRef-Package-apk-musl-utils-57fa937cf9933488",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-bee90ff53f14673e",
+      "relatedSpdxElement": "SPDXRef-Package-apk-alpine-baselayout-9969dc1df7885cb8",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-cfbeef858806724b",
+      "relatedSpdxElement": "SPDXRef-Package-apk-busybox-binsh-de1c98d914e8ec9c",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-binsh-de1c98d914e8ec9c",
+      "relatedSpdxElement": "SPDXRef-Package-apk-alpine-baselayout-9969dc1df7885cb8",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-ca-certificates-bundle-e3592a7874e0f5d6",
+      "relatedSpdxElement": "SPDXRef-Package-apk-libapk2-4a5d20f9c635b3d3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-ca-certificates-bundle-e3592a7874e0f5d6",
+      "relatedSpdxElement": "SPDXRef-Package-apk-apk-tools-6dd2f7c1b3d4916b",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-release-053b911c290830d5",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-b2475ccf7f79d847",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-zlib-0a4e8ae587cecf91",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-b2475ccf7f79d847",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libcrypto3-37b125e0a7e327fa",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-b2475ccf7f79d847",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libssl3-3cb125c75d760166",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-b2475ccf7f79d847",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-libapk2-4a5d20f9c635b3d3",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-b2475ccf7f79d847",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-b2475ccf7f79d847",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-utils-57fa937cf9933488",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-b2475ccf7f79d847",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-musl-61d4ade29f0ae917",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-b2475ccf7f79d847",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-apk-tools-6dd2f7c1b3d4916b",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-b2475ccf7f79d847",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-9969dc1df7885cb8",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-b2475ccf7f79d847",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-ssl-client-ab983d6d9aef1e90",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-b2475ccf7f79d847",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-scanelf-b7e9454f4655acca",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-b2475ccf7f79d847",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-alpine-baselayout-data-bee90ff53f14673e",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-b2475ccf7f79d847",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-cfbeef858806724b",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-b2475ccf7f79d847",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-busybox-binsh-de1c98d914e8ec9c",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-b2475ccf7f79d847",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-apk-ca-certificates-bundle-e3592a7874e0f5d6",
+      "relatedSpdxElement": "SPDXRef-File-lib-apk-db-installed-b2475ccf7f79d847",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-alpine-baselayout-9969dc1df7885cb8",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-alpine-baselayout-data-bee90ff53f14673e",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-alpine-keys-50de8c313ff4d985",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-alpine-release-053b911c290830d5",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-apk-tools-6dd2f7c1b3d4916b",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-busybox-cfbeef858806724b",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-busybox-binsh-de1c98d914e8ec9c",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-ca-certificates-bundle-e3592a7874e0f5d6",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-libapk2-4a5d20f9c635b3d3",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-libcrypto3-37b125e0a7e327fa",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-libssl3-3cb125c75d760166",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-musl-61d4ade29f0ae917",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-musl-utils-57fa937cf9933488",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-scanelf-b7e9454f4655acca",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-ssl-client-ab983d6d9aef1e90",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relatedSpdxElement": "SPDXRef-Package-apk-zlib-0a4e8ae587cecf91",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relatedSpdxElement": "SPDXRef-DocumentRoot-Image-index.docker.io-library-alpine",
+      "relationshipType": "DESCRIBES"
+    }
+  ]
+}

--- a/securebuild-api/lib/sbom/testdata/hello-world-latest.sbom
+++ b/securebuild-api/lib/sbom/testdata/hello-world-latest.sbom
@@ -1,0 +1,67 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "index.docker.io/library/hello-world",
+  "documentNamespace": "https://anchore.com/syft/image/index.docker.io/library/hello-world-6c670434-244e-4e88-a5e2-75b553ea09e8",
+  "creationInfo": {
+    "licenseListVersion": "3.25",
+    "creators": [
+      "Organization: Anchore, Inc",
+      "Tool: syft-1.28.0"
+    ],
+    "created": "2025-07-16T19:37:40Z"
+  },
+  "packages": [
+    {
+      "name": "index.docker.io/library/hello-world",
+      "SPDXID": "SPDXRef-DocumentRoot-Image-index.docker.io-library-hello-world",
+      "versionInfo": "sha256:ec153840d1e635ac434fab5e377081f17e0e15afab27beb3f726c3265039cfff",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c5f10b4c90f129d1bc72f7e1af5ad9083ec99499066358d2e75371b7c747545f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:oci/index.docker.io%2Flibrary%2Fhello-world@sha256%3Ac5f10b4c90f129d1bc72f7e1af5ad9083ec99499066358d2e75371b7c747545f?arch=arm64"
+        }
+      ],
+      "primaryPackagePurpose": "CONTAINER"
+    }
+  ],
+  "files": [
+    {
+      "fileName": "hello",
+      "SPDXID": "SPDXRef-File-hello-145f3f8c320f7855",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0000000000000000000000000000000000000000"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "comment": "layerID: sha256:98a92b28c9b8d3cd4353801cba6ad181e86aaa616221e14739210acbda35b7fd"
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relatedSpdxElement": "SPDXRef-DocumentRoot-Image-index.docker.io-library-hello-world",
+      "relationshipType": "DESCRIBES"
+    }
+  ]
+}

--- a/securebuild-api/lib/team/service-account.ts
+++ b/securebuild-api/lib/team/service-account.ts
@@ -1,0 +1,373 @@
+import srs from "secure-random-string";
+import { getDB } from "../data/db";
+import { getParam } from "../data/param";
+import { ServiceAccount, ServiceAccountWithValue } from "../types/service-account";
+import { traceFunction, getActiveSpan } from "../observability/tracing";
+import {
+  generateServiceAccountToken,
+  hashTokenSHA256,
+  verifyTokenBcrypt,
+  serviceAccountGetPartialValue,
+  ALGORITHM_SHA256,
+  ALGORITHM_BCRYPT,
+} from "./token";
+
+// ErrServiceAccountNotFound is returned when a service account is not found
+export class ServiceAccountNotFoundError extends Error {
+  constructor(message: string = "service account not found") {
+    super(message);
+    this.name = "ServiceAccountNotFoundError";
+  }
+}
+
+export async function createServiceAccount(teamId: string, name: string, expiresIn: string): Promise<ServiceAccountWithValue> {
+  try {
+    const db = getDB(await getParam("DB_URI"));
+
+    // Generate new token with SHA-256
+    const { token, hash, partialValue } = generateServiceAccountToken();
+
+    const id = srs({ length: 12, alphanumeric: true });
+    const expiresAt = expiresIn === 'never' ? null : new Date(Date.now() + parseInt(expiresIn) * 24 * 60 * 60 * 1000);
+    const createdAt = new Date();
+
+    const result = await db.query(
+      `
+        INSERT INTO service_account (id, name, partial_value, expires_at, expires_in, last_used_at, created_at, team_id, bcrypt_hash, hash_algorithm)
+        VALUES ($1, $2, $3, $4, $5, null, $6, $7, $8, $9)
+        RETURNING id, name, partial_value, expires_at, expires_in, last_used_at, created_at
+      `,
+      [id, name, partialValue, expiresAt, expiresIn, createdAt, teamId, hash, ALGORITHM_SHA256]
+    );
+
+    return {
+      id: result.rows[0].id,
+      name: result.rows[0].name,
+      partialValue: result.rows[0].partial_value,
+      expiresAt: result.rows[0].expires_at,
+      expiresIn: result.rows[0].expires_in,
+      lastUsedAt: result.rows[0].last_used_at,
+      createdAt: result.rows[0].created_at,
+      value: token,
+    };
+  } catch (err) {
+    console.error("Error creating service account:", err);
+    throw err;
+  }
+}
+
+export async function rotateServiceAccount(serviceAccount: ServiceAccount): Promise<ServiceAccountWithValue> {
+  try {
+    const db = getDB(await getParam("DB_URI"));
+
+    // Generate new token with SHA-256
+    const { token, hash, partialValue } = generateServiceAccountToken();
+
+    const expiresIn = serviceAccount.expiresIn;
+    const expiresAt = expiresIn === 'never' ? null : new Date(Date.now() + parseInt(expiresIn!) * 24 * 60 * 60 * 1000);
+
+    await db.query(
+      `update service_account set partial_value = $1, bcrypt_hash = $2, expires_at = $3, hash_algorithm = $4 where id = $5`,
+      [partialValue, hash, expiresAt, ALGORITHM_SHA256, serviceAccount.id]
+    );
+
+    return {
+      id: serviceAccount.id,
+      name: serviceAccount.name,
+      partialValue: partialValue,
+      expiresAt: expiresAt,
+      expiresIn: expiresIn,
+      lastUsedAt: serviceAccount.lastUsedAt,
+      createdAt: serviceAccount.createdAt,
+      value: token,
+    };
+  } catch (err) {
+    console.error("Error rotating service account:", err);
+    throw err;
+  }
+}
+
+export async function deleteServiceAccount(serviceAccount: ServiceAccount): Promise<void> {
+  try {
+    const db = getDB(await getParam("DB_URI"));
+    await db.query(`delete from service_account where id = $1`, [serviceAccount.id]);
+  } catch (err) {
+    console.error("Error deleting service account:", err);
+    throw err;
+  }
+}
+
+export async function listServiceAccounts(teamId: string): Promise<ServiceAccount[]> {
+  try {
+    const db = getDB(await getParam("DB_URI"));
+
+    const query = `select id, name, partial_value, expires_at, expires_in, last_used_at, created_at from service_account where team_id = $1`
+    const result = await db.query(query, [teamId]);
+
+    const serviceAccounts = result.rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      partialValue: row.partial_value,
+      expiresAt: row.expires_at,
+      expiresIn: row.expires_in,
+      lastUsedAt: row.last_used_at,
+      createdAt: row.created_at,
+    }));
+
+    return serviceAccounts;
+  } catch (err) {
+    console.error("Error listing service accounts:", err);
+    throw err;
+  }
+}
+
+export async function renameServiceAccount(serviceAccountId: string, newName: string): Promise<void> {
+  try {
+    const db = getDB(await getParam("DB_URI"));
+    await db.query(`update service_account set name = $1 where id = $2`, [newName, serviceAccountId]);
+  } catch (err) {
+    console.error("Error renaming service account:", err);
+    throw err;
+  }
+}
+
+/**
+ * UpdateServiceAccountLastActive updates the last used timestamp for a service account
+ *
+ * It returns an error if the update fails.
+ */
+async function updateServiceAccountLastActive(serviceAccountID: string): Promise<void> {
+  const db = getDB(await getParam("DB_URI"));
+  const query = `update service_account set last_used_at = now() where id = $1`;
+  await db.query(query, [serviceAccountID]);
+}
+
+/**
+ * findServiceAccountWithValueSHA256 looks up a service account using SHA-256 hash lookup
+ *
+ * This is the fast path for new tokens.
+ */
+async function findServiceAccountWithValueSHA256(
+  teamId: string | undefined,
+  plainTextValue: string
+): Promise<{ serviceAccount: ServiceAccount; teamId: string }> {
+  const db = getDB(await getParam("DB_URI"));
+
+  // Fast path: Try SHA-256 lookup first (for new tokens)
+  const sha256Hash = hashTokenSHA256(plainTextValue);
+
+  let sha256Query: string;
+  let queryParams: any[];
+
+  if (teamId) {
+    sha256Query = `
+      SELECT id, name, expires_at, hash_algorithm, expires_in, last_used_at, created_at, team_id, partial_value
+      FROM service_account
+      WHERE team_id = $1
+        AND bcrypt_hash = $2
+        AND hash_algorithm = $3
+        AND (expires_at IS NULL OR expires_at > NOW())
+    `;
+    queryParams = [teamId, sha256Hash, ALGORITHM_SHA256];
+  } else {
+    sha256Query = `
+      SELECT id, name, expires_at, hash_algorithm, expires_in, last_used_at, created_at, team_id, partial_value
+      FROM service_account
+      WHERE bcrypt_hash = $1
+        AND hash_algorithm = $2
+        AND (expires_at IS NULL OR expires_at > NOW())
+    `;
+    queryParams = [sha256Hash, ALGORITHM_SHA256];
+  }
+
+  const result = await db.query(sha256Query, queryParams);
+
+  if (result.rows.length === 0) {
+    throw new ServiceAccountNotFoundError();
+  }
+
+  const row = result.rows[0];
+
+  return {
+    serviceAccount: {
+      id: row.id,
+      name: row.name,
+      partialValue: row.partial_value,
+      expiresAt: row.expires_at,
+      expiresIn: row.expires_in,
+      lastUsedAt: row.last_used_at,
+      createdAt: row.created_at,
+    },
+    teamId: row.team_id,
+  };
+}
+
+/**
+ * findServiceAccountWithValueBcrypt looks up a service account using bcrypt comparison
+ *
+ * This is the slow path for legacy tokens. If a match is found, it automatically
+ * migrates the token to SHA-256.
+ */
+async function findServiceAccountWithValueBcrypt(
+  teamId: string | undefined,
+  plainTextValue: string
+): Promise<{ serviceAccount: ServiceAccount; teamId: string }> {
+  const db = getDB(await getParam("DB_URI"));
+
+  // Slow path: Fall back to bcrypt for legacy tokens
+  // Use partial_value filter to reduce bcrypt comparisons
+  const partialValue = serviceAccountGetPartialValue(plainTextValue);
+
+  let query: string;
+  let queryParams: any[];
+
+  if (teamId) {
+    query = `
+      SELECT id, name, expires_at, bcrypt_hash, expires_in, last_used_at, created_at, team_id, partial_value
+      FROM service_account
+      WHERE team_id = $1
+        AND hash_algorithm = $2
+        AND partial_value = $3
+        AND (expires_at IS NULL OR expires_at > NOW())
+    `;
+    queryParams = [teamId, ALGORITHM_BCRYPT, partialValue];
+  } else {
+    query = `
+      SELECT id, name, expires_at, bcrypt_hash, expires_in, last_used_at, created_at, team_id, partial_value
+      FROM service_account
+      WHERE hash_algorithm = $1
+        AND partial_value = $2
+        AND (expires_at IS NULL OR expires_at > NOW())
+    `;
+    queryParams = [ALGORITHM_BCRYPT, partialValue];
+  }
+
+  const result = await db.query(query, queryParams);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const serviceAccounts: Map<string, { row: any }> = new Map();
+
+  for (const row of result.rows) {
+    serviceAccounts.set(row.bcrypt_hash, { row });
+  }
+
+  for (const [hash, { row }] of serviceAccounts) {
+    const isMatch = await verifyTokenBcrypt(plainTextValue, hash);
+    if (isMatch) {
+      const fields = {
+        serviceAccountID: row.id,
+        teamId,
+      };
+
+      console.log("found service account with bcrypt", fields);
+
+      // Auto-migrate to SHA-256
+      const newHash = hashTokenSHA256(plainTextValue);
+      const migrationQuery = `
+        UPDATE service_account
+        SET bcrypt_hash = $1, hash_algorithm = $2
+        WHERE id = $3
+      `;
+
+      try {
+        await db.query(migrationQuery, [newHash, ALGORITHM_SHA256, row.id]);
+        console.log("migrated service account token from bcrypt to SHA-256", fields);
+      } catch (err) {
+        console.error("failed to migrate token to SHA-256 for service account", fields, err);
+        // Don't fail authentication if migration fails
+      }
+
+      return {
+        serviceAccount: {
+          id: row.id,
+          name: row.name,
+          partialValue: row.partial_value,
+          expiresAt: row.expires_at,
+          expiresIn: row.expires_in,
+          lastUsedAt: row.last_used_at,
+          createdAt: row.created_at,
+        },
+        teamId: row.team_id,
+      };
+    }
+  }
+
+  throw new ServiceAccountNotFoundError();
+}
+
+/**
+ * FindServiceAccountWithValue looks up a service account by its plain text value,
+ * first trying SHA-256 and then bcrypt
+ *
+ * If the service account is found, it returns the service account and teamId.
+ * If the service account is not found, it returns null.
+ * If the service account is found with bcrypt, it will automatically migrate it to SHA-256.
+ *
+ * @param teamIdOrPlainText - Either the teamId (when both params provided) or plainTextValue (when single param)
+ * @param plainTextValue - The plain text token value (optional, used when teamId is provided)
+ */
+export const findServiceAccountWithValue = traceFunction(
+  "lib.team.findServiceAccountWithValue",
+  async (
+    teamIdOrPlainText: string,
+    plainTextValue?: string
+  ): Promise<{ serviceAccount: ServiceAccount; teamId: string } | null> => {
+    // Handle both signatures: (plainTextValue) and (teamId, plainTextValue)
+    let teamId: string | undefined;
+    let token: string;
+
+    if (plainTextValue === undefined) {
+      // Single parameter: findServiceAccountWithValue(plainTextValue)
+      teamId = undefined;
+      token = teamIdOrPlainText;
+    } else {
+      // Two parameters: findServiceAccountWithValue(teamId, plainTextValue)
+      teamId = teamIdOrPlainText;
+      token = plainTextValue;
+    }
+    try {
+      const activeSpan = getActiveSpan();
+
+      // Try SHA-256 first (fast path)
+      try {
+        const result = await findServiceAccountWithValueSHA256(teamId, token);
+
+        // Update last used timestamp
+        await updateServiceAccountLastActive(result.serviceAccount.id);
+        result.serviceAccount.lastUsedAt = new Date(); // Update in returned object
+
+        activeSpan?.setTag("lookup.method", "sha256");
+        return result;
+      } catch (err) {
+        if (!(err instanceof ServiceAccountNotFoundError)) {
+          // If it's not a "not found" error, rethrow
+          throw err;
+        }
+        // Continue to bcrypt fallback
+      }
+
+      // Try bcrypt (slow path for legacy tokens)
+      try {
+        const result = await findServiceAccountWithValueBcrypt(teamId, token);
+
+        // Update last used timestamp
+        await updateServiceAccountLastActive(result.serviceAccount.id);
+        result.serviceAccount.lastUsedAt = new Date(); // Update in returned object
+
+        activeSpan?.setTag("lookup.method", "bcrypt");
+        return result;
+      } catch (err) {
+        if (!(err instanceof ServiceAccountNotFoundError)) {
+          // If it's not a "not found" error, rethrow
+          throw err;
+        }
+        // Token not found with either method
+      }
+
+      return null;
+    } catch (err) {
+      console.error("Error finding service account with value:", err);
+      throw err;
+    }
+  }
+);

--- a/securebuild-api/lib/team/token.test.ts
+++ b/securebuild-api/lib/team/token.test.ts
@@ -1,0 +1,412 @@
+import crypto from "crypto";
+import bcrypt from "bcrypt";
+import {
+  generateServiceAccountToken,
+  hashTokenSHA256,
+  verifyTokenSHA256,
+  verifyTokenBcrypt,
+  serviceAccountGetPartialValue,
+  ALGORITHM_SHA256,
+  ALGORITHM_BCRYPT,
+} from "./token";
+
+describe("Service Account Token Functions", () => {
+  describe("generateServiceAccountToken", () => {
+    it("should generate a token with correct structure", () => {
+      const result = generateServiceAccountToken();
+
+      expect(result).toHaveProperty("token");
+      expect(result).toHaveProperty("hash");
+      expect(result).toHaveProperty("partialValue");
+      expect(typeof result.token).toBe("string");
+      expect(typeof result.hash).toBe("string");
+      expect(typeof result.partialValue).toBe("string");
+    });
+
+    it("should generate token with correct prefix", () => {
+      const result = generateServiceAccountToken();
+
+      expect(result.token).toMatch(/^sbld_sa_/);
+    });
+
+    it("should generate token with sufficient random data", () => {
+      const result = generateServiceAccountToken();
+
+      // Token should be prefix (8 chars) + 32 random chars = at least 40 chars
+      expect(result.token.length).toBeGreaterThanOrEqual(40);
+    });
+
+    it("should generate unique tokens on each call", () => {
+      const result1 = generateServiceAccountToken();
+      const result2 = generateServiceAccountToken();
+      const result3 = generateServiceAccountToken();
+
+      expect(result1.token).not.toBe(result2.token);
+      expect(result1.token).not.toBe(result3.token);
+      expect(result2.token).not.toBe(result3.token);
+      expect(result1.hash).not.toBe(result2.hash);
+    });
+
+    it("should generate valid base64 hash", () => {
+      const result = generateServiceAccountToken();
+
+      // Base64 regex pattern
+      const base64Regex = /^[A-Za-z0-9+/]*={0,2}$/;
+      expect(result.hash).toMatch(base64Regex);
+    });
+
+    it("should extract partial value from token", () => {
+      const result = generateServiceAccountToken();
+
+      // Partial value should be 4 characters from after the prefix
+      expect(result.partialValue.length).toBe(12);
+
+      // Verify the partial value matches what's in the token
+      expect(result.partialValue).toBe(result.token.substring(0, 12));
+    });
+
+    it("should generate hash that can verify the token", () => {
+      const result = generateServiceAccountToken();
+
+      // The generated hash should verify the generated token
+      const isValid = verifyTokenSHA256(result.token, result.hash);
+      expect(isValid).toBe(true);
+    });
+  });
+
+  describe("hashTokenSHA256", () => {
+    it("should return consistent hash for same input", () => {
+      const token = "sbld_sa_test123456789";
+      const hash1 = hashTokenSHA256(token);
+      const hash2 = hashTokenSHA256(token);
+
+      expect(hash1).toBe(hash2);
+    });
+
+    it("should return different hashes for different inputs", () => {
+      const token1 = "sbld_sa_test123456789";
+      const token2 = "sbld_sa_test987654321";
+      const hash1 = hashTokenSHA256(token1);
+      const hash2 = hashTokenSHA256(token2);
+
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it("should return base64 encoded string", () => {
+      const token = "sbld_sa_test123456789";
+      const hash = hashTokenSHA256(token);
+
+      // Base64 regex pattern
+      const base64Regex = /^[A-Za-z0-9+/]*={0,2}$/;
+      expect(hash).toMatch(base64Regex);
+    });
+
+    it("should produce SHA-256 hash of correct length", () => {
+      const token = "sbld_sa_test123456789";
+      const hash = hashTokenSHA256(token);
+
+      // SHA-256 produces 32 bytes, which in base64 is 44 characters (with padding)
+      const decodedHash = Buffer.from(hash, "base64");
+      expect(decodedHash.length).toBe(32);
+    });
+
+    it("should handle empty string input", () => {
+      const hash = hashTokenSHA256("");
+
+      expect(hash).toBeTruthy();
+      expect(typeof hash).toBe("string");
+
+      // Empty string hash should be consistent
+      const hash2 = hashTokenSHA256("");
+      expect(hash).toBe(hash2);
+    });
+
+    it("should handle special characters in token", () => {
+      const token = "sbld_sa_!@#$%^&*()";
+      const hash = hashTokenSHA256(token);
+
+      expect(hash).toBeTruthy();
+      expect(typeof hash).toBe("string");
+    });
+  });
+
+  describe("verifyTokenSHA256", () => {
+    it("should return true for matching token and hash", () => {
+      const token = "sbld_sa_test123456789";
+      const hash = hashTokenSHA256(token);
+
+      const result = verifyTokenSHA256(token, hash);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false for non-matching token and hash", () => {
+      const token1 = "sbld_sa_test123456789";
+      const token2 = "sbld_sa_test987654321";
+      const hash1 = hashTokenSHA256(token1);
+
+      const result = verifyTokenSHA256(token2, hash1);
+
+      expect(result).toBe(false);
+    });
+
+    it("should return false for completely different hash", () => {
+      const token = "sbld_sa_test123456789";
+      const wrongHash = "aW52YWxpZGhhc2g="; // "invalidhash" in base64
+
+      const result = verifyTokenSHA256(token, wrongHash);
+
+      expect(result).toBe(false);
+    });
+
+    it("should return false for invalid base64 hash", () => {
+      const token = "sbld_sa_test123456789";
+      const invalidHash = "not-valid-base64!!!";
+
+      const result = verifyTokenSHA256(token, invalidHash);
+
+      expect(result).toBe(false);
+    });
+
+    it("should return false when hash lengths differ", () => {
+      const token = "sbld_sa_test123456789";
+      const shortHash = "YWJj"; // "abc" in base64 (3 bytes)
+
+      const result = verifyTokenSHA256(token, shortHash);
+
+      expect(result).toBe(false);
+    });
+
+    it("should handle empty token", () => {
+      const token = "";
+      const hash = hashTokenSHA256(token);
+
+      const result = verifyTokenSHA256(token, hash);
+
+      expect(result).toBe(true);
+    });
+
+    it("should use timing-safe comparison", () => {
+      // This test ensures the function calls timingSafeEqual
+      const token = "sbld_sa_test123456789";
+      const hash = hashTokenSHA256(token);
+
+      // Spy on crypto.timingSafeEqual
+      const timingSafeEqualSpy = jest.spyOn(crypto, "timingSafeEqual");
+
+      verifyTokenSHA256(token, hash);
+
+      expect(timingSafeEqualSpy).toHaveBeenCalled();
+
+      timingSafeEqualSpy.mockRestore();
+    });
+
+    it("should be case sensitive", () => {
+      const token = "sbld_sa_test123456789";
+      const hash = hashTokenSHA256(token);
+      const tokenUpperCase = "SBLD_SA_TEST123456789";
+
+      const result = verifyTokenSHA256(tokenUpperCase, hash);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("verifyTokenBcrypt", () => {
+    it("should return true for matching token and bcrypt hash", async () => {
+      const token = "sbld_sa_test123456789";
+      const hash = await bcrypt.hash(token, 10);
+
+      const result = await verifyTokenBcrypt(token, hash);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false for non-matching token and hash", async () => {
+      const token1 = "sbld_sa_test123456789";
+      const token2 = "sbld_sa_test987654321";
+      const hash = await bcrypt.hash(token1, 10);
+
+      const result = await verifyTokenBcrypt(token2, hash);
+
+      expect(result).toBe(false);
+    });
+
+    it("should return false for invalid bcrypt hash", async () => {
+      const token = "sbld_sa_test123456789";
+      const invalidHash = "not-a-valid-bcrypt-hash";
+
+      const result = await verifyTokenBcrypt(token, invalidHash);
+
+      expect(result).toBe(false);
+    });
+
+    it("should handle empty token with bcrypt hash", async () => {
+      const token = "";
+      const hash = await bcrypt.hash(token, 10);
+
+      const result = await verifyTokenBcrypt(token, hash);
+
+      expect(result).toBe(true);
+    });
+
+    it("should be case sensitive", async () => {
+      const token = "sbld_sa_test123456789";
+      const hash = await bcrypt.hash(token, 10);
+      const tokenUpperCase = "SBLD_SA_TEST123456789";
+
+      const result = await verifyTokenBcrypt(tokenUpperCase, hash);
+
+      expect(result).toBe(false);
+    });
+
+    it("should handle bcrypt errors gracefully", async () => {
+      const token = "sbld_sa_test123456789";
+      const malformedHash = "$2b$10$invalid";
+
+      const result = await verifyTokenBcrypt(token, malformedHash);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("serviceAccountGetPartialValue", () => {
+    it("should extract 4 characters from token with prefix", () => {
+      const token = "sbld_sa_abcd1234567890";
+      const partial = serviceAccountGetPartialValue(token);
+
+      expect(partial).toBe("sbld_sa_abcd");
+    });
+
+    it("should extract from position after prefix", () => {
+      const token = "sbld_sa_xyz9876543210";
+      const partial = serviceAccountGetPartialValue(token);
+
+      expect(partial).toBe("sbld_sa_xyz9");
+    });
+
+    it("should extract first 4 chars from token without prefix", () => {
+      const token = "randomtoken1234567890";
+      const partial = serviceAccountGetPartialValue(token);
+
+      expect(partial).toBe("rand");
+    });
+
+    it("should return full token if after-prefix is less than 4 chars", () => {
+      const token = "sbld_sa_abc";
+      const partial = serviceAccountGetPartialValue(token);
+
+      expect(partial).toBe(token);
+    });
+
+    it("should return full token if token without prefix is less than 4 chars", () => {
+      const token = "abc";
+      const partial = serviceAccountGetPartialValue(token);
+
+      expect(partial).toBe("abc");
+    });
+
+    it("should handle empty string", () => {
+      const token = "";
+      const partial = serviceAccountGetPartialValue(token);
+
+      expect(partial).toBe("");
+    });
+
+    it("should handle token that is exactly the prefix", () => {
+      const token = "sbld_sa_";
+      const partial = serviceAccountGetPartialValue(token);
+
+      expect(partial).toBe(token);
+    });
+
+    it("should handle token with exactly 4 chars after prefix", () => {
+      const token = "sbld_sa_abcd";
+      const partial = serviceAccountGetPartialValue(token);
+
+      expect(partial).toBe("sbld_sa_abcd");
+    });
+
+    it("should handle token with more than 4 chars after prefix", () => {
+      const token = "sbld_sa_abcdefghijklmnop";
+      const partial = serviceAccountGetPartialValue(token);
+
+      expect(partial).toBe("sbld_sa_abcd");
+    });
+
+    it("should handle unicode characters", () => {
+      const token = "sbld_sa_😀🎉🎊🎈more";
+      const partial = serviceAccountGetPartialValue(token);
+
+      // JavaScript's substring counts UTF-16 code units, not characters
+      // Emojis are 2 code units each, so 4 code units = 2 emojis
+      expect(partial.length).toBe(12);
+      expect(partial).toBe("sbld_sa_😀🎉");
+    });
+
+    it("should handle prefix-like patterns in middle of token", () => {
+      const token = "testsbld_sa_1234567890";
+      const partial = serviceAccountGetPartialValue(token);
+
+      // Should extract from beginning, not from the prefix pattern
+      expect(partial).toBe("test");
+    });
+  });
+
+  describe("Algorithm Constants", () => {
+    it("should export ALGORITHM_SHA256 constant", () => {
+      expect(ALGORITHM_SHA256).toBe("sha256");
+    });
+
+    it("should export ALGORITHM_BCRYPT constant", () => {
+      expect(ALGORITHM_BCRYPT).toBe("bcrypt");
+    });
+  });
+
+  describe("Integration Tests", () => {
+    it("should support full token lifecycle with SHA256", () => {
+      // Generate token
+      const { token, hash, partialValue } = generateServiceAccountToken();
+
+      // Verify token
+      const isValid = verifyTokenSHA256(token, hash);
+      expect(isValid).toBe(true);
+
+      // Verify partial value extraction
+      const extractedPartial = serviceAccountGetPartialValue(token);
+      expect(extractedPartial).toBe(partialValue);
+    });
+
+    it("should not verify token with wrong hash", () => {
+      const { token } = generateServiceAccountToken();
+      const { hash: wrongHash } = generateServiceAccountToken();
+
+      const isValid = verifyTokenSHA256(token, wrongHash);
+      expect(isValid).toBe(false);
+    });
+
+    it("should handle multiple token generations and verifications", () => {
+      const tokens = Array.from({ length: 10 }, () =>
+        generateServiceAccountToken()
+      );
+
+      // All tokens should be unique
+      const uniqueTokens = new Set(tokens.map((t) => t.token));
+      expect(uniqueTokens.size).toBe(10);
+
+      // All tokens should verify with their own hashes
+      tokens.forEach(({ token, hash }) => {
+        expect(verifyTokenSHA256(token, hash)).toBe(true);
+      });
+
+      // No token should verify with another token's hash
+      tokens.forEach(({ token }, i) => {
+        tokens.forEach(({ hash }, j) => {
+          if (i !== j) {
+            expect(verifyTokenSHA256(token, hash)).toBe(false);
+          }
+        });
+      });
+    });
+  });
+});

--- a/securebuild-api/lib/team/token.ts
+++ b/securebuild-api/lib/team/token.ts
@@ -1,0 +1,152 @@
+import crypto from "crypto";
+import bcrypt from "bcrypt";
+
+// serviceAccountTokenPrefix is prepended to all service account tokens for leak detection
+const SERVICE_ACCOUNT_TOKEN_PREFIX = "sbld_sa_";
+
+// tokenRandomBytes is the number of cryptographically secure random bytes generated
+const TOKEN_RANDOM_BYTES = 32; // 256 bits
+
+// algorithmSHA256 identifies SHA-256 hashed tokens
+export const ALGORITHM_SHA256 = "sha256";
+
+// algorithmBcrypt identifies bcrypt hashed tokens (legacy)
+export const ALGORITHM_BCRYPT = "bcrypt";
+
+/**
+ * GenerateServiceAccountToken generates a new service account token with cryptographically
+ * secure random data and returns the token, its SHA-256 hash, and a partial value for display.
+ *
+ * The token format is: "sbld_sa_" + base64url(32 random bytes)
+ * The hash is: base64(SHA-256(token))
+ * The partial value is extracted from the random portion after the prefix
+ *
+ * Returns:
+ *   - token: The full token string to be provided to the user (store securely)
+ *   - hash: The SHA-256 hash to be stored in the database
+ *   - partialValue: Characters for display purposes (from the random portion)
+ */
+export function generateServiceAccountToken(): {
+  token: string;
+  hash: string;
+  partialValue: string;
+} {
+  // Generate 32 bytes (256 bits) of cryptographically secure random data
+  const randomBytes = crypto.randomBytes(TOKEN_RANDOM_BYTES);
+  
+  // Encode as base64url for URL-safe tokens
+  const randomString = randomBytes.toString('base64url');
+
+  // Add prefix for leak detection
+  const token = SERVICE_ACCOUNT_TOKEN_PREFIX + randomString;
+
+  // Hash the full token with SHA-256
+  const hash = hashTokenSHA256(token);
+
+  // Partial value is extracted from the random portion (first 4 chars after prefix)
+  const partialValue = serviceAccountGetPartialValue(token);
+
+  return { token, hash, partialValue };
+}
+
+/**
+ * hashTokenSHA256 computes the SHA-256 hash of a token and returns it as base64-encoded string.
+ *
+ * This function is used both for generating hashes during token creation and for verifying
+ * presented tokens against stored hashes.
+ *
+ * Parameters:
+ *   - token: The full token string to hash
+ *
+ * Returns:
+ *   - The base64-encoded SHA-256 hash of the token
+ */
+export function hashTokenSHA256(token: string): string {
+  const hasher = crypto.createHash("sha256");
+  hasher.update(token);
+  const hashBytes = hasher.digest();
+  return hashBytes.toString("base64");
+}
+
+/**
+ * verifyTokenSHA256 verifies a presented token against a stored hash using the SHA-256 algorithm.
+ *
+ * Parameters:
+ *   - presentedToken: The token provided by the user/service
+ *   - storedHash: The hash stored in the database
+ *
+ * Returns:
+ *   - isValid: true if the token matches the stored hash
+ */
+export function verifyTokenSHA256(
+  presentedToken: string,
+  storedHash: string
+): boolean {
+  // Compute SHA-256 hash of presented token
+  const presentedHash = hashTokenSHA256(presentedToken);
+
+  // Use constant-time comparison to prevent timing attacks
+  // crypto.timingSafeEqual requires buffers of the same length
+  try {
+    const presentedBuffer = Buffer.from(presentedHash);
+    const storedBuffer = Buffer.from(storedHash);
+
+    if (presentedBuffer.length !== storedBuffer.length) {
+      return false;
+    }
+
+    return crypto.timingSafeEqual(presentedBuffer, storedBuffer);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * verifyTokenBcrypt verifies a presented token against a stored hash using the bcrypt algorithm.
+ *
+ * Parameters:
+ *   - presentedToken: The token provided by the user/service
+ *   - storedHash: The hash stored in the database
+ *
+ * Returns:
+ *   - isValid: true if the token matches the stored hash
+ */
+export async function verifyTokenBcrypt(
+  presentedToken: string,
+  storedHash: string
+): Promise<boolean> {
+  try {
+    // Use bcrypt's built-in comparison
+    return await bcrypt.compare(presentedToken, storedHash);
+  } catch {
+    // Token is invalid or other bcrypt error
+    return false;
+  }
+}
+
+/**
+ * serviceAccountGetPartialValue extracts characters from a token for filtering.
+ *
+ * If the token has the prefix "sbld_sa_", it extracts len(prefix) + 4 characters.
+ * Otherwise, it extracts the first 4 characters.
+ *
+ * Parameters:
+ *   - token: The token to extract from
+ *
+ * Returns:
+ *   - The partial value for database filtering
+ */
+export function serviceAccountGetPartialValue(token: string): string {
+  if (token.startsWith(SERVICE_ACCOUNT_TOKEN_PREFIX)) {
+    if (token.length >= SERVICE_ACCOUNT_TOKEN_PREFIX.length + 4) {
+      return token.substring(0, SERVICE_ACCOUNT_TOKEN_PREFIX.length + 4);
+    }
+    return token;
+  }
+
+  if (token.length >= 4) {
+    return token.substring(0, 4);
+  }
+
+  return token;
+}

--- a/securebuild-api/lib/types/externalimage.ts
+++ b/securebuild-api/lib/types/externalimage.ts
@@ -1,0 +1,32 @@
+
+export interface ExternalImage {
+  digest: string;
+  registry: string;
+  imageName: string;
+  imageTag: string;
+  createdAt: Date;
+}
+
+export type SBOMStatus = 'pending' | 'generating' | 'succeeded' | 'failed' | null;
+export type ScanStatus = 'queued' | 'running' | 'succeeded' | 'failed' | null;
+
+export interface TagCompletionStatus {
+  digest: string;
+  isSbomComplete: boolean;
+  isScanComplete: boolean;
+  isSignatureComplete: boolean;
+  sbomStatus: SBOMStatus;
+  scanStatus: ScanStatus;
+}
+
+export interface TrackedExternalImage {
+  registry: string;
+  imageName: string;
+  imageTags: string[];
+  createdAt: Date;
+
+  hasX8664: boolean;
+  hasArm64: boolean;
+
+  tagCompletionStatus: { [tag: string]: TagCompletionStatus };
+}

--- a/securebuild-api/lib/types/service-account.ts
+++ b/securebuild-api/lib/types/service-account.ts
@@ -1,0 +1,13 @@
+export interface ServiceAccount {
+    id: string;
+    name: string;
+    createdAt: Date;
+    expiresAt: Date | null;
+    expiresIn: string | null;
+    lastUsedAt: Date | null;
+    partialValue: string;
+}
+
+export interface ServiceAccountWithValue extends ServiceAccount {
+    value: string;
+}

--- a/securebuild-api/lib/utils/queue.ts
+++ b/securebuild-api/lib/utils/queue.ts
@@ -1,0 +1,84 @@
+import { getDB } from "../data/db";
+import { getParam } from "../data/param";
+import * as srs from "secure-random-string";
+
+interface QueuePayload {
+  [key: string]: string | number | boolean | null | undefined | any;
+}
+
+// Priority levels for work queue items (must match Go constants in pkg/persistence/queue.go)
+// 0 (or NULL) = normal priority, 1 = high priority
+export const PRIORITY_NORMAL = 0
+export const PRIORITY_HIGH = 1
+
+export async function enqueueWork(channel: string, payload: QueuePayload): Promise<string> {
+  return enqueueWorkWithPriority(channel, payload, PRIORITY_NORMAL)
+}
+
+export async function enqueueWorkWithPriority(channel: string, payload: QueuePayload, priority: number): Promise<string> {
+  const client = getDB(await getParam("DB_URI"));
+
+  const id = srs.default({ length: 12, alphanumeric: true });
+  const now = new Date();
+
+  await client.query(
+    `INSERT INTO work_queue (id, channel, payload, created_at, priority) ` +
+    `VALUES ($1, $2, $3, $4, $5)`,
+    [id, channel, payload, now, priority]
+  );
+
+  await client.query(`SELECT pg_notify('${channel}', $1)`, [id]);
+
+  return id;
+}
+
+export async function getWorkStatus(workId: string): Promise<{
+  id: string;
+  status: string;
+  created_at: Date;
+  updated_at?: Date;
+  error?: string;
+  metadata?: any;
+} | null> {
+  const client = getDB(await getParam("DB_URI"));
+
+  const result = await client.query(
+    `SELECT id, channel as status, payload as metadata, created_at FROM work_queue WHERE id = $1`,
+    [workId]
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  const row = result.rows[0];
+  return {
+    id: row.id,
+    status: 'queued', // For now, all work queue items are considered queued
+    created_at: row.created_at,
+    metadata: row.metadata
+  };
+}
+
+/**
+ * Checks if an SBOM already exists for this digest.
+ * Used to prevent duplicate enqueuing - checked both before enqueuing and after receiving.
+ */
+export async function hasExistingSBOM(digest: string): Promise<boolean> {
+  try {
+    const db = getDB(await getParam("DB_URI"))
+
+    const query = `
+      SELECT EXISTS(
+        SELECT 1 FROM external_image_sbom
+        WHERE digest = $1
+      ) as exists
+    `
+    const result = await db.query(query, [digest])
+    return result.rows[0]?.exists === true
+  } catch (err) {
+    console.error(`hasExistingSBOM error:`, err)
+    // On error, return false to allow work to be enqueued (better to duplicate than miss)
+    return false
+  }
+}

--- a/securebuild-api/lib/utils/timestamp.ts
+++ b/securebuild-api/lib/utils/timestamp.ts
@@ -1,0 +1,45 @@
+/**
+ * Helper function to parse UTC timestamp from database
+ * Handles both old format (without timezone) and new format (with timezone from PR 778)
+ * 
+ * Supports:
+ * - Old format: '2024-05-17 14:48:00.123456' (no timezone)
+ * - New format: '2024-05-17 14:48:00.123456+00' (with timezone)
+ * - Date objects (returns as-is)
+ * - ISO strings with timezone info
+ * 
+ * @param timestamp - Timestamp from database (string, Date, or null)
+ * @returns Parsed Date object or undefined if input is null/empty
+ */
+export function parseUTCTimestamp(timestamp: string | Date | null): Date | undefined {
+  if (!timestamp) return undefined;
+
+  // If it's already a Date object, return it
+  if (timestamp instanceof Date) {
+    return timestamp;
+  }
+
+  // PostgreSQL returns timestamps in format '2024-05-17 14:48:00.123456' when cast to text
+  // We need to convert this to ISO format for proper UTC parsing
+  if (typeof timestamp === 'string' && timestamp.includes(' ') && !timestamp.includes('T')) {
+    // Check if timestamp already has timezone info before appending 'Z'
+    const hasTimezone = timestamp.includes('+') || timestamp.includes('-', 10);
+    if (hasTimezone) {
+      // Replace space with 'T' and normalize bare offset (+HH or -HH) to +HH:00 / -HH:00
+      // PostgreSQL ::text on timestamptz gives '+00' but ISO 8601 requires '+00:00'
+      let normalized = timestamp.replace(' ', 'T');
+      normalized = normalized.replace(/([+-]\d{2})$/, '$1:00');
+      return new Date(normalized);
+    } else {
+      // No timezone, replace space with 'T' and add 'Z' to indicate UTC
+      return new Date(`${timestamp}Z`.replace(' ', 'T'));
+    }
+  }
+
+  // If the timestamp doesn't end with 'Z' or have timezone info, assume it's UTC
+  if (typeof timestamp === 'string' && !timestamp.includes('Z') && !timestamp.includes('+') && !timestamp.includes('-', 10)) {
+    return new Date(timestamp + 'Z'); // Add Z to indicate UTC
+  }
+
+  return new Date(timestamp);
+}

--- a/securebuild-api/next.config.js
+++ b/securebuild-api/next.config.js
@@ -1,0 +1,34 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'standalone',
+  // Pin the file-tracing and Turbopack root to this package directory so that
+  // stray lockfiles elsewhere on the machine don't mis-root the standalone
+  // bundle (monorepo-safe).
+  outputFileTracingRoot: __dirname,
+  turbopack: {
+    root: __dirname,
+  },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()',
+          },
+        ],
+      },
+    ];
+  },
+};
+
+module.exports = nextConfig;

--- a/securebuild-api/package-lock.json
+++ b/securebuild-api/package-lock.json
@@ -1,0 +1,12566 @@
+{
+  "name": "securebuild-api",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "securebuild-api",
+      "version": "0.1.0",
+      "dependencies": {
+        "@aws-sdk/client-ecr": "^3.1016.0",
+        "@aws-sdk/client-ecr-public": "^3.1016.0",
+        "@snyk/docker-registry-v2-client": "^2.24.2",
+        "bcrypt": "^6.0.0",
+        "dd-trace": "^5.93.0",
+        "next": "^16.2.3",
+        "pg": "^8.20.0",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "secure-random-string": "^1.1.4"
+      },
+      "devDependencies": {
+        "@testcontainers/postgresql": "^11.13.0",
+        "@types/bcrypt": "^6.0.0",
+        "@types/jest": "^30.0.0",
+        "@types/node": "^25.6.0",
+        "@types/pg": "^8.20.0",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "@types/secure-random-string": "^1.1.3",
+        "eslint": "^9",
+        "eslint-config-next": "^16.2.3",
+        "jest": "^30.3.0",
+        "testcontainers": "^11.13.0",
+        "ts-jest": "^29.4.6",
+        "tsx": "^4.21.0",
+        "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@aws-sdk/client-ecr": {
+      "version": "3.1081.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.1081.0.tgz",
+      "integrity": "sha512-ufJqk4ggMMoqMAdTrSyvijLmopNgQtBso+f0QEQF07DMEnIAu25wtpId44lR9c5DtoC+76uGLwfq86UAjrU+3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/credential-provider-node": "^3.972.64",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ecr-public": {
+      "version": "3.1081.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr-public/-/client-ecr-public-3.1081.0.tgz",
+      "integrity": "sha512-Pd28DVXBhWPSa0YFYLETzuCBD5akYSJmGYSjLY0BE7OYM+1QOZ+4XzWVsAFezsIwtA28wz8UfkzCPbQdizJczg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/credential-provider-node": "^3.972.64",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.29.tgz",
+      "integrity": "sha512-yqKcltLbtRh1ubzhRSldIs8jFHNZlyMlgoIccCC0aDVbrB99nXaBdmfr89mK7obWX/NVg4rAMpCpZ6dCDiVBtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.15",
+        "@aws-sdk/xml-builder": "^3.972.33",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.0",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.55.tgz",
+      "integrity": "sha512-Ah36tYkqyaVnaHkx7VseoTYrHUmwgBps3V+wnrC1idhIIMGlviH0FtrX9EIPdAlVHvXC7FQZLhmHBRz+pLaiWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.57.tgz",
+      "integrity": "sha512-/vp6i5YEliJqRm5k/BDmYjAyRAMTdkjW6UciVRk9oh/0OfDCWeb/ih7hqte4lFvKXkIbsqe9AdK9LQK6NGardw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.62.tgz",
+      "integrity": "sha512-pQIRiQQs+MUlVnJdWJ7/6KS0WxcLRVfut57OFgwC3cnM1F8mXw3Kh4gAVwj6AtvD6CWx8x6+po4ENRcqe64XrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/credential-provider-env": "^3.972.55",
+        "@aws-sdk/credential-provider-http": "^3.972.57",
+        "@aws-sdk/credential-provider-login": "^3.972.61",
+        "@aws-sdk/credential-provider-process": "^3.972.55",
+        "@aws-sdk/credential-provider-sso": "^3.972.61",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.61",
+        "@aws-sdk/nested-clients": "^3.997.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.61.tgz",
+      "integrity": "sha512-jtrxWwC7slqxh7DnAWHrwsA3UwCsnlypdYtavGT7EX5p791wxWQys7QzkCZ7JvOMAyylDtPoxyV+ic0zg3rV9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/nested-clients": "^3.997.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.64",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.64.tgz",
+      "integrity": "sha512-zyKVYDyMR9VQL/kPi03ygN2vtD9uLMuWRLoJ77KxgZZaS1VlJloI+SzleF9Zg4HWUI+AIu+ZRs8zsJFNqbrxsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.55",
+        "@aws-sdk/credential-provider-http": "^3.972.57",
+        "@aws-sdk/credential-provider-ini": "^3.972.62",
+        "@aws-sdk/credential-provider-process": "^3.972.55",
+        "@aws-sdk/credential-provider-sso": "^3.972.61",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.61",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.55.tgz",
+      "integrity": "sha512-x0XjjF0l1WGRtK2vEhTZqCguQuAIZLep9l2+eeEmuxQQjjD3BlGQXY5xADR+l3t576UX+dxRkRtTjEu40l81Vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.61.tgz",
+      "integrity": "sha512-d/V0VRsz73i+PHhbult/tx0Y1+de1SNQVsXkcQCmpfeBq7uODy/RTxNsOLpT9ZVHxcRNzbQFuywLKC33fUMIxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/nested-clients": "^3.997.29",
+        "@aws-sdk/token-providers": "3.1081.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.61.tgz",
+      "integrity": "sha512-Bv4n3NOI6hPy+rmr6Bw9R6LnBVRkcp3ncj2E2IKSYJG+0UkysSitWMvbgndNvMxDw7gE1pQ/ErwkNceuKwj7zQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/nested-clients": "^3.997.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.29.tgz",
+      "integrity": "sha512-ot6v8J5W8P0w6ryyuIkXP1bHZHTlvwtn83mVCYaBE0GJ6tJX4vPSBx7M98w9O4wmmDruFsDBUMjhEHA+OosUFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz",
+      "integrity": "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1081.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1081.0.tgz",
+      "integrity": "sha512-kduAeI6cL+zqwj3gjPh9LhuX7kBZ83msYxutavaR+UPm5K8J7iThJBvNRAsFNyWTji92CSU8dogUgvi9T0BehA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/nested-clients": "^3.997.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.15.tgz",
+      "integrity": "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
+      "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@datadog/flagging-core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@datadog/flagging-core/-/flagging-core-1.2.1.tgz",
+      "integrity": "sha512-qeDkki9fFlqyoZBrn7tneT6pZ04EKKvf3xxisYw1a74zbJihvQui/ARUsjXCurRpzpFqGGTJw/oz+HnXaKhcdw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "spark-md5": "^3.0.2"
+      }
+    },
+    "node_modules/@datadog/libdatadog": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@datadog/libdatadog/-/libdatadog-0.9.4.tgz",
+      "integrity": "sha512-55wHHAuhHOOrBGoWV+fRuEDypN6PMJZq4LTOwExnhoDMvVcZKtqYT05xea/toRs0o75+A1IeNAQHsRLbJMf5oA==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/@datadog/native-appsec": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-11.0.1.tgz",
+      "integrity": "sha512-Y/XfknUmmJcw4hhQVhqzgdQvfjy+EGmXuUBgtVkI1r+/qS00egYu+wD/x7pOvjdbZNqN96znVszAnXvDQAzMDQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@datadog/native-appsec/node_modules/node-gyp-build": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
+      "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/@datadog/native-iast-taint-tracking": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-4.2.0.tgz",
+      "integrity": "sha512-NpZABJQoNMzF6cU521RT4GQ8/FbfFRoDepOLTcLYKyw0DY2WmSpg3iG+PoQNK4O3jPSXC++K3rg59GiQgA3Mog==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^3.9.0"
+      }
+    },
+    "node_modules/@datadog/native-iast-taint-tracking/node_modules/node-gyp-build": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
+      "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/@datadog/native-metrics": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-3.1.2.tgz",
+      "integrity": "sha512-7AEWt0ZLr/ogR/9if1DmFBDTg3y67xM+gdhXUXKs+UQMxK0lnjrOHgN7fkpEmUG1uL+EkX2BDE3ENDlQ23J7OQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^6.1.0",
+        "node-gyp-build": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@datadog/native-metrics/node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@datadog/native-metrics/node_modules/node-gyp-build": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
+      "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/@datadog/openfeature-node-server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-2.0.0.tgz",
+      "integrity": "sha512-Ummu/Bd7ZJpCCNdFnZUt/JI+L1+8OMK53+MyIXbS7dCt4JXWWwelbpzSGqmC2jWbWQ/mTo4hEfnFw3kYOINbXA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@datadog/flagging-core": "1.2.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@openfeature/server-sdk": ">=1.15.1"
+      }
+    },
+    "node_modules/@datadog/pprof": {
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.15.1.tgz",
+      "integrity": "sha512-4mI750tX6okNROS4YKvGQjyAQ+VqfzDqzysCytOJhL2E2ktK/q4M0PtC7j70tiirGb/fO9fjma3IMNSRLYX+xQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.8.4",
+        "pprof-format": "^2.2.1",
+        "source-map": "^0.7.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@datadog/wasm-js-rewriter": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@datadog/wasm-js-rewriter/-/wasm-js-rewriter-5.0.1.tgz",
+      "integrity": "sha512-EzbV3Lrdt3udQEsbDOVC5gB1y7yxfpBbrSIk4jaEsGjyj0Dbv2HGj7tZjs+qXzIzNonHc8h5El2bYZOGfC2wwg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "js-yaml": "^4.1.0",
+        "lru-cache": "^7.14.0",
+        "module-details-from-path": "^1.0.3",
+        "node-gyp-build": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
+      "integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+      "integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.4.1",
+        "@jest/pattern": "30.4.0",
+        "@jest/reporters": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "exit-x": "^0.2.2",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-changed-files": "30.4.1",
+        "jest-config": "30.4.2",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-resolve-dependencies": "30.4.2",
+        "jest-runner": "30.4.2",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "30.4.1",
+        "jest-snapshot": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@sinonjs/fake-timers": "^15.4.0",
+        "@types/node": "*",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+      "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/types": "30.4.1",
+        "jest-mock": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
+      "integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "collect-v8-coverage": "^1.0.2",
+        "exit-x": "^0.2.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^5.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.2",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+      "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+      "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "callsites": "^3.1.0",
+        "graceful-fs": "^4.2.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
+      "integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "collect-v8-coverage": "^1.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+      "integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.4.1",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+      "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.4.1",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "pirates": "^4.0.7",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
+      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
+      "license": "MIT"
+    },
+    "node_modules/@next/eslint-plugin-next": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.10.tgz",
+      "integrity": "sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "3.3.1"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
+      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
+      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
+      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
+      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nolyfill/is-core-module": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
+      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@openfeature/core": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-P0u3/ht/oZCQT89fOed+laLk0kZR529a825cS02uPDglxXbE97irWYpDAeRGGVETIzKfuy+H2g8c3Ccv/tXJNQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@openfeature/server-sdk": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.22.0.tgz",
+      "integrity": "sha512-YBrf6SQkn0FNB/dRAtLEs41dvFMUE8CrQTwI+iLaMFUIqWlqGNJfGnulKSneEKS+2OgKTAC6DdmKcZ6tK7kBcg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@openfeature/core": "^1.11.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.132.0.tgz",
+      "integrity": "sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.132.0.tgz",
+      "integrity": "sha512-SThDrSeamB/kG2+NxcJ5/wSLcV6dUqDknrPLqFYQ0ST/55mtBP4M7Q/f3QbubH6aAd11wpzZn/nwbVRSdobOpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.132.0.tgz",
+      "integrity": "sha512-Lc0f/TYoKBghE5/2Gsv7bLXk+TJZunx2Tf61X8hG4ARXdc8UYI26dCGccFSd1AyFbK3jfaNXtMnupggDbjPXdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.132.0.tgz",
+      "integrity": "sha512-RG2eJIpf7C21z9HSSXFw1bTArdpKe7Y4fwcJTwRq1yCSe1vSavaN9GA1sm9KqzemTLAGVktQ+7qBTGp0vQeUZg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.132.0.tgz",
+      "integrity": "sha512-wQIPntPLtJ8NcBpvKPbEv3NqzV6k8eP8tP/jE9Rg8HTg/j7urZGFSsTCPCW5k77Qfw2DM4vRvc9p3I4yq/Shvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.132.0.tgz",
+      "integrity": "sha512-PixKEpeSe3yxQWqNyOCBALRYc72+Tj7ILDofUl3iXo25cVOzLA6jHUhmOINRtWIPh7dbUie3QNeabwaQpZTw6w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.132.0.tgz",
+      "integrity": "sha512-sCR+DzGHlyHKnbA2z9zWjTUhIo8Sy0enJl4RDsBwPmkxYynPatpwOAWe8W5127SlW0boqUWHGtr1NWn5UwIhXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.132.0.tgz",
+      "integrity": "sha512-sQBix5P2cW+IpzTcCwYxnh9yALrKSIkKJThspBvMGcygSMnbzkSvhN7SfuX1hvBk8y1XEChsdkU3ET0V5DmzUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.132.0.tgz",
+      "integrity": "sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.132.0.tgz",
+      "integrity": "sha512-CmX/ulNBOEwWTyVRmcpYKAcAizW6+OjtLJgo7fXoL9OqQvjF4VER8tPomv44vwzfSCy1BHbsB0ZlZYzYJNj4cA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.132.0.tgz",
+      "integrity": "sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.132.0.tgz",
+      "integrity": "sha512-bLz+Xi+Agnfmd7kWPEsSVwCn2k4EyIalZkNBcQ0OGIv9rqn8VgCPLNd03tM9mKX/5TdlvDXalz0q71BIrOPNqg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.132.0.tgz",
+      "integrity": "sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.132.0.tgz",
+      "integrity": "sha512-WcEaSNHFk8yz5YFlQQAlhq6jOFmZBB/RKE7uzhyCIf+pF1Lmv9gUH4221mle2Gd9iHyWT3ySNph8yZgb1xYdWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.132.0.tgz",
+      "integrity": "sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.132.0.tgz",
+      "integrity": "sha512-FWzmUGrZ6GUby4U7WIwcCtab6tdmlTO3xTRRKyb5kjIJVEiaUAT8animUG/nK8ZCA8gkRkPOTId4rl6uTqUmJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.132.0.tgz",
+      "integrity": "sha512-TlbMppxJI5CjWDes0QaP6G3aneVg1yikBu5QYI+DUShF9WDL66ccgKFNNGmi/Wybtszw6hxwAvv76T4DaPKnHw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.132.0.tgz",
+      "integrity": "sha512-RH/NbFjGKqdUAUi7Oh3LQPxUk2hsWFEEQ38HSnbRQT8QjBZFKqL1fMbmsB3N4jy/KPh9iX94+9dmkEMBBbambw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.132.0.tgz",
+      "integrity": "sha512-JUr4jQY9jxoIB/YTLXr6XofSi5xikj6p5/Ns1h0VOBDT0j1jKU+kMsv2xxv51RwnETcXpA1Yw/9oUAfcqfaqEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.132.0.tgz",
+      "integrity": "sha512-2dapgHpA5X8DSXF4AU36hJWYf6zP0tKjMXFRAZFBD62pkevW/uhFDXoFH9Y/3Fd2EtDrw5ByNnR1wVE9X9y0SQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.1.tgz",
+      "integrity": "sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.6.tgz",
+      "integrity": "sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.3.tgz",
+      "integrity": "sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.3.tgz",
+      "integrity": "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.2.tgz",
+      "integrity": "sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.1.tgz",
+      "integrity": "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@snyk/docker-registry-v2-client": {
+      "version": "2.24.4",
+      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.24.4.tgz",
+      "integrity": "sha512-adh3YNMBOF5Iqi7Nc9D49pIQMB9zxX9Q995PJIhXUa/WgVmUMLTZSFgS6M72G89XXk7UYrJOyHDD3zgKaeqPRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "needle": "^3.5.0",
+        "parse-link-header": "^2.0.0",
+        "tslib": "^1.10.0"
+      }
+    },
+    "node_modules/@snyk/docker-registry-v2-client/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@testcontainers/postgresql": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@testcontainers/postgresql/-/postgresql-11.14.0.tgz",
+      "integrity": "sha512-wYbJn8GRTj8qfqzfVubxioYWlHJU/ImIjuzPwyy9C5Qfo6g3GLduPZAj+BifvqTZjgT3gd4gFVLCPhBji7dc1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "testcontainers": "^11.14.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/docker-modem": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+      "integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
+    "node_modules/@types/dockerode": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-4.0.1.tgz",
+      "integrity": "sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/docker-modem": "*",
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/secure-random-string": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/secure-random-string/-/secure-random-string-1.1.3.tgz",
+      "integrity": "sha512-MKbmGsX3pZUmKzYM9zvfr7F76jH89BLOh2tVk6UhP/+CmqUd7tho3zTOLUmF2WnO3B5Q6BT5CfzL//rKUp7oHQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2-streams": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.13.tgz",
+      "integrity": "sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
+      "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/type-utils": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.63.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
+      "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+      "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.63.0",
+        "@typescript-eslint/types": "^8.63.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+      "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+      "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
+      "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+      "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+      "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.63.0",
+        "@typescript-eslint/tsconfig-utils": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+      "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+      "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.63.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
+      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "devOptional": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/babel-jest": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+      "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "30.4.1",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.4.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "workspaces": [
+        "test/babel-8"
+      ],
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-instrument": "^6.0.2",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+      "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/babel__core": "^7.20.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+      "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "30.4.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.0.tgz",
+      "integrity": "sha512-322oSBHOhMhOm2CVwn7b3+gWQqwzSgIY4gNpKKb+Ha5jx2dEl9ClOgz/SK57DwuDql8YQg8JRpb9U0o8K3pW9g==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.42",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
+      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001800",
+        "electron-to-chromium": "^1.5.387",
+        "node-releases": "^2.0.50",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001803",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dc-polyfill": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/dc-polyfill/-/dc-polyfill-0.1.11.tgz",
+      "integrity": "sha512-TyyeGcjx0YeThAI9fTFtgsvj5qd4R+aGfVmXiUhevbgzWFDr7IK4tv4YjE6jaGzLHQTchk4h7DHdr5q4WGgaZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/dd-trace": {
+      "version": "5.111.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.111.0.tgz",
+      "integrity": "sha512-ikBksG0JxPALf+lMCq5JZ+g5rwyaqw8x7BwVEbCYAiYV1Wk0z16+F/TIl9z45V43ireXKz7TbiWZocZEQkuCLA==",
+      "license": "(Apache-2.0 OR BSD-3-Clause)",
+      "dependencies": {
+        "dc-polyfill": "^0.1.11",
+        "import-in-the-middle": "^3.2.0",
+        "opentracing": ">=0.14.7"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@datadog/libdatadog": "0.9.4",
+        "@datadog/native-appsec": "11.0.1",
+        "@datadog/native-iast-taint-tracking": "4.2.0",
+        "@datadog/native-metrics": "3.1.2",
+        "@datadog/openfeature-node-server": "2.0.0",
+        "@datadog/pprof": "5.15.1",
+        "@datadog/wasm-js-rewriter": "5.0.1",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/api-logs": "<1.0.0",
+        "oxc-parser": "^0.132.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/docker-compose": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.4.2.tgz",
+      "integrity": "sha512-rPHigTKGaEHpkUmfd69QgaOp+Os5vGJwG/Ry8lcr8W/382AmI+z/D7qoa9BybKIkqNppaIbs8RYeHSevdQjWww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/docker-modem": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
+      "integrity": "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/docker-modem/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/dockerode": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.12.tgz",
+      "integrity": "sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@grpc/grpc-js": "^1.11.1",
+        "@grpc/proto-loader": "^0.7.13",
+        "docker-modem": "^5.0.7",
+        "protobufjs": "^7.3.2",
+        "tar-fs": "^2.1.4",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/dockerode/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/dockerode/node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/dockerode/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
+      "integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.10.tgz",
+      "integrity": "sha512-HSybLOY0QKf39i4FWUqPN0xWiNDi6A6UqJmZtgDkS3zMqjXTqULvj/sueXx3cdCG0mVG+qH6k5/qdegklH1d1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/eslint-plugin-next": "16.2.10",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-import-resolver-typescript": "^3.5.2",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
+        "eslint-plugin-react": "^7.37.0",
+        "eslint-plugin-react-hooks": "^7.0.0",
+        "globals": "16.4.0",
+        "typescript-eslint": "^8.46.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0",
+        "typescript": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/globals": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+      "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.16.1",
+        "resolve": "^2.0.0-next.6"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
+      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@nolyfill/is-core-module": "1.0.39",
+        "debug": "^4.4.0",
+        "get-tsconfig": "^4.10.0",
+        "is-bun-module": "^2.0.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.13",
+        "unrs-resolver": "^1.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+      "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/exit-x": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+      "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-port": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.1.tgz",
+      "integrity": "sha512-0rymlHSFLwZ0ixx8DaQkoIyZojJPY2a0K2nEYslhKJ6jIYO/m0IcCb7iQsFPmS7WmKwISZiIrv5Icstrw/CmqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-bun-module/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+      "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.4.2",
+        "@jest/types": "30.4.1",
+        "import-local": "^3.2.0",
+        "jest-cli": "30.4.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+      "integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "jest-util": "30.4.1",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+      "integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "co": "^4.6.0",
+        "dedent": "^1.6.0",
+        "is-generator-fn": "^2.1.0",
+        "jest-each": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "p-limit": "^3.1.0",
+        "pretty-format": "30.4.1",
+        "pure-rand": "^7.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+      "integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.4.2",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "exit-x": "^0.2.2",
+        "import-local": "^3.2.0",
+        "jest-config": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+      "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/get-type": "30.1.0",
+        "@jest/pattern": "30.4.0",
+        "@jest/test-sequencer": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-jest": "30.4.1",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "deepmerge": "^4.3.1",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-circus": "30.4.2",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-runner": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "parse-json": "^5.2.0",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "esbuild-register": ">=3.4.0",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "esbuild-register": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
+      "integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+      "integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+      "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+      "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "anymatch": "^3.1.3",
+        "fb-watchman": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
+        "picomatch": "^4.0.3",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+      "integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+      "integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-pnp-resolver": "^1.2.3",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "slash": "^3.0.0",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+      "integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "30.4.0",
+        "jest-snapshot": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+      "integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.4.1",
+        "@jest/environment": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-haste-map": "30.4.1",
+        "jest-leak-detector": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-resolve": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "jest-worker": "30.4.1",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+      "integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/globals": "30.4.1",
+        "@jest/source-map": "30.0.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "cjs-module-lexer": "^2.1.0",
+        "collect-v8-coverage": "^1.0.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+      "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1",
+        "@babel/types": "^7.27.3",
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "@jest/snapshot-utils": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-preset-current-node-syntax": "^1.2.0",
+        "chalk": "^4.1.2",
+        "expect": "30.4.1",
+        "graceful-fs": "^4.2.11",
+        "jest-diff": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1",
+        "semver": "^7.7.2",
+        "synckit": "^0.11.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+      "integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.4.1",
+        "camelcase": "^6.3.0",
+        "chalk": "^4.1.2",
+        "leven": "^3.1.0",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+      "integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "jest-util": "30.4.1",
+        "string-length": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+      "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.4.1",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/needle": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.5.0.tgz",
+      "integrity": "sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/next": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
+      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.2.10",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.2.10",
+        "@next/swc-darwin-x64": "16.2.10",
+        "@next/swc-linux-arm64-gnu": "16.2.10",
+        "@next/swc-linux-arm64-musl": "16.2.10",
+        "@next/swc-linux-x64-gnu": "16.2.10",
+        "@next/swc-linux-x64-musl": "16.2.10",
+        "@next/swc-win32-arm64-msvc": "16.2.10",
+        "@next/swc-win32-x64-msvc": "16.2.10",
+        "sharp": "^0.34.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-exports-info": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
+      "integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opentracing": {
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
+      "integrity": "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/oxc-parser": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.132.0.tgz",
+      "integrity": "sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@oxc-project/types": "^0.132.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.132.0",
+        "@oxc-parser/binding-android-arm64": "0.132.0",
+        "@oxc-parser/binding-darwin-arm64": "0.132.0",
+        "@oxc-parser/binding-darwin-x64": "0.132.0",
+        "@oxc-parser/binding-freebsd-x64": "0.132.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.132.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.132.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.132.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.132.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.132.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.132.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.132.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.132.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.132.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.132.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-link-header": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pprof-format": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.2.tgz",
+      "integrity": "sha512-hd90rHVDhNOhgHTmazVzDSVwTLOBjpZQ26AO/0j46sAFZ9uSWY0DcK2zJcwnuo2R6EzufBbOoWlPazA5nSyHcg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/properties-reader": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-3.0.1.tgz",
+      "integrity": "sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "mkdirp": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/properties?sponsor=1"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-cwd/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/secure-random-string": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/secure-random-string/-/secure-random-string-1.1.4.tgz",
+      "integrity": "sha512-wkl2kL6/eT0II0HvuRAGW3dunWwfFV81Rdueu8+we0smnJU1B/aEksngOsoACs6XUyVeeZAM4eJvprRuPs0PPQ==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
+      "license": "(WTFPL OR MIT)",
+      "optional": true
+    },
+    "node_modules/split-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ssh-remote-port-forward": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ssh-remote-port-forward/-/ssh-remote-port-forward-1.0.4.tgz",
+      "integrity": "sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ssh2": "^0.5.48",
+        "ssh2": "^1.4.0"
+      }
+    },
+    "node_modules/ssh-remote-port-forward/node_modules/@types/ssh2": {
+      "version": "0.5.52",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.52.tgz",
+      "integrity": "sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2-streams": "*"
+      }
+    },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
+      }
+    },
+    "node_modules/stable-hash": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-length/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.3.6"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/testcontainers": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-11.14.0.tgz",
+      "integrity": "sha512-r9pniwv/iwzyHaI7gwAvAm4Y+IvjJg3vBWdjrUCaDMc2AXIr4jKbq7jJO18Mw2ybs73pZy1Aj7p/4RVBGMRWjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@types/dockerode": "^4.0.1",
+        "archiver": "^7.0.1",
+        "async-lock": "^1.4.1",
+        "byline": "^5.0.0",
+        "debug": "^4.4.3",
+        "docker-compose": "^1.4.2",
+        "dockerode": "^4.0.10",
+        "get-port": "^7.2.0",
+        "proper-lockfile": "^4.1.2",
+        "properties-reader": "^3.0.1",
+        "ssh-remote-port-forward": "^1.0.4",
+        "tar-fs": "^3.1.2",
+        "tmp": "^0.2.5",
+        "undici": "^7.24.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.8.0",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.63.0.tgz",
+      "integrity": "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.63.0",
+        "@typescript-eslint/parser": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    }
+  }
+}

--- a/securebuild-api/package.json
+++ b/securebuild-api/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "securebuild-api",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 3002",
+    "build": "next build --turbo",
+    "start": "next start",
+    "lint": "eslint .",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:integration": "jest --config integration/jest.config.js"
+  },
+  "dependencies": {
+    "@aws-sdk/client-ecr": "^3.1016.0",
+    "@aws-sdk/client-ecr-public": "^3.1016.0",
+    "@snyk/docker-registry-v2-client": "^2.24.2",
+    "bcrypt": "^6.0.0",
+    "dd-trace": "^5.93.0",
+    "next": "^16.2.3",
+    "pg": "^8.20.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "secure-random-string": "^1.1.4"
+  },
+  "devDependencies": {
+    "@testcontainers/postgresql": "^11.13.0",
+    "@types/bcrypt": "^6.0.0",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^25.6.0",
+    "@types/pg": "^8.20.0",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@types/secure-random-string": "^1.1.3",
+    "eslint": "^9",
+    "eslint-config-next": "^16.2.3",
+    "jest": "^30.3.0",
+    "testcontainers": "^11.13.0",
+    "ts-jest": "^29.4.6",
+    "tsx": "^4.21.0",
+    "typescript": "5.9.3"
+  },
+  "engines": {
+    "node": ">=24"
+  }
+}

--- a/securebuild-api/tsconfig.json
+++ b/securebuild-api/tsconfig.json
@@ -1,0 +1,42 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "target": "ES6",
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "integration"
+  ]
+}


### PR DESCRIPTION
# SecureBuild API — Proposal

Extract the external-image API from `securebuild-www` (Next.js) into a standalone Node.js service called `securebuild-api` within this repository. API-only, no UI.

Base URL: `https://securebuild.com/api/v1/external-image`

## Endpoints

| # | Method & Endpoint | Purpose |
|---|---|---|
| 1 | `POST /api/v1/external-image` | Trigger a scan of a new image (with optional pull credentials) |
| 2 | `POST /api/v1/external-image/scan` | Fetch security scan summaries (CVE details) for images/digests |
| 3 | `POST /api/v1/external-image/scan` (with `format=raw`) | Fetch raw security scan bundles |
| 4 | `POST /api/v1/external-image/scan-summary` | Fetch aggregated vulnerability counts per image/digest |
| 5 | `GET /api/v1/external-image/sbom` | Fetch SBOM (by `image_url` or `digest` query params) |

## Authentication

Bearer token in `Authorization` header: `Authorization: Bearer <token>`

- One static token per environment (production and staging), both belonging to the same team.
- Token is SHA-256 hashed and looked up in `service_account` table. Legacy bcrypt tokens auto-migrate to SHA-256 on first use.
- Expired tokens (`expires_at` in the past) rejected with 401. `expires_at IS NULL` = never expires.
- `team_id` from the matched service account scopes all data access.

---

## Plan

### Step 1 — Scaffold `securebuild-api`

Create `securebuild-api/` alongside `securebuild-app/`. Copy `package.json`, `tsconfig.json`, `jest.config.js`, `next.config.js` from `securebuild-www` and trim to API-only dependencies (drop all React/Tailwind/UI packages). Keep `next`, `pg`, `bcrypt`, `secure-random-string`, `@snyk/docker-registry-v2-client`, `@aws-sdk/client-ecr`, `@aws-sdk/client-ecr-public`, `dd-trace`. Add `@testcontainers/postgresql` + `testcontainers` to devDeps. Keep the `@/*` path alias and `output: 'standalone'`.

### Step 2 — Copy implementations from `securebuild-www`

Copy these files preserving directory structure:

```
app/api/v1/external-image/route.ts               # POST (create), GET (status)
app/api/v1/external-image/scan/route.ts          # POST (batch), GET (single)
app/api/v1/external-image/scan-summary/route.ts  # POST (aggregated counts)
app/api/v1/external-image/sbom/route.ts          # GET (single + batch SBOM merge)

lib/team/service-account.ts    # findServiceAccountWithValue()
lib/team/token.ts              # SHA-256/bcrypt token hashing
lib/types/service-account.ts   # ServiceAccount types

lib/externalimage/externalimage.ts   # DB read/write: upsert, scan, sbom, batch, status, credentials
lib/externalimage/registry.ts        # parseImageRef, getImageDigest, ECR credential exchange
lib/externalimage/registry.test.ts   # parseImageRef tests
lib/types/externalimage.ts           # TrackedExternalImage, SBOMStatus, ScanStatus types

lib/utils/queue.ts          # enqueueWork, hasExistingSBOM
lib/sbom/merger.ts          # SPDX 2.3 SBOM merger
lib/data/db.ts              # pg Pool, withTransaction
lib/data/param.ts           # getParam("DB_URI")
lib/utils/timestamp.ts      # parseUTCTimestamp
lib/observability/tracing.ts  # DataDog tracing wrappers
datadog/tracer.ts             # DataDog tracer init
__mocks__/server-only.js      # server-only mock for Jest
```

### Step 3 — Integration tests (local)

The test suite uses **real HTTP requests** (mirrors Go integration tests in `integration/ociproxy` and `integration/apkproxy` — real server on random port, HTTP `fetch` calls, no module mocks).

- **`local`** (default): Testcontainers PostgreSQL + a local Docker distribution registry (Testcontainers `registry:3.0.0`) + real Next.js server on random port. A tiny test image is pushed to the local registry at setup; POST /external-image resolves the digest from it — no external dependencies. No worker runs — scan/SBOM data is pre-seeded via YAML.

```bash
npm run test:integration
```

**Copy from `securebuild-www/integration/`** — fixtures (`database.ts`, `auth.ts`), `jest.config.js`, `setup.ts`, and all seed-data YAML are directly reusable. The existing seed data covers all scan states (succeeded/queued/running/failed/pending SBOM/generating SBOM) with realistic grype results for amd64 + arm64. Adapt `root.test.ts` → `create.test.ts` and `scan.test.ts` by replacing direct route handler calls with HTTP `fetch` via a shared `HttpClient`.

**Local registry** — add a `fixtures/registry.ts` (port from Go `integration/testutil/registry.go`): starts `registry:3.0.0` via Testcontainers, pushes a minimal test image (empty scratch + one layer) to it. POST /external-image resolves the digest from this local registry — zero external network dependencies. The registry address (e.g. `localhost:<port>/test-image:latest`) is the "created image" used by the test.

**Two distinct images** (no data overlap):
- **Created image** (pushed to local Testcontainers registry, e.g. `localhost:<port>/test-image:latest`): submitted via POST. Validates 201 + digest. Not used for read tests.
- **Existing image** (seeded via YAML with fake registry `test-registry.example.com` + digest `sha256:abc123...`): used for all read endpoint validation.

**Scan readiness:** seed data already has scan/SBOM rows for the existing image. For the POST-created image, verify `sbom_status='pending'` via GET. No polling needed.

**Test flow:**

```
Phase 1 — Create:
  POST /external-image (created image) → assert 201, extract digest
  GET /external-image?sha=<createdDigest> → assert sbom_status fields present

Phase 2 — Read (against existing image, independent of Phase 1):
  GET /scan?digest=<existingDigest>&arch=amd64&format=parsed → 200, counts + vulnerability_details
  POST /scan {digests:[<existingDigest>]} → 200, array with input/digest/result/not_found/scan_status/sbom_status
  POST /scan {images:[<existingImage>], format:raw} → 200, array with matches
  POST /scan-summary {digests:[<existingDigest>]} → 200, array with counts {critical,high,medium,low,total}
  GET /sbom?digest=<existingDigest> → 200, SBOM JSON object
  GET /sbom?image_url=<existingImage> → 200, SBOM JSON object

Phase 3 — Auth:
  Missing/invalid token on each endpoint → 401
```

**Assertions validate shape, not values:** status codes (exact), required response keys present, `counts` fields are numbers, `not_found` is boolean, `scan_status` is valid enum, `result` has expected keys per format, SBOM has `SPDXID`/`packages`/`relationships`, `X-SecureBuild-*` headers present, `digest` matches expected value.

### Step 4 — GitHub Actions

Add `securebuild-api/` to `check-changes/action.yml` path detection (new `run-api` output). Add jobs mirroring `securebuild-app` jobs:

- **`test.yml`**: `securebuild-api-tests` — `npm test` on PR
- **`build.yml`**: `securebuild-api-build` — `npm run build` on PR
- **`integration.yml`**: `securebuild-api-integration` — `npm run test:integration` with SchemaHero + Docker
- **`release.yml`**: `build-api` job — build standalone bundle, upload artifact, add to release

No secrets added to GitHub Actions.

---

## Environment Variables

### Service runtime

| Variable | Required | Used By |
|---|---|---|
| `DB_URI` (or `SECUREBUILD_PG_URI`) | Yes | Postgres connection string |
| `EXTERNAL_REGISTRY_ENCRYPTION_SECRET` | Yes | AES-GCM encrypt/decrypt of registry passwords |
| `AWS_ECR_PUBLIC_ACCESS_KEY_ID` | No | Default creds for public ECR rate-limit avoidance |
| `AWS_ECR_PUBLIC_SECRET_ACCESS_KEY` | No | Default creds for public ECR |
| `DD_ENABLED` | No | Enable DataDog tracing (no-op when unset) |

## Database

No new schema. Uses the existing shared Postgres with schema in `db/schema/tables/`. Tables: `service_account`, `securebuild_team`, `external_image`, `external_image_tag`, `external_image_team`, `external_image_credential`, `external_image_sbom`, `external_image_sbom_status`, `external_image_scan`, `work_queue`.
