### PR TITLE
Track when external_image_tag rows are updated

### DIFF
--- a/db/schema/tables/external-image-tag.yaml
+++ b/db/schema/tables/external-image-tag.yaml
@@ -26,6 +26,8 @@ schema:
       type: timestamp with time zone
       constraints:
         notNull: true
+    - name: last_submitted_at
+      type: timestamp with time zone
     - name: digest
       type: text
       constraints:

--- a/pkg/externalimage/externalimage.go
+++ b/pkg/externalimage/externalimage.go
@@ -499,6 +499,9 @@ func AddExternalImage(ctx context.Context, registry string, imageName string, ta
 	}
 
 	// Insert into external_image_tag table
+	// Note: last_submitted_at is intentionally NOT set here — this function is
+	// called by the digest-change monitor, not the API. Only upsertExternalImage
+	// (the API path) sets last_submitted_at.
 	query = `
 		insert into external_image_tag (registry, image_name, image_tag, created_at, digest, next_check_digest_at, next_scan_at)
 		values ($1, $2, $3, $4, $5, $6, $7)

--- a/securebuild-api/lib/externalimage/externalimage.ts
+++ b/securebuild-api/lib/externalimage/externalimage.ts
@@ -15,7 +15,7 @@ export async function upsertExternalImage(registry: string, imageName: string, i
 
       await client.query(query, [registry, imageName, new Date()])
 
-      const queryTag = `insert into external_image_tag (registry, image_name, image_tag, created_at, digest, next_check_digest_at, next_scan_at) values ($1, $2, $3, $4, $5, $6, $7) on conflict (registry, image_name, image_tag) do update set digest = $5, next_check_digest_at = $6, next_scan_at = $7`
+      const queryTag = `insert into external_image_tag (registry, image_name, image_tag, created_at, last_submitted_at, digest, next_check_digest_at, next_scan_at) values ($1, $2, $3, $4, $4, $5, $6, $7) on conflict (registry, image_name, image_tag) do update set digest = $5, next_check_digest_at = $6, next_scan_at = $7, last_submitted_at = $4`
       await client.query(queryTag, [registry, imageName, imageTag, new Date(), digest, inFourHours, inFourHours])
 
       if (username && password) {


### PR DESCRIPTION
Add `updated_at` to the `external_image_tag` table. This will be updated when an image is submitted multiple times.