### PR TITLE
Tiered image scanning based on last_submitted_at timestamp

### DIFF
--- a/db/schema/tables/external-image-tag.yaml
+++ b/db/schema/tables/external-image-tag.yaml
@@ -11,6 +11,10 @@ schema:
         columns:
           - digest
         isUnique: false
+      - name: idx_external_image_tag_last_submitted_at
+        columns:
+          - last_submitted_at
+        isUnique: false
     columns:
     - name: registry
       type: text

--- a/integration/worker/external_image/scan_tier_test.go
+++ b/integration/worker/external_image/scan_tier_test.go
@@ -1,0 +1,203 @@
+package worker_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/securebuildhq/securebuild/integration/testutil"
+	"github.com/securebuildhq/securebuild/pkg/listener"
+	"github.com/securebuildhq/securebuild/pkg/param"
+	"github.com/securebuildhq/securebuild/pkg/persistence"
+	"github.com/securebuildhq/securebuild/pkg/scan"
+	"github.com/securebuildhq/securebuild/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// referenceTime is the fixed "now" used in tier tests. All seed data
+// timestamps are relative to this value.
+const referenceTime = "2026-01-15T12:00:00Z"
+
+// tierTestDigests mirrors the seed data in testdata/seed-data/.
+var (
+	activeDigest    = "sha256:active-tier-digest-12345678901234567890123456789012"
+	recentDigest    = "sha256:recent-tier-digest-12345678901234567890123456789012"
+	staleDigest     = "sha256:stale-tier-digest-12345678901234567890123456789012"
+	excludedDigest  = "sha256:excluded-tier-digest-12345678901234567890123456789012"
+	neverScannedDg  = "sha256:never-scanned-digest-12345678901234567890123456789012"
+	freshDigest     = "sha256:fresh-active-digest-12345678901234567890123456789012"
+	activeScannedDg = "sha256:active-scanned-digest-12345678901234567890123456789012"
+)
+
+func setupTierTestDB(t *testing.T) (context.Context, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	testDB := testutil.SetupTestDatabase(ctx, t)
+
+	projectRoot, err := testutil.FindProjectRoot()
+	require.NoError(t, err)
+
+	schemaDir := filepath.Join(projectRoot, "db", "schema", "tables")
+	err = testutil.ApplySchemaHero(ctx, testDB.ConnStr, schemaDir, false)
+	require.NoError(t, err)
+
+	seedDataDir := filepath.Join(projectRoot, "integration", "worker", "external_image", "testdata", "seed-data")
+	err = testutil.ApplySchemaHero(ctx, testDB.ConnStr, seedDataDir, true)
+	require.NoError(t, err)
+
+	overrides := map[string]string{
+		"DB_URI": testDB.ConnStr,
+	}
+	ctx, err = param.Init(param.InitSourceEnvironment, overrides)
+	require.NoError(t, err)
+
+	err = persistence.InitPostgres(ctx)
+	require.NoError(t, err)
+
+	// Inject a fake clock so tier queries and idempotency checks use a
+	// deterministic reference time. Both scan and externalimage packages
+	// read the now func from util.WithNowFunc.
+	refTime, err := time.Parse(time.RFC3339, referenceTime)
+	require.NoError(t, err)
+	ctx = util.WithNowFunc(ctx, func() time.Time { return refTime })
+
+	cleanup := func() {
+		persistence.ClosePool(ctx)
+		testutil.TeardownTestDatabase(ctx, t, testDB)
+	}
+
+	return ctx, cleanup
+}
+
+// TestSelectExternalImageDigestsToScanTiers verifies that the tiered back-off
+// scheduling selects digests from the correct tier based on last_submitted_at
+// and that images >90 days old are excluded from the scheduler.
+func TestSelectExternalImageDigestsToScanTiers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	ctx, cleanup := setupTierTestDB(t)
+	defer cleanup()
+
+	t.Run("All tiers selected with sufficient capacity", func(t *testing.T) {
+		digests, err := scan.SelectExternalImageDigestsToScan(ctx, 25)
+		require.NoError(t, err)
+
+		assert.Contains(t, digests, neverScannedDg, "never-scanned digest should be selected")
+		assert.Contains(t, digests, activeDigest, "active tier digest should be selected")
+		assert.Contains(t, digests, recentDigest, "recent tier digest should be selected")
+		assert.Contains(t, digests, staleDigest, "stale tier digest should be selected")
+		assert.NotContains(t, digests, excludedDigest, "excluded digest (>90 days) should NOT be selected")
+	})
+
+	t.Run("Never-scanned prioritized over rescans when capacity=1", func(t *testing.T) {
+		digests, err := scan.SelectExternalImageDigestsToScan(ctx, 1)
+		require.NoError(t, err)
+
+		assert.Len(t, digests, 1)
+		assert.Contains(t, digests, neverScannedDg, "never-scanned should be prioritized over active rescans")
+	})
+
+	t.Run("Never-scanned and active tier with capacity=2", func(t *testing.T) {
+		digests, err := scan.SelectExternalImageDigestsToScan(ctx, 2)
+		require.NoError(t, err)
+
+		assert.Len(t, digests, 2)
+		assert.Contains(t, digests, neverScannedDg)
+		// Second slot should be from the active tier (either active or active-scanned)
+		assert.True(t, containsAny(digests, activeDigest, activeScannedDg),
+			"second digest should be from active tier, got %v", digests)
+		assert.NotContains(t, digests, recentDigest, "recent tier should not be reached with capacity 2")
+	})
+
+	t.Run("Active tier fills before recent tier", func(t *testing.T) {
+		// Capacity 3: never-scanned(1) + active(2) = 3, recent should not appear
+		digests, err := scan.SelectExternalImageDigestsToScan(ctx, 3)
+		require.NoError(t, err)
+
+		assert.Len(t, digests, 3)
+		assert.Contains(t, digests, neverScannedDg)
+		assert.NotContains(t, digests, recentDigest, "recent tier should not be reached with capacity 3")
+		assert.NotContains(t, digests, staleDigest, "stale tier should not be reached with capacity 3")
+	})
+
+	t.Run("Excluded digest (>90 days) never selected", func(t *testing.T) {
+		digests, err := scan.SelectExternalImageDigestsToScan(ctx, 25)
+		require.NoError(t, err)
+
+		assert.NotContains(t, digests, excludedDigest, "excluded digest should never be selected")
+	})
+}
+
+// TestSelectExternalImageDigestsToScanFreshNotStale verifies that a digest
+// scanned within the tier's rescan interval is NOT selected.
+func TestSelectExternalImageDigestsToScanFreshNotStale(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	ctx, cleanup := setupTierTestDB(t)
+	defer cleanup()
+
+	digests, err := scan.SelectExternalImageDigestsToScan(ctx, 25)
+	require.NoError(t, err)
+
+	assert.NotContains(t, digests, freshDigest, "recently scanned digest within interval should not be selected")
+}
+
+// TestHandleExternalImageScanIdempotency verifies that a scan message arriving
+// after a scan already completed within 4 hours is discarded without re-scanning.
+// Uses the "fresh" digest from seed data, which has last_security_scanned_at
+// set to 1 hour before the reference time (within the 4h idempotency threshold).
+func TestHandleExternalImageScanIdempotency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	ctx, cleanup := setupTierTestDB(t)
+	defer cleanup()
+
+	// Track scan call count via mock. This mock is expected to never be called
+	// because the handler should discard the message before reaching RunScanForDigest.
+	// If scanCallCount is non-zero, the idempotency guard failed.
+	scanCallCount := 0
+	mockScanExternalImage := func(ctx context.Context, digest string) (map[string]string, error) {
+		scanCallCount++
+		return map[string]string{
+			"x86_64": `{"matches":[],"descriptor":{"name":"grype","version":"0.95.0"}}`,
+		}, nil
+	}
+	ctx = listener.WithMockScanExternalImage(ctx, mockScanExternalImage)
+
+	// Call the handler with the fresh digest — should discard because scan
+	// completed 1 hour before reference time (within 4h threshold).
+	payload := `{"digest":"` + freshDigest + `"}`
+	err := listener.HandleExternalImageScan(ctx, payload)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, scanCallCount, "scan should not be called for recently scanned digest")
+
+	// Verify scan status is still 'succeeded' (not re-scanned)
+	scanStatuses := getScanStatuses(t, ctx, freshDigest)
+	require.Len(t, scanStatuses, 1)
+	assert.Equal(t, "succeeded", scanStatuses[0].Status)
+}
+
+// containsAny returns true if the slice contains any of the given values.
+func containsAny(slice []string, values ...string) bool {
+	for _, s := range slice {
+		for _, v := range values {
+			if s == v {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/integration/worker/external_image/testdata/seed-data/external-image-sbom.yaml
+++ b/integration/worker/external_image/testdata/seed-data/external-image-sbom.yaml
@@ -1,0 +1,143 @@
+database: securebuild
+name: external_image_sbom
+requires:
+  - external-image-tag
+seedData:
+  rows:
+    # Active tier SBOM — scanned 5h before reference (stale for 4h interval)
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:active-tier-digest-12345678901234567890123456789012"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: sbom
+          value:
+            str: '{"artifacts":[]}'
+        - column: source
+          value:
+            str: "syft"
+        - column: created_at
+          value:
+            str: "2026-01-14T00:00:00Z"
+        - column: last_security_scanned_at
+          value:
+            str: "2026-01-15T07:00:00Z"
+    # Recent tier SBOM — scanned 2 days before reference (stale for 24h interval)
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:recent-tier-digest-12345678901234567890123456789012"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: sbom
+          value:
+            str: '{"artifacts":[]}'
+        - column: source
+          value:
+            str: "syft"
+        - column: created_at
+          value:
+            str: "2026-01-05T00:00:00Z"
+        - column: last_security_scanned_at
+          value:
+            str: "2026-01-13T12:00:00Z"
+    # Stale tier SBOM — scanned 10 days before reference (stale for 7d interval)
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:stale-tier-digest-12345678901234567890123456789012"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: sbom
+          value:
+            str: '{"artifacts":[]}'
+        - column: source
+          value:
+            str: "syft"
+        - column: created_at
+          value:
+            str: "2025-12-01T00:00:00Z"
+        - column: last_security_scanned_at
+          value:
+            str: "2026-01-05T00:00:00Z"
+    # Excluded tier SBOM — scanned 30 days before reference (stale, but >90d excluded)
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:excluded-tier-digest-12345678901234567890123456789012"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: sbom
+          value:
+            str: '{"artifacts":[]}'
+        - column: source
+          value:
+            str: "syft"
+        - column: created_at
+          value:
+            str: "2025-10-06T00:00:00Z"
+        - column: last_security_scanned_at
+          value:
+            str: "2025-12-15T00:00:00Z"
+    # Never-scanned SBOM — no last_security_scanned_at
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:never-scanned-digest-12345678901234567890123456789012"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: sbom
+          value:
+            str: '{"artifacts":[]}'
+        - column: source
+          value:
+            str: "syft"
+        - column: created_at
+          value:
+            str: "2026-01-14T00:00:00Z"
+    # Fresh SBOM — scanned 1h before reference (within 4h interval, NOT stale)
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:fresh-active-digest-12345678901234567890123456789012"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: sbom
+          value:
+            str: '{"artifacts":[]}'
+        - column: source
+          value:
+            str: "syft"
+        - column: created_at
+          value:
+            str: "2026-01-14T00:00:00Z"
+        - column: last_security_scanned_at
+          value:
+            str: "2026-01-15T11:00:00Z"
+    # Active-scanned SBOM — scanned 5h before reference (stale for 4h interval)
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:active-scanned-digest-12345678901234567890123456789012"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: sbom
+          value:
+            str: '{"artifacts":[]}'
+        - column: source
+          value:
+            str: "syft"
+        - column: created_at
+          value:
+            str: "2026-01-14T00:00:00Z"
+        - column: last_security_scanned_at
+          value:
+            str: "2026-01-15T07:00:00Z"

--- a/integration/worker/external_image/testdata/seed-data/external-image-scan.yaml
+++ b/integration/worker/external_image/testdata/seed-data/external-image-scan.yaml
@@ -1,0 +1,29 @@
+database: securebuild
+name: external_image_scan
+requires:
+  - external-image-sbom
+seedData:
+  rows:
+    # Fresh digest — scan succeeded 1 hour before reference time (within 4h threshold)
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:fresh-active-digest-12345678901234567890123456789012"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: created_at
+          value:
+            str: "2026-01-14T00:00:00Z"
+        - column: status
+          value:
+            str: "succeeded"
+        - column: scan_completed_at
+          value:
+            str: "2026-01-15T11:00:00Z"
+        - column: scan_attempted_at
+          value:
+            str: "2026-01-15T11:00:00Z"
+        - column: scan_status_updated_at
+          value:
+            str: "2026-01-15T11:00:00Z"

--- a/integration/worker/external_image/testdata/seed-data/external-image-tag.yaml
+++ b/integration/worker/external_image/testdata/seed-data/external-image-tag.yaml
@@ -1,0 +1,189 @@
+database: securebuild
+name: external_image_tag
+requires:
+  - external-image
+seedData:
+  rows:
+    # Active tier: submitted 1 day before reference (2026-01-15)
+    - columns:
+        - column: registry
+          value:
+            str: "docker.io"
+        - column: image_name
+          value:
+            str: "library/tier-test"
+        - column: image_tag
+          value:
+            str: "active"
+        - column: created_at
+          value:
+            str: "2026-01-14T00:00:00Z"
+        - column: last_submitted_at
+          value:
+            str: "2026-01-14T00:00:00Z"
+        - column: digest
+          value:
+            str: "sha256:active-tier-digest-12345678901234567890123456789012"
+        - column: next_check_digest_at
+          value:
+            str: "2026-01-16T00:00:00Z"
+        - column: next_scan_at
+          value:
+            str: "2026-01-16T00:00:00Z"
+    # Recent tier: submitted 10 days before reference
+    - columns:
+        - column: registry
+          value:
+            str: "docker.io"
+        - column: image_name
+          value:
+            str: "library/tier-test"
+        - column: image_tag
+          value:
+            str: "recent"
+        - column: created_at
+          value:
+            str: "2026-01-05T00:00:00Z"
+        - column: last_submitted_at
+          value:
+            str: "2026-01-05T00:00:00Z"
+        - column: digest
+          value:
+            str: "sha256:recent-tier-digest-12345678901234567890123456789012"
+        - column: next_check_digest_at
+          value:
+            str: "2026-01-06T00:00:00Z"
+        - column: next_scan_at
+          value:
+            str: "2026-01-06T00:00:00Z"
+    # Stale tier: submitted 45 days before reference
+    - columns:
+        - column: registry
+          value:
+            str: "docker.io"
+        - column: image_name
+          value:
+            str: "library/tier-test"
+        - column: image_tag
+          value:
+            str: "stale"
+        - column: created_at
+          value:
+            str: "2025-12-01T00:00:00Z"
+        - column: last_submitted_at
+          value:
+            str: "2025-12-01T00:00:00Z"
+        - column: digest
+          value:
+            str: "sha256:stale-tier-digest-12345678901234567890123456789012"
+        - column: next_check_digest_at
+          value:
+            str: "2025-12-02T00:00:00Z"
+        - column: next_scan_at
+          value:
+            str: "2025-12-02T00:00:00Z"
+    # Excluded tier: submitted 100 days before reference (>90 days)
+    - columns:
+        - column: registry
+          value:
+            str: "docker.io"
+        - column: image_name
+          value:
+            str: "library/tier-test"
+        - column: image_tag
+          value:
+            str: "excluded"
+        - column: created_at
+          value:
+            str: "2025-10-06T00:00:00Z"
+        - column: last_submitted_at
+          value:
+            str: "2025-10-06T00:00:00Z"
+        - column: digest
+          value:
+            str: "sha256:excluded-tier-digest-12345678901234567890123456789012"
+        - column: next_check_digest_at
+          value:
+            str: "2025-10-07T00:00:00Z"
+        - column: next_scan_at
+          value:
+            str: "2025-10-07T00:00:00Z"
+    # Never-scanned: submitted 1 day before reference, no scan ever
+    - columns:
+        - column: registry
+          value:
+            str: "docker.io"
+        - column: image_name
+          value:
+            str: "library/tier-test"
+        - column: image_tag
+          value:
+            str: "never-scanned"
+        - column: created_at
+          value:
+            str: "2026-01-14T00:00:00Z"
+        - column: last_submitted_at
+          value:
+            str: "2026-01-14T00:00:00Z"
+        - column: digest
+          value:
+            str: "sha256:never-scanned-digest-12345678901234567890123456789012"
+        - column: next_check_digest_at
+          value:
+            str: "2026-01-16T00:00:00Z"
+        - column: next_scan_at
+          value:
+            str: "2026-01-16T00:00:00Z"
+    # Fresh (not stale): submitted 1 day before reference, scanned 1h before reference
+    - columns:
+        - column: registry
+          value:
+            str: "docker.io"
+        - column: image_name
+          value:
+            str: "library/tier-test"
+        - column: image_tag
+          value:
+            str: "fresh"
+        - column: created_at
+          value:
+            str: "2026-01-14T00:00:00Z"
+        - column: last_submitted_at
+          value:
+            str: "2026-01-14T00:00:00Z"
+        - column: digest
+          value:
+            str: "sha256:fresh-active-digest-12345678901234567890123456789012"
+        - column: next_check_digest_at
+          value:
+            str: "2026-01-16T00:00:00Z"
+        - column: next_scan_at
+          value:
+            str: "2026-01-16T00:00:00Z"
+    # Active-scanned: submitted 1 day before reference, scanned 5h before (stale for 4h)
+    # Used to verify never-scanned is prioritized over active rescans
+    - columns:
+        - column: registry
+          value:
+            str: "docker.io"
+        - column: image_name
+          value:
+            str: "library/tier-test"
+        - column: image_tag
+          value:
+            str: "active-scanned"
+        - column: created_at
+          value:
+            str: "2026-01-14T00:00:00Z"
+        - column: last_submitted_at
+          value:
+            str: "2026-01-14T00:00:00Z"
+        - column: digest
+          value:
+            str: "sha256:active-scanned-digest-12345678901234567890123456789012"
+        - column: next_check_digest_at
+          value:
+            str: "2026-01-16T00:00:00Z"
+        - column: next_scan_at
+          value:
+            str: "2026-01-16T00:00:00Z"

--- a/integration/worker/external_image/testdata/seed-data/external-image.yaml
+++ b/integration/worker/external_image/testdata/seed-data/external-image.yaml
@@ -1,0 +1,15 @@
+database: securebuild
+name: external_image
+requires: []
+seedData:
+  rows:
+    - columns:
+        - column: registry
+          value:
+            str: "docker.io"
+        - column: image_name
+          value:
+            str: "library/tier-test"
+        - column: created_at
+          value:
+            str: "2025-10-01T00:00:00Z"

--- a/pkg/externalimage/externalimage.go
+++ b/pkg/externalimage/externalimage.go
@@ -11,6 +11,7 @@ import (
 	"github.com/securebuildhq/securebuild/pkg/image"
 	"github.com/securebuildhq/securebuild/pkg/logger"
 	"github.com/securebuildhq/securebuild/pkg/persistence"
+	"github.com/securebuildhq/securebuild/pkg/util"
 )
 
 // SBOMStatus represents the status of SBOM generation for an external image.
@@ -41,6 +42,7 @@ const (
 type ScanStatus string
 
 const (
+	ScanStatusUnknown   ScanStatus = "unknown"
 	ScanStatusQueued    ScanStatus = "queued"
 	ScanStatusRunning   ScanStatus = "running"
 	ScanStatusSucceeded ScanStatus = "succeeded"
@@ -279,8 +281,8 @@ func SetSBOMStatusFailed(ctx context.Context, digest string, errorMessage string
 // InitializeScanStatusQueued creates a scan status record with status='queued'.
 // This is used after SBOM creation to indicate that a scan is pending.
 // Does not set scan_attempted_at or scan_completed_at (those are set when scan actually runs).
-// On conflict, updates status to 'queued' only if current status is 'pending_sbom' or 'generating_sbom'.
-// This allows proper state transition: pending_sbom -> generating_sbom -> queued.
+// On conflict, updates status to 'queued' only if current status is 'unknown',
+// 'pending_sbom', or 'generating_sbom'.
 func InitializeScanStatusQueued(ctx context.Context, digest, arch string) error {
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
@@ -294,7 +296,7 @@ func InitializeScanStatusQueued(ctx context.Context, digest, arch string) error 
 		SET status = $4,
 		    updated_at = $3,
 		    scan_status_updated_at = $3
-		WHERE external_image_scan.status IN ('pending_sbom', 'generating_sbom')
+		WHERE external_image_scan.status IN ('unknown', 'pending_sbom', 'generating_sbom')
 	`
 
 	_, err := conn.Exec(ctx, query, digest, arch, now, string(ScanStatusQueued))
@@ -418,6 +420,36 @@ func HasExistingSBOM(ctx context.Context, digest string) (bool, error) {
 		return false, err
 	}
 	return sbom != nil, nil
+}
+
+// WasScannedRecently checks whether the digest was scanned within the given duration.
+// Uses last_security_scanned_at from external_image_sbom (digest-level timestamp).
+// Returns true only if every architecture has been scanned and the oldest scan
+// is within the threshold. Returns false if any architecture has never been
+// scanned (NULL last_security_scanned_at) or if the oldest scan is stale.
+func WasScannedRecently(ctx context.Context, digest string, threshold time.Duration) (bool, error) {
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+
+	var hasUnscanned bool
+	var lastScannedAt *time.Time
+	err := conn.QueryRow(ctx, `
+		SELECT
+			bool_or(last_security_scanned_at IS NULL),
+			min(last_security_scanned_at)
+		FROM external_image_sbom
+		WHERE digest = $1
+	`, digest).Scan(&hasUnscanned, &lastScannedAt)
+	if err != nil {
+		return false, fmt.Errorf("failed to check scan recency for digest %s: %w", digest, err)
+	}
+
+	if hasUnscanned || lastScannedAt == nil {
+		return false, nil
+	}
+
+	now := util.GetNowFunc(ctx)()
+	return now.Sub(*lastScannedAt) < threshold, nil
 }
 
 func SetExternalImageSBOM(ctx context.Context, digest string, sbom string, source string, arch string, imageSizeBytes int64, imageDigest string) error {

--- a/pkg/externalimage/externalimage.go
+++ b/pkg/externalimage/externalimage.go
@@ -531,18 +531,19 @@ func AddExternalImage(ctx context.Context, registry string, imageName string, ta
 	}
 
 	// Insert into external_image_tag table
-	// Note: last_submitted_at is intentionally NOT set here — this function is
-	// called by the digest-change monitor, not the API. Only upsertExternalImage
-	// (the API path) sets last_submitted_at.
+	// Set last_submitted_at = now() so the digest is included in scan tier
+	// queries. The monitor re-adds an image when it detects a digest change,
+	// which indicates active tracking — same as the API submission path.
+	now := time.Now()
 	query = `
-		insert into external_image_tag (registry, image_name, image_tag, created_at, digest, next_check_digest_at, next_scan_at)
-		values ($1, $2, $3, $4, $5, $6, $7)
+		insert into external_image_tag (registry, image_name, image_tag, created_at, last_submitted_at, digest, next_check_digest_at, next_scan_at)
+		values ($1, $2, $3, $4, $4, $5, $6, $7)
 		on conflict (registry, image_name, image_tag) do update
-		set digest = $5, next_check_digest_at = $6, next_scan_at = $7, created_at = $4
+		set digest = $5, last_submitted_at = $4, next_check_digest_at = $6, next_scan_at = $7, created_at = $4
 	`
 
-	inFourHours := time.Now().Add(time.Hour * 4)
-	_, err = conn.Exec(ctx, query, registry, imageName, tag, time.Now(), digest, inFourHours, inFourHours)
+	inFourHours := now.Add(time.Hour * 4)
+	_, err = conn.Exec(ctx, query, registry, imageName, tag, now, digest, inFourHours, inFourHours)
 	if err != nil {
 		return fmt.Errorf("failed to insert/update external image tag %s/%s:%s: %w", registry, imageName, tag, err)
 	}

--- a/pkg/listener/external-image-sbom.go
+++ b/pkg/listener/external-image-sbom.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/securebuildhq/securebuild/pkg/externalimage"
 	extimgtypes "github.com/securebuildhq/securebuild/pkg/externalimage/types"
@@ -282,6 +283,34 @@ func storeScanResults(ctx context.Context, digest string, scanResults map[string
 		return 0, err
 	}
 	return successCount, nil
+}
+
+// HandleExternalImageScan processes an on-demand external image scan request
+// from the external_image_scan work queue channel. It performs an idempotency
+// check (discard if scanned within 4 hours) and then delegates to RunScanForDigest.
+// Exported for integration testing.
+func HandleExternalImageScan(ctx context.Context, payloadJSON string) error {
+	p := types.ExternalImageScanPayload{}
+	if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+		return fmt.Errorf("failed to unmarshal external image scan payload: %w", err)
+	}
+
+	if p.Digest == "" {
+		return fmt.Errorf("external image scan payload missing digest")
+	}
+
+	recent, err := externalimage.WasScannedRecently(ctx, p.Digest, 4*time.Hour)
+	if err != nil {
+		logger.Warn("failed to check scan recency, proceeding with scan",
+			zap.String("digest", p.Digest),
+			zap.Error(err))
+	} else if recent {
+		logger.Info("discarding external_image_scan message: scan completed within 4 hours",
+			zap.String("digest", p.Digest))
+		return nil
+	}
+
+	return RunScanForDigest(ctx, p.Digest)
 }
 
 // RunScanForDigest runs a security scan for a digest that already has SBOM data.

--- a/pkg/listener/external-image-sbom.go
+++ b/pkg/listener/external-image-sbom.go
@@ -231,7 +231,8 @@ func extractArchFromPlatform(platform string) string {
 
 // storeScanResults parses and stores scan results per architecture.
 // The span is started inside this function so the traced operation is the function itself.
-func storeScanResults(ctx context.Context, digest string, scanResults map[string]string, attempt, maxAttempts int) (successCount int, err error) {
+// Returns the list of architectures that were successfully stored.
+func storeScanResults(ctx context.Context, digest string, scanResults map[string]string, attempt, maxAttempts int) (successArchs []string, err error) {
 	span, ctx := telemetry.StartSpan(ctx, "listener.external_image_scan.store_results")
 	defer func() {
 		if err != nil {
@@ -271,18 +272,18 @@ func storeScanResults(ctx context.Context, digest string, scanResults map[string
 			continue
 		}
 
-		successCount++
+		successArchs = append(successArchs, arch)
 		logger.Info("stored scan result for architecture",
 			zap.String("digest", digest),
 			zap.String("arch", arch),
 			zap.Int("attempt", attempt),
 			zap.Int("max_attempts", maxAttempts))
 	}
-	if len(scanResults) > 0 && successCount == 0 {
+	if len(scanResults) > 0 && len(successArchs) == 0 {
 		err = fmt.Errorf("failed to store scan results for any of %d architecture(s)", len(scanResults))
-		return 0, err
+		return nil, err
 	}
-	return successCount, nil
+	return successArchs, nil
 }
 
 // HandleExternalImageScan processes an on-demand external image scan request
@@ -357,7 +358,7 @@ func RunScanForDigest(ctx context.Context, digest string) error {
 	// If all architectures fail to parse/marshal/save, storeScanResults returns an error but
 	// each failure is already recorded via recordScanFailure. Return nil so the job finishes
 	// without retry (retrying would not fix data/parse/save issues).
-	successCount, err := storeScanResults(ctx, digest, scanResults, attempt, maxAttempts)
+	successArchs, err := storeScanResults(ctx, digest, scanResults, attempt, maxAttempts)
 	if err != nil {
 		logger.Warn("all architectures failed to store scan results; failures recorded, not retrying",
 			zap.String("digest", digest),
@@ -387,8 +388,17 @@ func RunScanForDigest(ctx context.Context, digest string) error {
 		zap.Int("max_attempts", maxAttempts))
 	// Only count as succeeded when (1) scan returned results for every expected arch, and
 	// (2) we successfully stored every result (parse/marshal/save for each arch).
-	if len(storedSBOMs) > 0 && allExpectedArchsGotScanResults && successCount == len(scanResults) {
+	if len(storedSBOMs) > 0 && allExpectedArchsGotScanResults && len(successArchs) == len(scanResults) {
 		telemetry.Increment(telemetry.MetricExternalImageScanSucceeded, []string{telemetry.TagChannelExternalImageScan})
+	}
+
+	// Update last_security_scanned_at for architectures whose results were
+	// successfully stored. scanResults keys are the arches that were scanned
+	// successfully; successArchs are the subset that were also stored.
+	if err := scan.UpdateLastSecurityScanned(ctx, digest, successArchs, time.Now().UTC()); err != nil {
+		logger.Warn("failed to update last_security_scanned_at",
+			zap.String("digest", digest),
+			zap.Error(err))
 	}
 
 	return nil

--- a/pkg/listener/start.go
+++ b/pkg/listener/start.go
@@ -274,9 +274,14 @@ func StartExternalImageSbomListener(ctx context.Context, l *Listener) {
 }
 
 func StartExternalImageScanListener(ctx context.Context, l *Listener) {
-	l.AddHandler(ctx, "external_image_scan", 1, time.Minute*1, func(ctx context.Context, notification *pgconn.Notification) error {
-		// this handler has been removed in favor of selecting digests from the DB directly
-		return nil
+	l.AddHandler(ctx, "external_image_scan", 1, time.Minute*5, func(ctx context.Context, notification *pgconn.Notification) error {
+		return telemetry.WithSpan(ctx, "listener.external_image_scan", func(ctx context.Context) error {
+			if err := HandleExternalImageScan(ctx, notification.Payload); err != nil {
+				logger.Error(fmt.Errorf("failed to handle external image scan notification: %w", err))
+				return fmt.Errorf("failed to handle external image scan notification: %w", err)
+			}
+			return nil
+		})
 	})
 }
 

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -16,6 +16,7 @@ import (
 	"github.com/securebuildhq/securebuild/pkg/persistence"
 	"github.com/securebuildhq/securebuild/pkg/security"
 	"github.com/securebuildhq/securebuild/pkg/telemetry"
+	"github.com/securebuildhq/securebuild/pkg/util"
 	"go.uber.org/zap"
 )
 
@@ -214,11 +215,42 @@ func getRegistryHostname(imageURL string) (string, error) {
 	return parts[0], nil
 }
 
-// selectExternalImageDigestsToScan returns a prioritized list of external image digests to scan.
-// Priority:
-// 1) Digests that have SBOMs but no successful scans yet
-// 2) Digests ordered by the time of their last successful scan (oldest first)
-func selectExternalImageDigestsToScan(ctx context.Context, maxToProcess int) ([]string, error) {
+// scanTier defines a back-off tier for rescan scheduling.
+// Each tier has a last_submitted_at window and a rescan interval.
+// Tiers are queried in priority order; higher tiers are filled before
+// lower tiers contribute digests. Images submitted >90 days ago (tier 5)
+// are excluded from the scheduler entirely (on-demand only).
+//
+// submittedAfter is the minimum age (e.g. "7 days" means submitted more than 7 days ago).
+// submittedBefore is the maximum age (e.g. "0 days" means submitted less than 0 days ago = now).
+// The tier window is: ref - submittedBefore < last_submitted_at <= ref - submittedAfter
+// For active: submitted 0-7 days ago → last_submitted > ref-7d AND last_submitted <= ref-0d
+type scanTier struct {
+	name            string
+	submittedAfter  string // minimum age: last_submitted_at > ref - interval
+	submittedBefore string // maximum age: last_submitted_at <= ref - interval
+	rescanInterval  string // rescan threshold: last_security_scanned_at < ref - interval
+}
+
+var scanTiers = []scanTier{
+	{name: "active", submittedAfter: "7 days", submittedBefore: "0 days", rescanInterval: "4 hours"},
+	{name: "recent", submittedAfter: "30 days", submittedBefore: "7 days", rescanInterval: "24 hours"},
+	{name: "stale", submittedAfter: "90 days", submittedBefore: "30 days", rescanInterval: "7 days"},
+}
+
+// SelectExternalImageDigestsToScan returns a prioritized list of external image digests to scan.
+//
+// Priority order:
+//  1. Never scanned: digests with SBOMs but no scans yet
+//  2. Active tier:  last_submitted < 7 days,    rescan if older than 4 hours
+//  3. Recent tier:  last_submitted 7-30 days,   rescan if older than 24 hours
+//  4. Stale tier:   last_submitted 30-90 days,  rescan if older than 7 days
+//  5. Excluded:     last_submitted > 90 days    — not scanned by scheduler
+//
+// Each tier uses ORDER BY random() for fair distribution within the tier.
+// After each query, remaining capacity is evaluated; if 0, lower tiers are skipped.
+// A seen map prevents duplicate digests across tiers.
+func SelectExternalImageDigestsToScan(ctx context.Context, maxToProcess int) ([]string, error) {
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
@@ -226,53 +258,68 @@ func selectExternalImageDigestsToScan(ctx context.Context, maxToProcess int) ([]
 		maxToProcess = 25
 	}
 
+	referenceTime := util.GetNowFunc(ctx)()
+
 	selectedDigests := make([]string, 0, maxToProcess)
 	seen := map[string]struct{}{}
 
-	// 1) Digests with SBOMs but no scans yet (based on last_security_scanned_at)
+	// Tier 1: Digests with SBOMs but no scans yet (first scan, highest priority)
 	rows, err := conn.Query(ctx, `
-		SELECT s.digest, MIN(s.created_at) AS first_sbom_at
+		SELECT s.digest
 		FROM external_image_sbom s
+		WHERE s.last_security_scanned_at IS NULL
 		GROUP BY s.digest
-		HAVING MIN(s.last_security_scanned_at) IS NULL
-		ORDER BY first_sbom_at ASC
+		ORDER BY random()
 		LIMIT $1
 	`, maxToProcess)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query digests missing scans: %w", err)
 	}
-	defer rows.Close()
 	for rows.Next() {
 		var digest string
-		var firstSBOMAt time.Time
-		if err := rows.Scan(&digest, &firstSBOMAt); err != nil {
+		if err := rows.Scan(&digest); err != nil {
 			logger.Warn("failed to scan row for missing-scan digest", zap.Error(err))
 			continue
 		}
 		selectedDigests = append(selectedDigests, digest)
 		seen[digest] = struct{}{}
 	}
+	rows.Close()
 
 	remaining := maxToProcess - len(selectedDigests)
-	if remaining > 0 {
-		// 2) Digests with scans, order by oldest last scan using last_security_scanned_at on SBOMs
-		rows2, err := conn.Query(ctx, `
-			SELECT digest, MIN(last_security_scanned_at) AS last_security_scanned_at
-			FROM external_image_sbom
-			WHERE last_security_scanned_at IS NOT NULL AND last_security_scanned_at < now() - interval '4 hours'
-			GROUP BY digest
-			ORDER BY last_security_scanned_at ASC
-			LIMIT $1
-		`, remaining)
-		if err != nil {
-			return nil, fmt.Errorf("failed to query digests by last scan time: %w", err)
+
+	// Tiers 2-4: Back-off tiers based on last_submitted_at
+	for _, tier := range scanTiers {
+		if remaining <= 0 {
+			break
 		}
-		defer rows2.Close()
-		for rows2.Next() {
+
+		query := fmt.Sprintf(`
+			WITH tier_tags AS (
+				SELECT digest
+				FROM external_image_tag
+				WHERE last_submitted_at > $2::timestamptz - interval '%s'
+				  AND last_submitted_at <= $2::timestamptz - interval '%s'
+				GROUP BY digest
+			)
+			SELECT s.digest
+			FROM external_image_sbom s
+			JOIN tier_tags t ON t.digest = s.digest
+			WHERE s.last_security_scanned_at IS NOT NULL
+			  AND s.last_security_scanned_at < $2::timestamptz - interval '%s'
+			GROUP BY s.digest
+			ORDER BY random()
+			LIMIT $1
+		`, tier.submittedAfter, tier.submittedBefore, tier.rescanInterval)
+
+		rows, err := conn.Query(ctx, query, remaining, referenceTime)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query %s tier digests: %w", tier.name, err)
+		}
+		for rows.Next() {
 			var digest string
-			var lastScannedAt time.Time
-			if err := rows2.Scan(&digest, &lastScannedAt); err != nil {
-				logger.Warn("failed to scan row for last-scanned digest", zap.Error(err))
+			if err := rows.Scan(&digest); err != nil {
+				logger.Warn("failed to scan row for tier digest", zap.String("tier", tier.name), zap.Error(err))
 				continue
 			}
 			if _, ok := seen[digest]; ok {
@@ -280,7 +327,9 @@ func selectExternalImageDigestsToScan(ctx context.Context, maxToProcess int) ([]
 			}
 			selectedDigests = append(selectedDigests, digest)
 			seen[digest] = struct{}{}
+			remaining--
 		}
+		rows.Close()
 	}
 
 	return selectedDigests, nil
@@ -298,12 +347,10 @@ func updateLastSecurityScannedAt(ctx context.Context, digest string, t time.Time
 }
 
 // processExternalImageScans selects external image SBOMs to scan and processes them.
-// Priority:
-// 1) Digests that have SBOMs but no successful scans yet
-// 2) Digests ordered by the time of their last successful scan (oldest first)
+// Selection uses tiered back-off based on last_submitted_at (see SelectExternalImageDigestsToScan).
 // returns true if there are no more digests to scan
 func processExternalImageScans(ctx context.Context, maxToProcess int) (bool, error) {
-	selectedDigests, err := selectExternalImageDigestsToScan(ctx, maxToProcess)
+	selectedDigests, err := SelectExternalImageDigestsToScan(ctx, maxToProcess)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -335,12 +335,18 @@ func SelectExternalImageDigestsToScan(ctx context.Context, maxToProcess int) ([]
 	return selectedDigests, nil
 }
 
-// updateLastSecurityScannedAt updates the last_security_scanned_at timestamp for all SBOMs of a digest.
-func updateLastSecurityScannedAt(ctx context.Context, digest string, t time.Time) error {
+// UpdateLastSecurityScanned updates the last_security_scanned_at timestamp
+// for the specified architectures of a digest. If archs is empty, no update
+// is performed.
+func UpdateLastSecurityScanned(ctx context.Context, digest string, archs []string, t time.Time) error {
+	if len(archs) == 0 {
+		return nil
+	}
+
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
-	if _, err := conn.Exec(ctx, `UPDATE external_image_sbom SET last_security_scanned_at = $2 WHERE digest = $1`, digest, t); err != nil {
+	if _, err := conn.Exec(ctx, `UPDATE external_image_sbom SET last_security_scanned_at = $3 WHERE digest = $1 AND arch = ANY($2)`, digest, archs, t); err != nil {
 		return err
 	}
 	return nil
@@ -385,11 +391,19 @@ func processExternalImageScans(ctx context.Context, maxToProcess int) (bool, err
 				zap.String("digest", digest),
 				zap.Error(err))
 
-			// Update last_scanned_at on failure to avoid hot-loop retries
-			if execErr := updateLastSecurityScannedAt(ctx, digest, time.Now().UTC()); execErr != nil {
+			// Update last_security_scanned_at for arches that were scanned (scanResults
+			// keys) to prevent hot-loop retries. When ScanExternalImage returns an error,
+			// scanResults is empty, so this is a no-op and all arches remain eligible
+			// for retry — the scheduler's MaxImagesPerCycle limit and cycle interval
+			// throttle retries naturally.
+			scannedArchs := make([]string, 0, len(scanResults))
+			for arch := range scanResults {
+				scannedArchs = append(scannedArchs, arch)
+			}
+			if err := UpdateLastSecurityScanned(ctx, digest, scannedArchs, time.Now().UTC()); err != nil {
 				logger.Warn("failed to update last_security_scanned_at after scan failure",
 					zap.String("digest", digest),
-					zap.Error(execErr))
+					zap.Error(err))
 			}
 
 			// Record failure for each architecture from the SBOMs
@@ -431,6 +445,7 @@ func processExternalImageScans(ctx context.Context, maxToProcess int) (bool, err
 			}
 		}
 
+		successArchs := make([]string, 0, len(scanResults))
 		for arch, scanResult := range scanResults {
 			parsedResults, err := image.ParseScanResultDetails(scanResult)
 			if err != nil {
@@ -478,6 +493,7 @@ func processExternalImageScans(ctx context.Context, maxToProcess int) (bool, err
 				recordArchFailure(arch, fmt.Sprintf("scan completed but failed to save results: %v", err))
 				continue
 			}
+			successArchs = append(successArchs, arch)
 		}
 
 		// Check for architectures in stored SBOMs that didn't get scan results
@@ -495,9 +511,11 @@ func processExternalImageScans(ctx context.Context, maxToProcess int) (bool, err
 			}
 		}
 
-		// Mark SBOMs for this digest as scanned now (digest-level timestamp)
-		if err := updateLastSecurityScannedAt(ctx, digest, time.Now().UTC()); err != nil {
-			logger.Warn("failed to update last_security_scanned_at for digest",
+		// Update last_security_scanned_at for architectures whose results were
+		// successfully stored. scanResults keys are the arches that ScanExternalImage
+		// scanned successfully; successArchs are the subset that were also stored.
+		if err := UpdateLastSecurityScanned(ctx, digest, successArchs, time.Now().UTC()); err != nil {
+			logger.Warn("failed to update last_security_scanned_at",
 				zap.String("digest", digest),
 				zap.Error(err))
 		}

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -505,3 +505,71 @@ func processExternalImageScans(ctx context.Context, maxToProcess int) (bool, err
 
 	return false, nil
 }
+
+// ReportScanMetrics sends gauge metrics for the scan backlog and running scans.
+//
+// For each tier (including never-scanned), it counts digests that have not been
+// scanned within their respective rescan interval — i.e., digests that are
+// eligible for scanning right now. It also counts how many scans are currently
+// in the 'running' status.
+//
+// Gauges sent:
+//   - securebuild.external_image.scan.backlog  (tag: tier=<never_scanned|active|recent|stale>)
+//   - securebuild.external_image.scan.running
+func ReportScanMetrics(ctx context.Context) {
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+
+	referenceTime := util.GetNowFunc(ctx)()
+
+	// Never scanned: digests with SBOMs where last_security_scanned_at IS NULL
+	var neverScannedCount int
+	if err := conn.QueryRow(ctx, `
+		SELECT COUNT(DISTINCT s.digest)
+		FROM external_image_sbom s
+		WHERE s.last_security_scanned_at IS NULL
+	`).Scan(&neverScannedCount); err != nil {
+		logger.Warn("failed to count never-scanned digests", zap.Error(err))
+	} else {
+		telemetry.Gauge(telemetry.MetricExternalImageScanBacklog, float64(neverScannedCount),
+			[]string{telemetry.TagScanTier + ":never_scanned"})
+	}
+
+	// Per-tier backlog: digests whose last_security_scanned_at is older than
+	// the tier's rescan interval, within the tier's last_submitted_at window.
+	for _, tier := range scanTiers {
+		var count int
+		query := fmt.Sprintf(`
+			WITH tier_tags AS (
+				SELECT digest
+				FROM external_image_tag
+				WHERE last_submitted_at > $1::timestamptz - interval '%s'
+				  AND last_submitted_at <= $1::timestamptz - interval '%s'
+				GROUP BY digest
+			)
+			SELECT COUNT(DISTINCT s.digest)
+			FROM external_image_sbom s
+			JOIN tier_tags t ON t.digest = s.digest
+			WHERE s.last_security_scanned_at IS NOT NULL
+			  AND s.last_security_scanned_at < $1::timestamptz - interval '%s'
+		`, tier.submittedAfter, tier.submittedBefore, tier.rescanInterval)
+
+		if err := conn.QueryRow(ctx, query, referenceTime).Scan(&count); err != nil {
+			logger.Warn("failed to count tier backlog", zap.String("tier", tier.name), zap.Error(err))
+			continue
+		}
+
+		telemetry.Gauge(telemetry.MetricExternalImageScanBacklog, float64(count),
+			[]string{telemetry.TagScanTier + ":" + tier.name})
+	}
+
+	// Running scans: count of external_image_scan rows with status = 'running'
+	var runningCount int
+	if err := conn.QueryRow(ctx, `
+		SELECT COUNT(*) FROM external_image_scan WHERE status = 'running'
+	`).Scan(&runningCount); err != nil {
+		logger.Warn("failed to count running scans", zap.Error(err))
+	} else {
+		telemetry.Gauge(telemetry.MetricExternalImageScansRunning, float64(runningCount), nil)
+	}
+}

--- a/pkg/scan/scheduler.go
+++ b/pkg/scan/scheduler.go
@@ -24,6 +24,9 @@ const (
 
 	// MaxImagesPerCycle limits how many images are processed in each scheduler cycle
 	MaxImagesPerCycle = 25
+
+	// MetricsReportInterval is how often scan backlog and running scan gauges are sent
+	MetricsReportInterval = 1 * time.Minute
 )
 
 // GetRandomizedScanInterval returns ScanInterval plus a random offset of ±60 minutes
@@ -35,6 +38,20 @@ func GetRandomizedScanInterval() time.Duration {
 
 func StartScheduler(ctx context.Context) error {
 	logger.Info("Starting scan scheduler")
+
+	// Periodic metrics reporter for scan backlog and running scan counts
+	go func() {
+		ticker := time.NewTicker(MetricsReportInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				ReportScanMetrics(ctx)
+			}
+		}
+	}()
 
 	go func() {
 		for {

--- a/pkg/telemetry/datadog.go
+++ b/pkg/telemetry/datadog.go
@@ -24,8 +24,13 @@ const (
 	MetricExternalImageScanFailed    = "securebuild.external_image.scan.failed"
 	MetricExternalImageScanSucceeded = "securebuild.external_image.scan.succeeded"
 
+	MetricExternalImageScanBacklog = "securebuild.external_image.scan.backlog"
+	MetricExternalImageScansRunning = "securebuild.external_image.scan.running"
+
 	TagChannelExternalImageSBOM = "channel:external_image_sbom"
 	TagChannelExternalImageScan = "channel:external_image_scan"
+
+	TagScanTier = "tier"
 )
 
 // --- Tracing (dd-trace-go) ---

--- a/pkg/util/clock.go
+++ b/pkg/util/clock.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"context"
+	"time"
+)
+
+// NowFunc returns the current time. Production code uses the default (time.Now);
+// tests can inject a fixed clock via WithNowFunc for deterministic time comparisons.
+type NowFunc func() time.Time
+
+type nowFuncKey struct{}
+
+// WithNowFunc returns a context carrying a custom now function. Used in tests
+// to provide a deterministic reference time.
+func WithNowFunc(ctx context.Context, fn NowFunc) context.Context {
+	return context.WithValue(ctx, nowFuncKey{}, fn)
+}
+
+// GetNowFunc returns the now function from the context if injected,
+// otherwise falls back to time.Now.
+func GetNowFunc(ctx context.Context) NowFunc {
+	if fn, ok := ctx.Value(nowFuncKey{}).(NowFunc); ok {
+		return fn
+	}
+	return time.Now
+}

--- a/securebuild-api/app/api/v1/external-image/route.ts
+++ b/securebuild-api/app/api/v1/external-image/route.ts
@@ -3,7 +3,7 @@ import { getImageDigest, parseImageRef } from '@/lib/externalimage/registry'
 import { enqueueWork, hasExistingSBOM } from '@/lib/utils/queue'
 import { NextRequest, NextResponse } from 'next/server'
 import { findServiceAccountWithValue } from '@/lib/team/service-account'
-import { getExternalImageDigestForTag, getExternalImageLastScannedAt, getExternalImagePlatforms, getExternalImageScan, getSBOMStatus, teamOwnsDigest } from '@/lib/externalimage/externalimage'
+import { getExternalImageDigestForTag, getExternalImageLastScannedAt, getExternalImagePlatforms, getExternalImageScan, getSBOMStatus, teamOwnsDigest, EnqueueScanForDigest } from '@/lib/externalimage/externalimage'
 
 export async function POST(request: NextRequest) {
   try {
@@ -162,6 +162,17 @@ export async function GET(request: NextRequest) {
     ])
     const sbomStatus = sbomStatusResult ?? null
 
+    // On-demand scan trigger: if the scan is stale (>4h or missing) and not
+    // already queued/running, enqueue a scan via the external_image_scan channel.
+    // Non-fatal: if this fails, we still return whatever scan data we have.
+    let scanStartedAt: Date | null = null
+    try {
+      const enqueueResult = await EnqueueScanForDigest(currentDigest)
+      scanStartedAt = enqueueResult.scanStartedAt
+    } catch (err) {
+      console.warn(`EnqueueScanForDigest failed for digest ${currentDigest}:`, err)
+    }
+
     // Build scan statuses array from individual architecture results
     const scanStatuses = []
     if (amd64Scan) {
@@ -214,6 +225,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({
       digest: currentDigest,
       last_scanned_at: lastScannedAt,
+      scan_started_at: scanStartedAt,
       platforms: platforms,
       scan_status: scanStatus,
       scan_status_message: scanStatusMessage,

--- a/securebuild-api/app/api/v1/external-image/scan/route.ts
+++ b/securebuild-api/app/api/v1/external-image/scan/route.ts
@@ -1,4 +1,4 @@
-import { getBatchDigestsForTags, getBatchExternalImageScans, type ImageRefTag, getExternalImageDigestForTag, getExternalImageScan, teamOwnsDigest, BatchScanResult } from "@/lib/externalimage/externalimage"
+import { getBatchDigestsForTags, getBatchExternalImageScans, type ImageRefTag, getExternalImageDigestForTag, getExternalImageScan, teamOwnsDigest, BatchScanResult, EnqueueScanForDigest } from "@/lib/externalimage/externalimage"
 import { parseImageRef } from "@/lib/externalimage/registry"
 import { NextRequest, NextResponse } from "next/server"
 import { findServiceAccountWithValue } from "@/lib/team/service-account"
@@ -91,6 +91,17 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({ error: 'Scan results not found' }, { status: 404 })
       }
 
+      // On-demand scan trigger: if the scan is stale (>4h or missing) and not
+      // already queued/running, enqueue a scan via the external_image_scan channel.
+      // Non-fatal: if this fails, we still return whatever scan data we have.
+      let scanStartedAt: Date | null = null
+      try {
+        const enqueueResult = await EnqueueScanForDigest(digest)
+        scanStartedAt = enqueueResult.scanStartedAt
+      } catch (err) {
+        console.warn(`EnqueueScanForDigest failed for digest ${digest}:`, err)
+      }
+
       // Get scan results using the unified function (returns a row even for queued/running when scan_result is NULL)
       const scanData = await getExternalImageScan(digest, dbArch, format as 'raw' | 'parsed')
       if (!scanData) {
@@ -103,6 +114,7 @@ export async function GET(request: NextRequest) {
         image_size_bytes: scanData.imageSizeBytes,
         digest_first_seen_at: scanData.digestFirstSeenAt,
         last_scanned_at: scanData.scanCompletedAt,
+        scan_started_at: scanStartedAt,
         updated_at: scanData.updatedAt,
         scan_status: scanData.status,
         scan_status_message: scanData.scanStatusMessage,

--- a/securebuild-api/integration/api/v1/external-image/on-demand-scan.test.ts
+++ b/securebuild-api/integration/api/v1/external-image/on-demand-scan.test.ts
@@ -1,0 +1,191 @@
+import * as path from 'path';
+import { Client } from 'pg';
+import { setupTestEnvironment, TestEnvironment } from '../../../fixtures/environment';
+
+/**
+ * Integration tests for the on-demand scan trigger (Part 3).
+ *
+ * When a client requests scan results via GET /scan or GET /external-image and
+ * the image's last scan is older than 4 hours (stale) and not currently
+ * queued/running, the API enqueues an external_image_scan work queue message
+ * and returns scan_started_at.
+ *
+ * Stale image:    API request enqueues work + returns scan_started_at.
+ * Non-stale image: API request does NOT enqueue work, returns existing results.
+ *
+ * Uses a pg Client listening on the external_image_scan channel to validate
+ * that the correct payload is received (or not received) without querying
+ * the work_queue table directly.
+ *
+ * Runs against a local Testcontainers stack using real HTTP requests.
+ */
+describe('On-demand scan trigger', () => {
+  let env: TestEnvironment;
+  let listenClient: Client;
+
+  beforeAll(async () => {
+    const seedDataDir = path.join(__dirname, 'seed-data');
+    env = await setupTestEnvironment(seedDataDir);
+
+    // Connect a dedicated pg client and start listening on the scan channel.
+    // This captures NOTIFY messages sent by EnqueueScanForDigest.
+    // The client stays connected for the lifetime of the test suite.
+    listenClient = new Client({ connectionString: env.connectionString });
+    await listenClient.connect();
+    await listenClient.query('LISTEN external_image_scan');
+  });
+
+  afterAll(async () => {
+    if (listenClient) {
+      try { await listenClient.query('UNLISTEN external_image_scan'); } catch {}
+      try { await listenClient.end(); } catch {}
+    }
+    await env.teardown();
+  });
+
+  /**
+   * Helper: listen for the next external_image_scan notification and resolve
+   * with the payload from the work_queue row, or null if none arrives within
+   * the timeout. Must be called before the action that triggers the notify.
+   */
+  async function waitForScanNotification(
+    timeoutMs: number,
+  ): Promise<{ digest: string } | null> {
+    return new Promise((resolve) => {
+      let settled = false;
+
+      const cleanup = () => {
+        listenClient.off('notification', onNotification);
+      };
+
+      const onNotification = async (msg: { channel: string; payload: string }) => {
+        if (msg.channel !== 'external_image_scan' || settled) return;
+        settled = true;
+        cleanup();
+
+        // The notification payload is the work_queue row ID.
+        // Fetch the actual payload (with digest) from the work_queue table.
+        try {
+          const result = await env.dbPool.query(
+            `SELECT payload FROM work_queue WHERE id = $1`,
+            [msg.payload]
+          );
+          if (result.rows.length > 0) {
+            const row = result.rows[0];
+            const payload = typeof row.payload === 'string' ? JSON.parse(row.payload) : row.payload;
+            resolve({ digest: payload.digest });
+          } else {
+            resolve(null);
+          }
+        } catch {
+          resolve(null);
+        }
+      };
+
+      listenClient.on('notification', onNotification);
+
+      const timer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          cleanup();
+          resolve(null);
+        }
+      }, timeoutMs);
+      timer.unref();
+    });
+  }
+
+  /**
+   * Start listening for a scan notification, then call the action.
+   * This ensures the listener is registered before the notify is sent.
+   */
+  async function expectScanNotification(
+    digest: string,
+    action: () => Promise<void>,
+  ) {
+    const notificationPromise = waitForScanNotification(5000);
+    await action();
+    const notification = await notificationPromise;
+    expect(notification).not.toBeNull();
+    expect(notification!.digest).toBe(digest);
+  }
+
+  /**
+   * Start listening, call the action, and verify no notification arrives.
+   */
+  async function expectNoScanNotification(
+    action: () => Promise<void>,
+  ) {
+    const notificationPromise = waitForScanNotification(3000);
+    await action();
+    const notification = await notificationPromise;
+    expect(notification).toBeNull();
+  }
+
+  describe('Stale image (scan >4h old)', () => {
+    const digest = () => env.existingDigest;
+
+    it('GET /scan enqueues work queue message with correct digest payload', async () => {
+      // The seeded scan for this digest has scan_completed_at = 2024-01-01
+      // which is >4h ago, so EnqueueScanForDigest should trigger.
+      await expectScanNotification(digest(), async () => {
+        const res = await env.client.get(
+          `/api/v1/external-image/scan?digest=${encodeURIComponent(digest())}&arch=amd64&format=parsed`,
+        );
+        expect(res.status).toBe(200);
+
+        const data = res.data as Record<string, unknown>;
+        expect(data.scan_started_at).toBeDefined();
+        expect(data.scan_started_at).not.toBeNull();
+      });
+    });
+
+    it('GET /external-image returns scan_started_at', async () => {
+      // Note: the first test already enqueued a scan for this digest,
+      // so the scan status is now 'queued'. EnqueueScanForDigest will
+      // detect the in-progress scan and return the existing scan_attempted_at
+      // without enqueuing a new notification.
+      const res = await env.client.get(
+        `/api/v1/external-image?sha=${encodeURIComponent(digest())}`,
+      );
+      expect(res.status).toBe(200);
+
+      const data = res.data as Record<string, unknown>;
+      expect(data.scan_started_at).toBeDefined();
+      expect(data.scan_started_at).not.toBeNull();
+    });
+  });
+
+  describe('Non-stale image (scan within 4h)', () => {
+    const digest = () => env.existingDigest;
+
+    beforeAll(async () => {
+      // Update the scan row to have scan_completed_at within the last 4 hours
+      // so the next request should NOT trigger a new scan.
+      await env.dbPool.query(
+        `UPDATE external_image_scan
+         SET scan_completed_at = NOW(), status = 'succeeded'
+         WHERE digest = $1`,
+        [digest()]
+      );
+      // Also update last_security_scanned_at on the SBOM so the idempotency
+      // check in the Go listener would pass (not directly tested here, but
+      // keeps the data consistent).
+      await env.dbPool.query(
+        `UPDATE external_image_sbom
+         SET last_security_scanned_at = NOW()
+         WHERE digest = $1`,
+        [digest()]
+      );
+    });
+
+    it('GET /scan does NOT enqueue a new work queue message', async () => {
+      await expectNoScanNotification(async () => {
+        const res = await env.client.get(
+          `/api/v1/external-image/scan?digest=${encodeURIComponent(digest())}&arch=amd64&format=parsed`,
+        );
+        expect(res.status).toBe(200);
+      });
+    });
+  });
+});

--- a/securebuild-api/integration/fixtures/environment.ts
+++ b/securebuild-api/integration/fixtures/environment.ts
@@ -12,6 +12,7 @@ import { createTestServiceAccount } from './auth';
 import { setupTestRegistry, teardownTestRegistry, TestRegistry } from './registry';
 import { startTestServer, TestServer } from './server';
 import { HttpClient } from './http-client';
+import { Pool } from 'pg';
 
 // Seeded "existing" image used for read endpoint validation.
 export const SEEDED_EXISTING_IMAGE = 'test-registry.example.com/test-org/test-image:latest';
@@ -29,6 +30,8 @@ export interface TestEnvironment {
   createImage: string;
   existingImage: string;
   existingDigest: string;
+  dbPool: Pool;
+  connectionString: string;
   teardown: () => Promise<void>;
 }
 
@@ -67,6 +70,8 @@ export async function setupTestEnvironment(seedDataDir: string): Promise<TestEnv
     createImage: registry.imageUrl,
     existingImage: SEEDED_EXISTING_IMAGE,
     existingDigest: SEEDED_EXISTING_DIGEST,
+    dbPool: testDB.pool,
+    connectionString: testDB.connectionString,
     teardown,
   };
 }

--- a/securebuild-api/lib/externalimage/externalimage.ts
+++ b/securebuild-api/lib/externalimage/externalimage.ts
@@ -1202,16 +1202,26 @@ export interface EnqueueScanResult {
 export async function EnqueueScanForDigest(digest: string): Promise<EnqueueScanResult> {
   const db = getDB(await getParam("DB_URI"))
 
-  // Step 1 (pre-transaction): Ensure scan rows exist for both architectures.
-  // New rows get status='unknown' (no scan ever attempted).
+  // Step 1 (pre-transaction): Ensure scan rows exist for architectures that
+  // have SBOMs. New rows get status='unknown' (no scan ever attempted).
   // ON CONFLICT DO NOTHING leaves existing rows untouched.
-  const archs = ['x86_64', 'aarch64']
-  for (const arch of archs) {
+  // Only arches with SBOMs are queued — an arch without an SBOM would leave
+  // a queued scan that can never be completed. Images may have one or both
+  // architectures.
+  const archResult = await db.query(
+    `SELECT DISTINCT arch FROM external_image_sbom WHERE digest = $1`,
+    [digest]
+  )
+  if (archResult.rows.length === 0) {
+    throw new Error(`no SBOMs found for digest ${digest}`)
+  }
+
+  for (const row of archResult.rows) {
     await db.query(
       `INSERT INTO external_image_scan (digest, arch, created_at, status, updated_at, scan_status_updated_at)
        VALUES ($1, $2, $3, 'unknown', $3, $3)
        ON CONFLICT (digest, arch) DO NOTHING`,
-      [digest, arch, new Date()]
+      [digest, row.arch, new Date()]
     )
   }
 

--- a/securebuild-api/lib/externalimage/externalimage.ts
+++ b/securebuild-api/lib/externalimage/externalimage.ts
@@ -3,6 +3,7 @@ import { getDB, withTransaction } from '../data/db';
 import { getParam } from '../data/param';
 import { traceFunction } from '../observability/tracing';
 import { parseUTCTimestamp } from '../utils/timestamp';
+import { enqueueWork } from '../utils/queue';
 
 
 export async function upsertExternalImage(registry: string, imageName: string, imageTag: string, digest: string, username: string | null, password: string | null, teamId: string): Promise<TrackedExternalImage> {
@@ -641,7 +642,7 @@ export type SBOMStatus = 'pending' | 'generating' | 'succeeded' | 'failed'
  * 3. succeeded: Scan completed successfully with results
  * 4. failed: Scan failed with error (see scanStatusMessage for details)
  */
-export type ScanStatus = 'queued' | 'running' | 'succeeded' | 'failed'
+export type ScanStatus = 'unknown' | 'queued' | 'running' | 'succeeded' | 'failed'
 
 export interface ScanStatusEntry {
   digest: string
@@ -1171,3 +1172,106 @@ export const getBatchDigestsForTags = traceFunction('lib.externalimage.getBatchD
       'args.image_tags.length': imageTags.length,
     })
   })
+
+export interface EnqueueScanResult {
+  scanStartedAt: Date | null
+  enqueued: boolean
+}
+
+/**
+ * EnqueueScanForDigest triggers an on-demand scan for a digest if the existing
+ * scan results are stale (older than 4 hours) or missing. Uses a transaction
+ * with row locking (SELECT ... FOR UPDATE) on external_image_sbom and
+ * external_image_scan to ensure atomicity and prevent duplicate enqueues.
+ *
+ * Steps (all inside one transaction):
+ *  1. LEFT JOIN external_image_sbom to external_image_scan with FOR UPDATE
+ *     — locks SBOM rows (must exist for a scan) and scan rows if they exist.
+ *  2. Staleness check: if any arch is queued/running, or all arches were
+ *     scanned within 4 hours, skip enqueue and return existing scan_attempted_at.
+ *  3. If stale/missing: insert into work_queue + pg_notify, then upsert
+ *     external_image_scan rows to 'queued' with a WHERE guard preventing
+ *     overwriting rows already in 'queued' or 'running' status.
+ *  4. Commit and return scan_attempted_at.
+ *
+ * @param digest - The image digest to scan
+ * @returns { scanStartedAt, enqueued } — scanStartedAt is the scan_attempted_at
+ *          timestamp (set to now() when enqueued, or existing value when not).
+ *          enqueued is true if a new scan was triggered.
+ */
+export async function EnqueueScanForDigest(digest: string): Promise<EnqueueScanResult> {
+  const db = getDB(await getParam("DB_URI"))
+
+  // Step 1 (pre-transaction): Ensure scan rows exist for both architectures.
+  // New rows get status='unknown' (no scan ever attempted).
+  // ON CONFLICT DO NOTHING leaves existing rows untouched.
+  const archs = ['x86_64', 'aarch64']
+  for (const arch of archs) {
+    await db.query(
+      `INSERT INTO external_image_scan (digest, arch, created_at, status, updated_at, scan_status_updated_at)
+       VALUES ($1, $2, $3, 'unknown', $3, $3)
+       ON CONFLICT (digest, arch) DO NOTHING`,
+      [digest, arch, new Date()]
+    )
+  }
+
+  // Step 2 (transaction): Lock scan rows, check staleness, enqueue if needed.
+  return withTransaction(db, async (client) => {
+    const lockQuery = `
+      SELECT digest, arch, status, scan_completed_at, scan_attempted_at
+      FROM external_image_scan
+      WHERE digest = $1
+      FOR UPDATE
+    `
+    const lockResult = await client.query(lockQuery, [digest])
+
+    // Step 3: Staleness check
+    let hasInProgress = false
+    let allRecent = true
+    let existingScanAttemptedAt: Date | null = null
+    const fourHoursAgo = new Date(Date.now() - 4 * 60 * 60 * 1000)
+
+    for (const row of lockResult.rows) {
+      const status = row.status
+      const scanCompletedAt = row.scan_completed_at
+
+      if (status === 'queued' || status === 'running') {
+        hasInProgress = true
+      }
+
+      if (status === 'unknown' || !scanCompletedAt || new Date(scanCompletedAt) < fourHoursAgo) {
+        allRecent = false
+      }
+
+      if (row.scan_attempted_at) {
+        const attemptedAt = new Date(row.scan_attempted_at)
+        if (!existingScanAttemptedAt || attemptedAt < existingScanAttemptedAt) {
+          existingScanAttemptedAt = attemptedAt
+        }
+      }
+    }
+
+    if (hasInProgress || (allRecent && lockResult.rows.length > 0)) {
+      return { scanStartedAt: existingScanAttemptedAt, enqueued: false }
+    }
+
+    // Step 4: Enqueue work + update scan rows to 'queued'
+    const now = new Date()
+
+    await enqueueWork('external_image_scan', { digest }, client)
+
+    for (const row of lockResult.rows) {
+      await client.query(
+        `UPDATE external_image_scan
+         SET status = 'queued',
+             updated_at = $3,
+             scan_attempted_at = $3,
+             scan_status_updated_at = $3
+         WHERE digest = $1 AND arch = $2 AND status NOT IN ('queued', 'running')`,
+        [digest, row.arch, now]
+      )
+    }
+
+    return { scanStartedAt: now, enqueued: true }
+  })
+}

--- a/securebuild-api/lib/utils/queue.ts
+++ b/securebuild-api/lib/utils/queue.ts
@@ -1,6 +1,7 @@
 import { getDB } from "../data/db";
 import { getParam } from "../data/param";
 import * as srs from "secure-random-string";
+import { PoolClient } from "pg";
 
 interface QueuePayload {
   [key: string]: string | number | boolean | null | undefined | any;
@@ -11,23 +12,23 @@ interface QueuePayload {
 export const PRIORITY_NORMAL = 0
 export const PRIORITY_HIGH = 1
 
-export async function enqueueWork(channel: string, payload: QueuePayload): Promise<string> {
-  return enqueueWorkWithPriority(channel, payload, PRIORITY_NORMAL)
+export async function enqueueWork(channel: string, payload: QueuePayload, client?: PoolClient): Promise<string> {
+  return enqueueWorkWithPriority(channel, payload, PRIORITY_NORMAL, client)
 }
 
-export async function enqueueWorkWithPriority(channel: string, payload: QueuePayload, priority: number): Promise<string> {
-  const client = getDB(await getParam("DB_URI"));
+export async function enqueueWorkWithPriority(channel: string, payload: QueuePayload, priority: number, client?: PoolClient): Promise<string> {
+  const db = client ?? getDB(await getParam("DB_URI"));
 
   const id = srs.default({ length: 12, alphanumeric: true });
   const now = new Date();
 
-  await client.query(
+  await db.query(
     `INSERT INTO work_queue (id, channel, payload, created_at, priority) ` +
     `VALUES ($1, $2, $3, $4, $5)`,
     [id, channel, payload, now, priority]
   );
 
-  await client.query(`SELECT pg_notify('${channel}', $1)`, [id]);
+  await db.query(`SELECT pg_notify('${channel}', $1)`, [id]);
 
   return id;
 }


### PR DESCRIPTION
# Proposal: Scan Back-off and On-Demand Scanning

## Problem

The scheduler's second priority query (`pkg/scan/scan.go:259-266`) rescans **every** digest whose `last_security_scanned_at` is older than 4 hours, regardless of whether anyone still cares about that image. As the image list grows perpetually, the rescan workload grows unboundedly. Current backlog: ~10K-25K images/day, 2 weeks behind. The scheduler processes 25 digests per cycle in a tight loop, but can't keep up with the ever-growing rescan demand.

Additionally, both priority queries scan oldest images first (`ORDER BY ... ASC`). When capacity is saturated, this means the backlog of stale images is always processed before newer, more relevant images. A newly submitted image can wait weeks behind the backlog before getting its first scan, which is the wrong priority ordering when we can't scan everything.

This proposal focuses on bounding the set of images the scheduler needs to scan, so that the workload is well-defined and finite regardless of how large the image list grows. Increasing raw scan throughput (e.g. more workers, parallelism, or infrastructure scaling) is a separate concern that should be addressed independently.

## Part 1: `last_submitted_at` on `external_image_tag`

**Why `external_image_tag`:** Submission is tag-scoped (clients submit `registry/repo:tag`). The tag row already gets `digest` and `next_check_digest_at` updated on re-submission (`securebuild-api/lib/externalimage/externalimage.ts:18`), but `created_at` is never touched. We need `last_submitted_at` to know when a tag was last actively submitted.

**Changes:**
- Add `last_submitted_at` column (timestamp with time zone) to `external_image_tag`
- Update the `ON CONFLICT DO UPDATE` clause in `upsertExternalImage` (`externalimage.ts:18`) to set `last_submitted_at = EXCLUDED.last_submitted_at` (or `now()`)
- Set `last_submitted_at = created_at` on initial insert
- The digest-change monitor (`pkg/externalimage/monitor.go`) should also update `last_submitted_at` when it re-adds an image due to a digest change, since that indicates active tracking
- Drop the `next_scan_at` column — it is written on every upsert and monitor update but never read by any query. It is a dead column.

**Backfill:** New `last_submitted_at` column will be NULL for existing rows. Set `last_submitted_at = created_at` for all existing rows (best approximation of last submission time). This can be done as part of the migration: `UPDATE external_image_tag SET last_submitted_at = created_at WHERE last_submitted_at IS NULL`.

**Note on digest-level relevance:** A digest can have multiple tags. To determine "when was this digest last submitted," we'd take `MAX(last_submitted_at)` across all tags pointing to that digest via the `digest` column on `external_image_tag`.

## Part 2: Scan Back-off Tiers

Modify `selectExternalImageDigestsToScan` (`pkg/scan/scan.go:221-287`) to use separate queries per tier, following the existing pattern of querying priority 1 (never scanned) then priority 2 (rescans) with a `remaining` counter. The current two-query structure expands to five queries, each with `ORDER BY random()` and `LIMIT remaining`:

| Query | Tier | Condition | Rescan interval |
|---|---|---|---|
| 1 (existing) | Never scanned | `last_security_scanned_at IS NULL` | n/a (first scan) |
| 2 | Active | `last_submitted < 7 days` | 4 hours |
| 3 | Recent | `last_submitted 7-30 days` | 24 hours |
| 4 | Stale | `last_submitted 30-90 days` | 7 days |
| 5 | Excluded | `last_submitted > 90 days` | not scanned by scheduler |

After each query, evaluate `remaining`. If `remaining > 0`, proceed to the next tier query. If `remaining == 0`, stop — the cycle is full. This ensures higher-priority tiers are always filled before lower-priority tiers contribute, and each tier is randomly ordered within itself.

Images submitted >90 days ago are excluded from the scheduler entirely (on-demand only, see Part 3). This dramatically reduces the working set so the backlog is bounded regardless of how large the image list grows.

Each tier query joins `external_image_sbom` to `external_image_tag` (via `digest`), filters on the tier's `last_submitted_at` bounds and `last_security_scanned_at` threshold. Example for tier 2 (active, < 7 days):

```sql
WITH tier_tags AS (
    SELECT digest
    FROM external_image_tag
    WHERE last_submitted_at > now() - interval '7 days'
    GROUP BY digest
)
SELECT s.digest
FROM external_image_sbom s
JOIN tier_tags t ON t.digest = s.digest
WHERE s.last_security_scanned_at IS NOT NULL
  AND s.last_security_scanned_at < now() - interval '4 hours'
GROUP BY s.digest
ORDER BY random()
LIMIT $1
```

The `last_submitted_at` filter is pushed into the CTE so only tags in the current tier are scanned, not the entire table. Tiers 3 and 4 follow the same shape with adjusted `last_submitted_at` bounds (in the CTE) and `last_security_scanned_at` intervals (in the outer query). A `seen` map (already used in the existing code) prevents duplicate digests across tiers.

**Index:** Add an index on `external_image_tag(last_submitted_at)` to support the tier-filtered CTE queries efficiently.

**Random ordering within tiers:** Currently both priority queries use `ORDER BY ... ASC` (oldest first), which means old images are always scanned before newer ones. This causes newer images to wait behind a large backlog of stale images. Changing to `ORDER BY random()` ensures fair distribution — no single image is starved or perpetually prioritized. This applies to all tier queries. The existing `GetRandomizedScanInterval()` in `pkg/scan/scheduler.go:31` already uses randomization for catalog image scans, so this is consistent with existing patterns.

(Tiers and intervals are starting points — should be tuned based on actual backlog numbers and scan throughput.)

## Part 3: On-Demand Scan Trigger

**Mechanism: Re-enable the `external_image_scan` channel.** The handler at `pkg/listener/start.go:276` is currently a no-op. We'd implement it to call `RunScanForDigest` (which already exists at `external-image-sbom.go:291`). The API enqueues via `enqueueWork('external_image_scan', { digest })` — same pattern used for SBOM generation.

When a client requests scan results via GET `/api/v1/external-image/scan` or GET `/api/v1/external-image` and the image's last scan is older than 4 hours (i.e., outside the active `< 7 days` tier) and not currently `queued`/`running`:

**What happens:**

1. **Pre-transaction insert (ensure scan rows exist):** Before opening a transaction, the API inserts `external_image_scan` rows for both supported architectures (`x86_64`, `aarch64`) with `status = 'unknown'` and `ON CONFLICT (digest, arch) DO NOTHING`:

   ```sql
   INSERT INTO external_image_scan (digest, arch, created_at, status, updated_at, scan_status_updated_at)
   VALUES ($1, $2, $3, 'unknown', $3, $3)
   ON CONFLICT (digest, arch) DO NOTHING
   ```

   This guarantees scan rows exist before the transaction begins. The `unknown` status (a new status value) means "scan row created but no scan ever attempted." Existing rows are left untouched.

2. **Transaction with row locking on scan rows:** The API opens a DB transaction and locks all `external_image_scan` rows for the digest with a plain `SELECT ... FOR UPDATE`:

   ```sql
   SELECT digest, arch, status, scan_completed_at, scan_attempted_at
   FROM external_image_scan
   WHERE digest = $1
   FOR UPDATE
   ```

   Since the pre-transaction insert guaranteed rows exist, this is a simple single-table lock — no JOIN needed. Concurrent API calls for the same digest block on this lock. All tables are indexed on `(digest, arch)`, so both the insert and the lock query hit the primary key index.

3. **Staleness check (inside transaction):** From the locked query results:
   - If any arch has `status` = `queued` or `running`, the scan is already in progress — skip to step 6 (no enqueue).
   - If all arches have `scan_completed_at` within the last 4 hours, the scan is recent enough — skip to step 6 (no enqueue).
   - If any scan row has `status` = `unknown` (no scan ever attempted) or `scan_completed_at` is stale (older than 4 hours), proceed to step 4.

4. **Enqueue and set `queued` status (inside transaction):** While still holding the lock, the API:
   - Enqueues `enqueueWork('external_image_scan', { digest })` (insert into `work_queue` + `pg_notify`).
   - Updates `external_image_scan` rows: `UPDATE ... SET status = 'queued', scan_attempted_at = now(), scan_status_updated_at = now() WHERE digest = $1 AND arch = $2 AND status NOT IN ('queued', 'running')`. The `WHERE` guard prevents overwriting a row that a worker already moved to `running`.
   - Both operations are in the same transaction, so they commit atomically — either the work queue message and the `queued` status both persist, or neither does. This eliminates the stuck-in-queued failure case without the ordering trade-off.

5. **Duplicate message handling (idempotency):** Despite the lock, a duplicate `external_image_scan` message could still arrive if a work queue retry re-delivers a message or if the `work_queue` insert commits but `pg_notify` is lost. The listener handler checks `scan_completed_at` (or `last_security_scanned_at`) before starting the scan. If the last scan completed less than 4 hours ago, the handler discards the message without scanning.

6. **Return response:** The API returns the **existing scan results** (stale, if any) along with `scan_started_at` (set to the `scan_attempted_at` value from `external_image_scan`). The client compares `scan_started_at` to `last_scanned_at` (`scan_completed_at`) — if `scan_started_at` is greater, a fresh scan is in progress. The client can poll again to get fresh results once the scan completes.

**`scan_started_at` definition:** `scan_started_at` is the `scan_attempted_at` column from `external_image_scan`. It is set to `now()` in step 4 inside the transaction. When the listener later calls `SetScanStatusRunning`, `scan_attempted_at` is updated again to the actual scan start time (existing behavior at `externalimage.go:149`), but the initial `queued` timestamp is what the client sees first.

**New `unknown` scan status:** A new `unknown` status is added to `external_image_scan.status`. It represents a scan row that has been created (by the pre-transaction insert) but has never had a scan attempted. The staleness check treats `unknown` as "needs scan" (same as missing or stale). The existing `InitializeScanStatusQueued` function (`pkg/externalimage/externalimage.go`) is updated to also upgrade `unknown` rows to `queued` (in addition to the existing `pending_sbom` and `generating_sbom` statuses).

**New DB function:** Add `EnqueueScanForDigest(digest) (scanStartedAt time.Time, err error)` that:
- **Pre-transaction:** Inserts `external_image_scan` rows for both architectures (`x86_64`, `aarch64`) with `status = 'unknown'` and `ON CONFLICT DO NOTHING`.
- **Transaction:** Runs `SELECT ... FOR UPDATE` on `external_image_scan` rows for the digest (single-table lock, no JOIN). Evaluates staleness from the locked rows (step 3). If not stale, returns the existing `scan_attempted_at` without enqueueing.
- If stale: inserts into `work_queue` + `pg_notify('external_image_scan', id)`, then updates `external_image_scan` rows to `status = 'queued'` with `WHERE status NOT IN ('queued', 'running')` guard, setting `scan_attempted_at = now()`, `scan_status_updated_at = now()`.
- Commits the transaction and returns the `scan_attempted_at` timestamp.
- Implemented in the API (TypeScript) layer in `securebuild-api/lib/externalimage/externalimage.ts`, following the existing pattern in `upsertExternalImage` (`externalimage.ts:12`).

**Listener handler:** The `external_image_scan` channel listener at `pkg/listener/start.go:276` (`StartExternalImageScanListener`) is currently a no-op — the handler body just returns nil. It needs to be implemented to:
- Parse the digest from the work queue payload.
- Check idempotency: query `scan_completed_at` (or `last_security_scanned_at`) for the digest. If the last scan completed less than 4 hours ago, discard the message without scanning (handles duplicate messages from work queue retries or `pg_notify` loss).
- If the scan is still needed, call `RunScanForDigest` (`pkg/listener/external-image-sbom.go:291`), which already handles marking arches `running`, scanning, storing results, and recording failures.

The listener is already registered at startup (`cmd/cli/run.go` via `StartListeners`), so no new registration is needed — only the handler implementation changes from no-op to active.

**Capacity note:** On-demand scans triggered via the `external_image_scan` channel run through the listener's work queue, which is separate from the scheduler's `MaxImagesPerCycle` limit (25 digests per cycle, `pkg/scan/scheduler.go:26`). In the initial iteration, on-demand scans are allowed to use workers beyond this limit — i.e., the scheduler cap only governs background rescans, not client-triggered scans. This means a burst of on-demand requests can temporarily increase scan concurrency. If this becomes a problem, rate limiting or a shared concurrency cap can be added later.

**Locking discipline for `InitializeScanStatusQueued`:** The existing `InitializeScanStatusQueued` (`pkg/externalimage/externalimage.go`) creates `external_image_scan` rows after SBOM generation. Since the on-demand trigger now uses a pre-transaction insert with `ON CONFLICT DO NOTHING` followed by a `SELECT ... FOR UPDATE` on `external_image_scan` (no SBOM lock needed), `InitializeScanStatusQueued` does not need to lock `external_image_sbom`. The `ON CONFLICT DO NOTHING` insert and the `WHERE status IN ('unknown', 'pending_sbom', 'generating_sbom')` guard on `InitializeScanStatusQueued`'s conflict update ensure the two paths don't clobber each other: whichever creates the row first wins, and the other either does nothing (on-demand's `DO NOTHING`) or only upgrades from a pre-scan status (`InitializeScanStatusQueued`'s `WHERE` guard).

## Summary of Changes

| Area | File(s) | Change |
|---|---|---|
| Schema | `db/schema/tables/external-image-tag.yaml` | Add `last_submitted_at` column + index; drop `next_scan_at` column |
| API submission | `securebuild-api/lib/externalimage/externalimage.ts:18` | Set `last_submitted_at` in ON CONFLICT; remove `next_scan_at` references |
| Monitor | `pkg/externalimage/externalimage.go` + `pkg/externalimage/monitor.go` | Update `last_submitted_at` on digest change; remove `next_scan_at` references |
| Scheduler query | `pkg/scan/scan.go:221-287` | Tiered back-off using `last_security_scanned_at` thresholds with per-tier `last_submitted_at` bounds |
| On-demand trigger | `securebuild-api/app/api/v1/external-image/scan/route.ts` + `route.ts` (GET) | Staleness check + `EnqueueScanForDigest` (pre-transaction insert + `SELECT ... FOR UPDATE` + enqueue + set `queued`) + return `scan_started_at` |
| New DB function | `securebuild-api/lib/externalimage/externalimage.ts` | `EnqueueScanForDigest` — pre-transaction insert (`unknown` status, `ON CONFLICT DO NOTHING`) + transaction with `SELECT ... FOR UPDATE` on `external_image_scan` + enqueue + update `queued` status |
| Scan status | `pkg/externalimage/externalimage.go` | Add `unknown` scan status; `InitializeScanStatusQueued` upgrades `unknown` → `queued` (no SBOM lock needed) |
| Scan channel | `pkg/listener/start.go:276` | Implement no-op `StartExternalImageScanListener` handler: idempotency check + `RunScanForDigest` |
| Backfill | Migration | `UPDATE external_image_tag SET last_submitted_at = created_at WHERE last_submitted_at IS NULL` |
| Integration tests | `integration/worker/external_image/` + `securebuild-api/integration/api/v1/external-image/` | Test tier-based scheduling, on-demand trigger (stale/non-stale/concurrent), idempotency, and lock isolation |

The tier thresholds (7d/30d/90d and 4h/24h/7d) should be validated against actual data.

## Testing

Integration tests are needed for the following scenarios, split across two test layers:

**API tests** (`securebuild-api/integration/api/v1/external-image/`) — verify that the API correctly enqueues events, without processing them:
- **On-demand trigger — stale image:** API request for an image whose scan is older than 4 hours sets `queued` status, returns `scan_started_at`, and verifies the `external_image_scan` work queue message is inserted (query `work_queue` table).
- **On-demand trigger — non-stale image:** API request for an image scanned within 4 hours does not insert a work queue message and returns existing results.

**Handler tests** (`integration/worker/external_image/`) — process mocked events, without going through the API:
- **Idempotency:** A mocked `external_image_scan` event arriving after a scan already completed within 4 hours is discarded by the listener without re-scanning.
- **Listener handler via existing scan tests:** The existing tests in `integration/worker/external_image/external_image_test.go` already call `RunScanForDigest` directly with a mock scanner (via `WithMockScanExternalImage` / `setupMocks`). Since the new `external_image_scan` listener handler is a thin wrapper around `RunScanForDigest` (plus the idempotency check), these existing tests should be refactored to invoke the handler instead of calling `RunScanForDigest` directly. This avoids duplicating scan test coverage while ensuring the handler's idempotency guard is exercised. New test cases should be added only for the idempotency discard path (scan completed < 4 hours ago).
- **Tier-based scheduling:** Verify that `selectExternalImageDigestsToScan` selects digests from the correct tier based on `last_submitted_at`, respects `remaining` limits between tiers, and that images >90 days old are excluded from the scheduler.

Existing integration tests are in `integration/worker/external_image/` (worker-side) and `securebuild-api/integration/api/v1/external-image/` (API-side). New tests should follow the patterns and seed data conventions in those directories.
