### PR TITLE
Use builders for image scanning

### DIFF
--- a/cmd/cli/run.go
+++ b/cmd/cli/run.go
@@ -136,6 +136,24 @@ func runWorker(ctx context.Context) error {
 		}
 	}
 
+	// Initialize scan capacity cache from builder filesystems (synchronous —
+	// must complete before listeners start so the external_image_scan handler
+	// has a populated cache for builder selection).
+	scanCache, err := scan.InitScanCapacityCache(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to initialize scan capacity cache: %w", err)
+	}
+
+	// Add scan cache to context for the external_image_scan handler
+	ctx = listener.WithScanCapacityCache(ctx, scanCache)
+
+	// Start scan status poller (collects results from builders every 10s)
+	go func() {
+		if err := listener.StartExternalImageScanStatusChecker(ctx, scanCache); err != nil {
+			logger.Error(fmt.Errorf("failed to start external image scan status checker: %w", err))
+		}
+	}()
+
 	go func() {
 		if err := listener.StartListeners(ctx); err != nil {
 			logger.Error(fmt.Errorf("failed to start listeners: %w", err))
@@ -201,7 +219,7 @@ func runWorker(ctx context.Context) error {
 
 	// Start the catalog scanner scheduler (grype scans)
 	go func() {
-		if err := scan.StartScheduler(ctx); err != nil {
+		if err := scan.StartScheduler(ctx, scanCache); err != nil {
 			logger.Error(fmt.Errorf("failed to start catalog scanner scheduler: %w", err))
 		}
 	}()

--- a/pkg/anchore/scanner.go
+++ b/pkg/anchore/scanner.go
@@ -160,7 +160,7 @@ func (s *GrypeScanner) ScanSBOMForCVEs(ctx context.Context, sbomJSON string) (re
 	}()
 
 	// Parse the SBOM
-	sbomObj, err := s.ParseSBOM(sbomJSON)
+	sbomObj, err := ParseSBOM(sbomJSON)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse SBOM: %w", err)
 	}
@@ -267,8 +267,11 @@ func (s *GrypeScanner) ScanSBOMForCVEs(ctx context.Context, sbomJSON string) (re
 	return buf.String(), nil
 }
 
-// ParseSBOM parses an SBOM string (either Syft JSON or SPDX JSON) into an SBOM object
-func (s *GrypeScanner) ParseSBOM(sbomJSON string) (*sbom.SBOM, error) {
+// ParseSBOM parses an SBOM string (either Syft JSON or SPDX JSON) into an SBOM object.
+// This is a standalone function that does not require a GrypeScanner instance,
+// useful when only SBOM parsing is needed (e.g. for package fix-version updates)
+// without loading the vulnerability database.
+func ParseSBOM(sbomJSON string) (*sbom.SBOM, error) {
 	// Auto-detect format by examining the JSON structure
 	format, err := detectSBOMFormat(sbomJSON)
 	if err != nil {

--- a/pkg/listener/external-image-sbom.go
+++ b/pkg/listener/external-image-sbom.go
@@ -13,6 +13,7 @@ import (
 	image "github.com/securebuildhq/securebuild/pkg/image"
 	"github.com/securebuildhq/securebuild/pkg/listener/types"
 	"github.com/securebuildhq/securebuild/pkg/logger"
+	"github.com/securebuildhq/securebuild/pkg/persistence"
 	"github.com/securebuildhq/securebuild/pkg/sbom"
 	"github.com/securebuildhq/securebuild/pkg/scan"
 	"github.com/securebuildhq/securebuild/pkg/telemetry"
@@ -315,14 +316,46 @@ func HandleExternalImageScan(ctx context.Context, payloadJSON string) error {
 }
 
 // RunScanForDigest runs a security scan for a digest that already has SBOM data.
-// It records failures in the database and returns nil on success (scan failures
-// are recorded but don't fail the job).
+//
+// In production, it enqueues an external_image_scan work item for builder-based
+// dispatch. The work item is processed by HandleExternalImageScanOnBuilder which
+// dispatches the scan to a builder VM, and the poller collects results.
+//
+// When a mock scan function is injected via WithMockScanExternalImage (used by
+// integration tests), it falls back to the in-process scan path: sets status to
+// running, calls the scan function, and stores results or failures synchronously.
+// This allows integration tests to verify scan state transitions without builders.
+//
 // Exported for integration testing.
 func RunScanForDigest(ctx context.Context, digest string) error {
 	attempt, maxAttempts := GetAttemptInfo(ctx)
 
-	// Get SBOMs to know the architectures, then mark them as running before starting scan.
-	// No span around GetExternalImageSBOMs: SQL is already traced by the client.
+	// If a mock scan function is injected, use the in-process scan path.
+	// This is used by integration tests that don't have builder VMs.
+	if _, hasMock := ctx.Value(scanExternalImageFuncKey).(func(context.Context, string) (map[string]string, error)); hasMock {
+		return runScanForDigestInProcess(ctx, digest, attempt, maxAttempts)
+	}
+
+	// Production: enqueue work item for builder-based dispatch.
+	payload, err := json.Marshal(types.ExternalImageScanPayload{Digest: digest})
+	if err != nil {
+		return fmt.Errorf("failed to marshal scan payload: %w", err)
+	}
+
+	if err := persistence.EnqueueWork(ctx, "external_image_scan", string(payload)); err != nil {
+		return fmt.Errorf("failed to enqueue external image scan: %w", err)
+	}
+
+	logger.Info("enqueued external image scan for digest",
+		zap.String("digest", digest))
+
+	return nil
+}
+
+// runScanForDigestInProcess runs the scan synchronously in-process using the
+// scan function from context (real or mocked). This is the legacy path used
+// by integration tests that inject mock scan functions.
+func runScanForDigestInProcess(ctx context.Context, digest string, attempt, maxAttempts int) error {
 	var storedSBOMs []extimgtypes.ExternalImageSBOM
 	storedSBOMs, err := externalimage.GetExternalImageSBOMs(ctx, digest)
 	if err != nil {
@@ -335,13 +368,11 @@ func RunScanForDigest(ctx context.Context, digest string) error {
 	for _, s := range storedSBOMs {
 		if err := externalimage.SetScanStatusRunning(ctx, digest, s.Arch); err != nil {
 			logger.Warn("failed to set scan status to running", zap.String("digest", digest), zap.String("arch", s.Arch), zap.Error(err), zap.Int("attempt", attempt), zap.Int("max_attempts", maxAttempts), zap.Bool("retryable", true))
-			// Continue with remaining architectures - this is a non-critical status update
 		}
 	}
 
 	scanResults, err := getScanExternalImageFunc(ctx)(ctx, digest)
 	if err != nil {
-		// Record the failure for each architecture so DB and Datadog metric are updated
 		storedSBOMsForFail, sbomErr := externalimage.GetExternalImageSBOMs(ctx, digest)
 		if sbomErr != nil {
 			return fmt.Errorf("failed to get SBOMs for recording scan failure: %w", sbomErr)
@@ -350,14 +381,9 @@ func RunScanForDigest(ctx context.Context, digest string) error {
 		for _, s := range storedSBOMsForFail {
 			recordScanFailure(ctx, digest, s.Arch, scanErr, false, attempt, maxAttempts)
 		}
-		// Don't fail the job - the scan failure is recorded and user can retry
 		return nil
 	}
 
-	// Store scan results for each architecture.
-	// If all architectures fail to parse/marshal/save, storeScanResults returns an error but
-	// each failure is already recorded via recordScanFailure. Return nil so the job finishes
-	// without retry (retrying would not fix data/parse/save issues).
 	successArchs, err := storeScanResults(ctx, digest, scanResults, attempt, maxAttempts)
 	if err != nil {
 		logger.Warn("all architectures failed to store scan results; failures recorded, not retrying",
@@ -369,10 +395,6 @@ func RunScanForDigest(ctx context.Context, digest string) error {
 		return nil
 	}
 
-	// Check for architectures in stored SBOMs that didn't get scan results.
-	// This handles partial failures where scan succeeds for some arches but not others.
-	// Reuse storedSBOMs from above so a transient refetch failure cannot skip verification
-	// (which would leave allExpectedArchsGotScanResults true and incorrectly fire the success metric).
 	allExpectedArchsGotScanResults := true
 	for _, sbom := range storedSBOMs {
 		if _, hasResult := scanResults[sbom.Arch]; !hasResult {
@@ -386,15 +408,10 @@ func RunScanForDigest(ctx context.Context, digest string) error {
 		zap.Int("architectures_scanned", len(scanResults)),
 		zap.Int("attempt", attempt),
 		zap.Int("max_attempts", maxAttempts))
-	// Only count as succeeded when (1) scan returned results for every expected arch, and
-	// (2) we successfully stored every result (parse/marshal/save for each arch).
 	if len(storedSBOMs) > 0 && allExpectedArchsGotScanResults && len(successArchs) == len(scanResults) {
 		telemetry.Increment(telemetry.MetricExternalImageScanSucceeded, []string{telemetry.TagChannelExternalImageScan})
 	}
 
-	// Update last_security_scanned_at for architectures whose results were
-	// successfully stored. scanResults keys are the arches that were scanned
-	// successfully; successArchs are the subset that were also stored.
 	if err := scan.UpdateLastSecurityScanned(ctx, digest, successArchs, time.Now().UTC()); err != nil {
 		logger.Warn("failed to update last_security_scanned_at",
 			zap.String("digest", digest),

--- a/pkg/listener/external-image-scan-builder.go
+++ b/pkg/listener/external-image-scan-builder.go
@@ -1,0 +1,444 @@
+package listener
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	syftpkg "github.com/anchore/syft/syft/pkg"
+	"github.com/securebuildhq/securebuild/pkg/anchore"
+	"github.com/securebuildhq/securebuild/pkg/buildbackend"
+	"github.com/securebuildhq/securebuild/pkg/externalimage"
+	image "github.com/securebuildhq/securebuild/pkg/image"
+	"github.com/securebuildhq/securebuild/pkg/listener/types"
+	"github.com/securebuildhq/securebuild/pkg/logger"
+	"github.com/securebuildhq/securebuild/pkg/persistence"
+	"github.com/securebuildhq/securebuild/pkg/scan"
+	"github.com/securebuildhq/securebuild/pkg/security"
+	"go.uber.org/zap"
+)
+
+// scanCacheContextKey is used to pass the ScanCapacityCache to the external
+// image scan handler via context.
+type scanCacheContextKey struct{}
+
+// WithScanCapacityCache returns a context that carries the ScanCapacityCache.
+func WithScanCapacityCache(ctx context.Context, cache *scan.ScanCapacityCache) context.Context {
+	return context.WithValue(ctx, scanCacheContextKey{}, cache)
+}
+
+// getScanCapacityCache retrieves the ScanCapacityCache from context, or nil.
+func getScanCapacityCache(ctx context.Context) *scan.ScanCapacityCache {
+	cache, _ := ctx.Value(scanCacheContextKey{}).(*scan.ScanCapacityCache)
+	return cache
+}
+
+// expectedArchs is the list of architectures that external image scans check for.
+var expectedArchs = []string{"x86_64", "aarch64"}
+
+// HandleExternalImageScanOnBuilder dispatches an external image CVE scan to a
+// builder VM. It copies the SBOM to the builder, launches grype CLI via nohup
+// for each architecture, and returns immediately. The scan status poller
+// collects results asynchronously.
+//
+// Queue message lifecycle:
+//   - Handler returns nil → message completed, grype runs async on builder
+//   - Handler returns NonRetryableError → message completed with error, not retried
+//   - Handler returns normal error → message retried by listener (e.g. no builder)
+func HandleExternalImageScanOnBuilder(ctx context.Context, payloadJSON string) error {
+	p := types.ExternalImageScanPayload{}
+	if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+		return fmt.Errorf("failed to unmarshal external image scan payload: %w", err)
+	}
+
+	if p.Digest == "" {
+		return fmt.Errorf("external image scan payload missing digest")
+	}
+
+	cache := getScanCapacityCache(ctx)
+	if cache == nil || !cache.IsReady() {
+		return fmt.Errorf("scan capacity cache is not ready")
+	}
+
+	recent, err := externalimage.WasScannedRecently(ctx, p.Digest, 4*time.Hour)
+	if err != nil {
+		logger.Warn("failed to check scan recency, proceeding with scan",
+			zap.String("digest", p.Digest),
+			zap.Error(err))
+	} else if recent {
+		logger.Info("discarding external_image_scan message: scan completed within 4 hours",
+			zap.String("digest", p.Digest))
+		return nil
+	}
+
+	// Idempotency: check if a scan is already running for this digest.
+	// The scheduler may enqueue duplicate work items before the status changes.
+	if isScanAlreadyRunning(ctx, p.Digest) {
+		logger.Info("discarding external_image_scan message: scan already running for digest",
+			zap.String("digest", p.Digest))
+		return nil
+	}
+
+	sboms, err := externalimage.GetExternalImageSBOMs(ctx, p.Digest)
+	if err != nil {
+		return fmt.Errorf("failed to get SBOMs for digest %s: %w", p.Digest, err)
+	}
+
+	sbomByArch := make(map[string]string)
+	for _, s := range sboms {
+		sbomByArch[s.Arch] = s.SBOM
+	}
+
+	if len(sbomByArch) == 0 {
+		for _, arch := range expectedArchs {
+			if err := externalimage.SetExternalImageScanStatus(ctx, externalimage.SetExternalImageScanStatusParams{
+				Digest:            p.Digest,
+				Arch:              arch,
+				Status:            externalimage.ScanStatusFailed,
+				ScanStatusMessage: "no SBOM found for this digest",
+			}); err != nil {
+				logger.Warn("failed to set scan status to failed for missing SBOM",
+					zap.String("digest", p.Digest),
+					zap.String("arch", arch),
+					zap.Error(err))
+			}
+		}
+		return NewNonRetryableError(fmt.Errorf("no SBOMs found for digest %s", p.Digest))
+	}
+
+	var archsToScan []string
+	for _, arch := range expectedArchs {
+		if _, hasSBOM := sbomByArch[arch]; hasSBOM {
+			archsToScan = append(archsToScan, arch)
+		} else {
+			if err := externalimage.SetExternalImageScanStatus(ctx, externalimage.SetExternalImageScanStatusParams{
+				Digest:            p.Digest,
+				Arch:              arch,
+				Status:            externalimage.ScanStatusFailed,
+				ScanStatusMessage: "no SBOM for this architecture",
+			}); err != nil {
+				logger.Warn("failed to set scan status to failed for missing arch SBOM",
+					zap.String("digest", p.Digest),
+					zap.String("arch", arch),
+					zap.Error(err))
+			}
+		}
+	}
+
+	if len(archsToScan) == 0 {
+		return NewNonRetryableError(fmt.Errorf("no architectures with SBOMs to scan for digest %s", p.Digest))
+	}
+
+	// Atomically claim the scan: set status to "running" for archs that are
+	// still "queued". If 0 rows are updated, another handler already claimed it.
+	claimed, claimErr := claimScanForDispatch(ctx, p.Digest, archsToScan)
+	if claimErr != nil {
+		// DB error during claim — return error so the listener retries.
+		return fmt.Errorf("failed to claim scan for dispatch: %w", claimErr)
+	}
+	if !claimed {
+		logger.Info("discarding external_image_scan message: scan already claimed by another handler",
+			zap.String("digest", p.Digest))
+		return nil
+	}
+
+	// If dispatch fails after the claim, revert the scan status to "queued"
+	// so the listener retry can re-dispatch. Otherwise the scan would stay
+	// "running" forever with no builder work directory for the poller to find.
+	dispatchErr := dispatchScanToBuilder(ctx, cache, p.Digest, sbomByArch, archsToScan)
+	if dispatchErr != nil {
+		revertScanToQueued(ctx, p.Digest, archsToScan)
+		return dispatchErr
+	}
+
+	return nil
+}
+
+// dispatchScanToBuilder handles the actual builder selection, file copy, and
+// grype launch. It reserves a capacity slot atomically and releases it if
+// any step fails before the scan is fully launched.
+//
+// The dispatch is split into two phases:
+//  1. Prepare all files (dirs, scan.json, sbom.json per arch) — if any step
+//     fails, no grype processes have started, so reverting is safe.
+//  2. Launch grype for all archs — if any launch fails, already-launched
+//     grype processes are killed before returning, preventing orphaned
+//     processes that would race with a retry on a different builder.
+func dispatchScanToBuilder(ctx context.Context, cache *scan.ScanCapacityCache, digest string, sbomByArch map[string]string, archsToScan []string) error {
+	builderVM, err := scan.SelectBuilderForScan(ctx, cache, digest)
+	if err != nil {
+		return fmt.Errorf("no builder available for scan: %w", err)
+	}
+
+	// SelectBuilderForScan already reserved a capacity slot and added a
+	// placeholder to the scans map. If we fail before calling AddScan to
+	// fill in the full metadata, release the slot and remove the placeholder.
+	slotReserved := true
+	defer func() {
+		if slotReserved {
+			cache.ReleaseScanSlot(builderVM.ID, digest)
+		}
+	}()
+
+	workDir, err := scan.ResolveScanWorkDir(ctx, builderVM, digest)
+	if err != nil {
+		return fmt.Errorf("failed to resolve scan work dir: %w", err)
+	}
+
+	runner, err := buildbackend.NewRunner(ctx, builderVM)
+	if err != nil {
+		return fmt.Errorf("failed to create runner for builder %s: %w", builderVM.ID, err)
+	}
+	defer runner.Close()
+
+	metadata := scan.ScanMetadata{
+		Digest:     digest,
+		CreatedAt:  time.Now().UTC(),
+		RetryCount: 0,
+	}
+
+	// Phase 1: Prepare all files. If any step fails here, no grype processes
+	// are running, so the caller can safely revert to "queued" and retry.
+	// Clean up the work directory so the poller doesn't discover a stale
+	// scan.json and treat it as live work.
+	if err := prepareScanFiles(ctx, runner, workDir, metadata, archsToScan, sbomByArch); err != nil {
+		cleanupScanDir(ctx, runner, workDir)
+		return fmt.Errorf("failed to prepare scan files on builder %s: %w", builderVM.ID, err)
+	}
+
+	// Phase 2: Launch grype for all archs. If a launch fails after some
+	// archs have already been launched, kill those processes and clean up
+	// the work directory so the poller doesn't discover a stale scan.json
+	// and treat it as live work that races with a retry on another builder.
+	launchedArchs := make([]string, 0, len(archsToScan))
+	for _, arch := range archsToScan {
+		grypeCmd := buildGrypeLaunchCommand(workDir, arch)
+		if _, err := runner.RunCommand(ctx, grypeCmd); err != nil {
+			logger.Warn("failed to launch grype, cleaning up already-launched processes",
+				zap.String("digest", digest),
+				zap.String("arch", arch),
+				zap.Strings("launchedArchs", launchedArchs),
+				zap.Error(err))
+			for _, launchedArch := range launchedArchs {
+				killGrypeProcess(ctx, runner, workDir, launchedArch)
+			}
+			cleanupScanDir(ctx, runner, workDir)
+			return fmt.Errorf("failed to launch grype for arch %s: %w", arch, err)
+		}
+		launchedArchs = append(launchedArchs, arch)
+		logger.Info("launched grype scan on builder",
+			zap.String("digest", digest),
+			zap.String("arch", arch),
+			zap.String("machineID", builderVM.ID),
+			zap.String("workDir", workDir))
+	}
+
+	// Scan successfully launched. AddScan records the scan metadata and
+	// keeps the reserved slot. The deferred ReleaseScanSlot is prevented
+	// by setting slotReserved to false.
+	cache.AddScan(builderVM.ID, scan.ScanDirInfo{
+		Digest:    digest,
+		WorkDir:   workDir,
+		CreatedAt: metadata.CreatedAt,
+	})
+	slotReserved = false
+
+	logger.Info("dispatched external image scan to builder",
+		zap.String("digest", digest),
+		zap.Int("archs", len(archsToScan)),
+		zap.String("machineID", builderVM.ID))
+
+	return nil
+}
+
+// prepareScanFiles creates the scan work directory, writes scan.json, and
+// copies SBOM files for each architecture. If this function returns an error,
+// no grype processes have been started, so the caller can safely revert.
+func prepareScanFiles(ctx context.Context, runner buildbackend.Runner, workDir string, metadata scan.ScanMetadata, archsToScan []string, sbomByArch map[string]string) error {
+	if err := runner.MkdirAll(workDir); err != nil {
+		return fmt.Errorf("failed to create scan work dir %s: %w", workDir, err)
+	}
+
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal scan metadata: %w", err)
+	}
+
+	scanJSONPath := filepath.Join(workDir, "scan.json")
+	if err := runner.WriteFile(scanJSONPath, string(metadataJSON)); err != nil {
+		return fmt.Errorf("failed to write scan.json: %w", err)
+	}
+
+	for _, arch := range archsToScan {
+		archDir := filepath.Join(workDir, arch)
+		outputDir := filepath.Join(archDir, "output")
+		if err := runner.MkdirAll(outputDir); err != nil {
+			return fmt.Errorf("failed to create output dir %s: %w", outputDir, err)
+		}
+
+		sbomPath := filepath.Join(archDir, "sbom.json")
+		if err := runner.WriteFile(sbomPath, sbomByArch[arch]); err != nil {
+			return fmt.Errorf("failed to write sbom.json for arch %s: %w", arch, err)
+		}
+	}
+
+	return nil
+}
+
+// buildGrypeLaunchCommand constructs the nohup shell command that runs grype
+// in the background on the builder. Grype scans the SBOM file and writes:
+//   - grype-scan.json (grype JSON output)
+//   - output/exit_code (grype exit code: 0=success)
+//   - output/grype.stderr (grype stderr)
+//   - output/grype.pid (actual grype process PID, not the bash wrapper)
+//
+// The command backgrounds grype as a child of the bash wrapper, captures its
+// PID, then waits for it to finish and records the exit code. This ensures
+// grype.pid contains the real grype PID so the timeout killer can target the
+// correct process.
+func buildGrypeLaunchCommand(workDir, arch string) string {
+	archDir := filepath.Join(workDir, arch)
+	return fmt.Sprintf(`nohup bash -c '
+  cd %q
+  grype sbom:./sbom.json --output json > grype-scan.json 2> output/grype.stderr &
+  grype_pid=$!
+  echo $grype_pid > output/grype.pid
+  wait $grype_pid
+  echo $? > output/exit_code
+' > %q 2>&1 < /dev/null &`, archDir, filepath.Join(archDir, "scan.log"))
+}
+
+// updatePackageFixVersionsForSBOM parses the SBOM and updates package fix
+// versions for APK packages. This is called by the poller after a successful
+// scan, using the SBOM from the DB (not from the builder).
+func updatePackageFixVersionsForSBOM(ctx context.Context, sbomJSON string) {
+	sbomObj, err := anchore.ParseSBOM(sbomJSON)
+	if err != nil {
+		logger.Warn("failed to parse SBOM for fix-version update",
+			zap.Error(err))
+		return
+	}
+
+	for pkg := range sbomObj.Artifacts.Packages.Enumerate() {
+		if pkg.Type != syftpkg.ApkPkg {
+			continue
+		}
+		if err := security.UpdatePackageFixVersions(ctx, sbomObj, pkg); err != nil {
+			logger.Warn("failed to update package fix versions",
+				zap.String("package", pkg.Name),
+				zap.String("version", pkg.Version),
+				zap.Error(err))
+		}
+	}
+}
+
+// storeBuilderScanResult parses and stores a successful scan result for a
+// single architecture. Returns true if the result was stored successfully.
+func storeBuilderScanResult(ctx context.Context, digest, arch, scanResult string) bool {
+	parsedResults, err := image.ParseScanResultDetails(scanResult)
+	if err != nil {
+		recordScanFailure(ctx, digest, arch,
+			externalimage.NewScanFailureError(externalimage.ErrParseScanResult,
+				fmt.Sprintf("failed to parse scan result: %s", err.Error())),
+			false, 0, 0)
+		return false
+	}
+
+	countsJSON, err := json.Marshal(parsedResults.Counts)
+	if err != nil {
+		recordScanFailure(ctx, digest, arch,
+			externalimage.NewScanFailureError(externalimage.ErrMarshalScanCounts,
+				fmt.Sprintf("failed to marshal scan counts: %s", err.Error())),
+			false, 0, 0)
+		return false
+	}
+
+	summaryJSON, err := json.Marshal(parsedResults)
+	if err != nil {
+		recordScanFailure(ctx, digest, arch,
+			externalimage.NewScanFailureError(externalimage.ErrMarshalScanSummary,
+				fmt.Sprintf("failed to marshal scan summary: %s", err.Error())),
+			false, 0, 0)
+		return false
+	}
+
+	if err := externalimage.SetExternalImageScanStatus(ctx, externalimage.SetExternalImageScanStatusParams{
+		Digest:               digest,
+		Arch:                 arch,
+		Status:               externalimage.ScanStatusSucceeded,
+		ParsedResults:        string(countsJSON),
+		ParsedResultsDetails: string(summaryJSON),
+		RawResult:            scanResult,
+	}); err != nil {
+		recordScanFailure(ctx, digest, arch,
+			externalimage.NewScanFailureError(externalimage.ErrSaveScanStatus,
+				fmt.Sprintf("scan completed but failed to save results: %s", err.Error())),
+			false, 0, 0)
+		return false
+	}
+
+	return true
+}
+
+// isScanAlreadyRunning checks if any external_image_scan row for the digest
+// has status 'running'. This prevents duplicate dispatch when the scheduler
+// enqueues multiple work items before the first handler sets the status.
+func isScanAlreadyRunning(ctx context.Context, digest string) bool {
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+
+	var count int
+	err := conn.QueryRow(ctx,
+		`SELECT COUNT(*) FROM external_image_scan WHERE digest = $1 AND status = 'running'`,
+		digest).Scan(&count)
+	if err != nil {
+		logger.Warn("failed to check if scan is already running, proceeding",
+			zap.String("digest", digest),
+			zap.Error(err))
+		return false
+	}
+	return count > 0
+}
+
+// claimScanForDispatch atomically transitions scan rows from "queued" to
+// "running" for the given digest and architectures. Returns (true, nil) if at
+// least one row was claimed, (false, nil) if another handler already claimed
+// it, or (false, err) if the claim failed due to a database error. On DB
+// error, the caller returns the error so the listener retries the message
+// instead of dispatching without a durable claim.
+func claimScanForDispatch(ctx context.Context, digest string, archs []string) (bool, error) {
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+
+	tag, err := conn.Exec(ctx,
+		`UPDATE external_image_scan
+		 SET status = 'running', scan_status_updated_at = NOW(), scan_attempted_at = COALESCE(scan_attempted_at, NOW())
+		 WHERE digest = $1 AND arch = ANY($2::text[]) AND status = 'queued'`,
+		digest, archs)
+	if err != nil {
+		return false, fmt.Errorf("failed to claim scan rows: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+// revertScanToQueued transitions scan rows from "running" back to "queued"
+// after a failed dispatch. This allows the listener retry to re-dispatch
+// the scan to a different builder. Without this, the scan would stay
+// "running" forever with no builder work directory for the poller to find.
+func revertScanToQueued(ctx context.Context, digest string, archs []string) {
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+
+	_, err := conn.Exec(ctx,
+		`UPDATE external_image_scan
+		 SET status = 'queued', scan_status_updated_at = NOW(), scan_status_message = NULL
+		 WHERE digest = $1 AND arch = ANY($2::text[]) AND status = 'running'`,
+		digest, archs)
+	if err != nil {
+		logger.Warn("failed to revert scan status to queued after dispatch failure",
+			zap.String("digest", digest),
+			zap.Error(err))
+	}
+}

--- a/pkg/listener/start.go
+++ b/pkg/listener/start.go
@@ -274,9 +274,13 @@ func StartExternalImageSbomListener(ctx context.Context, l *Listener) {
 }
 
 func StartExternalImageScanListener(ctx context.Context, l *Listener) {
-	l.AddHandler(ctx, "external_image_scan", 1, time.Minute*5, func(ctx context.Context, notification *pgconn.Notification) error {
+	maxWorkers := param.GetParam(ctx).PoolSize * param.GetParam(ctx).MaxScansPerBuilder
+	if maxWorkers < 1 {
+		maxWorkers = 1
+	}
+	l.AddHandler(ctx, "external_image_scan", maxWorkers, time.Minute*5, func(ctx context.Context, notification *pgconn.Notification) error {
 		return telemetry.WithSpan(ctx, "listener.external_image_scan", func(ctx context.Context) error {
-			if err := HandleExternalImageScan(ctx, notification.Payload); err != nil {
+			if err := HandleExternalImageScanOnBuilder(ctx, notification.Payload); err != nil {
 				logger.Error(fmt.Errorf("failed to handle external image scan notification: %w", err))
 				return fmt.Errorf("failed to handle external image scan notification: %w", err)
 			}

--- a/pkg/listener/update-external-image-scan-status.go
+++ b/pkg/listener/update-external-image-scan-status.go
@@ -1,0 +1,403 @@
+package listener
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/securebuildhq/securebuild/pkg/buildbackend"
+	buildertypes "github.com/securebuildhq/securebuild/pkg/builder/types"
+	"github.com/securebuildhq/securebuild/pkg/externalimage"
+	"github.com/securebuildhq/securebuild/pkg/listener/types"
+	"github.com/securebuildhq/securebuild/pkg/logger"
+	"github.com/securebuildhq/securebuild/pkg/persistence"
+	"github.com/securebuildhq/securebuild/pkg/scan"
+	"github.com/securebuildhq/securebuild/pkg/telemetry"
+	"go.uber.org/zap"
+)
+
+// StartExternalImageScanStatusChecker runs the scan status poller loop.
+// Every ScanPollerInterval (10s), it checks all running builders for
+// completed scans, collects results, updates the DB, and cleans up.
+// It also detects builders that have been deleted and re-enqueues their scans.
+func StartExternalImageScanStatusChecker(ctx context.Context, cache *scan.ScanCapacityCache) error {
+	logger.Info("Starting external image scan status checker")
+
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info("External image scan status checker shutting down")
+			return nil
+		default:
+		}
+
+		if err := pollScanStatus(ctx, cache); err != nil {
+			logger.Error(fmt.Errorf("failed to poll scan status: %w", err))
+		}
+
+		time.Sleep(scan.ScanPollerInterval)
+	}
+}
+
+// pollScanStatus performs one poll cycle: checks all running builders for
+// completed scans and handles builders that have disappeared.
+func pollScanStatus(ctx context.Context, cache *scan.ScanCapacityCache) error {
+	span, ctx := telemetry.StartSpan(ctx, "listener.poll_scan_status")
+	defer span.Finish()
+
+	builders, err := scan.GetRunningBuilders(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to query running builders: %w", err)
+	}
+
+	runningBuilderIDs := make(map[string]bool)
+	for _, b := range builders {
+		runningBuilderIDs[b.ID] = true
+	}
+
+	for _, b := range builders {
+		processBuilderScans(ctx, cache, b)
+	}
+
+	for _, machineID := range cache.GetBuilderIDs() {
+		if !runningBuilderIDs[machineID] {
+			handleMissingBuilder(ctx, cache, machineID)
+		}
+	}
+
+	return nil
+}
+
+// processBuilderScans checks all scan directories on a single builder,
+// collects results for completed scans, and cleans up finished scan dirs.
+func processBuilderScans(ctx context.Context, cache *scan.ScanCapacityCache, vm buildertypes.BuilderVM) {
+	baseDir, err := scan.ResolveScanBaseDir(ctx, vm)
+	if err != nil {
+		logger.Warn("failed to resolve scan base dir for builder, skipping",
+			zap.String("machineID", vm.ID),
+			zap.Error(err))
+		return
+	}
+
+	runner, err := buildbackend.NewRunner(ctx, vm)
+	if err != nil {
+		logger.Warn("failed to create runner for builder, skipping this cycle",
+			zap.String("machineID", vm.ID),
+			zap.Error(err))
+		return
+	}
+	defer runner.Close()
+
+	scanDirs, err := scan.ListScanDirsWithRunner(ctx, runner, baseDir)
+	if err != nil {
+		logger.Warn("failed to list scan dirs on builder, skipping this cycle",
+			zap.String("machineID", vm.ID),
+			zap.Error(err))
+		return
+	}
+
+	// Reconcile cache with discovered scan dirs. If a scan dir is still
+	// running (not all archs done) but not tracked in the cache (e.g. it
+	// was missed during InitScanCapacityCache because the builder was
+	// unreachable at startup), add it so capacity tracking is accurate
+	// and missing-builder recovery can re-enqueue it if the VM disappears.
+	cachedDigests := make(map[string]bool)
+	for _, info := range cache.GetScansForBuilder(vm.ID) {
+		cachedDigests[info.Digest] = true
+	}
+	for _, sd := range scanDirs {
+		if sd.Metadata.Digest != "" && !sd.AllArchsDone && !cachedDigests[sd.Metadata.Digest] {
+			cache.AddScanWithCount(vm.ID, scan.ScanDirInfo{
+				Digest:    sd.Metadata.Digest,
+				WorkDir:   sd.WorkDir,
+				CreatedAt: sd.Metadata.CreatedAt,
+			})
+			logger.Info("added discovered scan to cache during poll",
+				zap.String("digest", sd.Metadata.Digest),
+				zap.String("machineID", vm.ID))
+		}
+	}
+
+	for _, sd := range scanDirs {
+		processScanDir(ctx, cache, vm, runner, sd)
+	}
+}
+
+// processScanDir processes a single scan directory on a builder.
+// For each architecture, it checks if grype has completed and collects results.
+// When all architectures are complete, it cleans up the scan directory.
+func processScanDir(ctx context.Context, cache *scan.ScanCapacityCache, vm buildertypes.BuilderVM, runner buildbackend.Runner, sd scan.ScanDirStatus) {
+	digest := sd.Metadata.Digest
+	if digest == "" {
+		logger.Warn("scan dir has no digest in metadata, cleaning up",
+			zap.String("workDir", sd.WorkDir))
+		cleanupScanDir(ctx, runner, sd.WorkDir)
+		return
+	}
+
+	now := time.Now().UTC()
+	successArchs := make([]string, 0)
+	allDone := len(sd.ArchStatuses) > 0
+
+	for arch, status := range sd.ArchStatuses {
+		if status.Done {
+			allDone = allDone && true
+			exitCode, parseErr := strconv.Atoi(strings.TrimSpace(status.ExitCode))
+			if parseErr != nil {
+				logger.Warn("failed to parse exit code, treating as failure",
+					zap.String("digest", digest),
+					zap.String("arch", arch),
+					zap.String("exitCode", status.ExitCode),
+					zap.Error(parseErr))
+				exitCode = 1
+			}
+
+			if exitCode == 0 {
+				if handled := handleSuccessfulScan(ctx, runner, sd.WorkDir, digest, arch); handled {
+					successArchs = append(successArchs, arch)
+				}
+			} else {
+				handleFailedScan(ctx, runner, sd.WorkDir, digest, arch, exitCode)
+			}
+		} else {
+			age := now.Sub(sd.Metadata.CreatedAt)
+			if age > scan.ScanTimeout {
+				logger.Warn("scan timed out, killing grype process",
+					zap.String("digest", digest),
+					zap.String("arch", arch),
+					zap.Duration("age", age),
+					zap.Duration("timeout", scan.ScanTimeout))
+				killGrypeProcess(ctx, runner, sd.WorkDir, arch)
+				writeExitCode(ctx, runner, sd.WorkDir, arch, 124)
+				handleFailedScan(ctx, runner, sd.WorkDir, digest, arch, 124)
+				status.Done = true
+				status.ExitCode = "124"
+			} else {
+				allDone = false
+			}
+		}
+	}
+
+	if allDone && len(sd.ArchStatuses) > 0 {
+		scannedArchs := make([]string, 0, len(sd.ArchStatuses))
+		for arch := range sd.ArchStatuses {
+			scannedArchs = append(scannedArchs, arch)
+		}
+		if err := scan.UpdateLastSecurityScanned(ctx, digest, scannedArchs, now); err != nil {
+			logger.Warn("failed to update last_security_scanned_at",
+				zap.String("digest", digest),
+				zap.Error(err))
+		}
+
+		cleanupScanDir(ctx, runner, sd.WorkDir)
+		cache.RemoveScan(vm.ID, digest)
+
+		logger.Info("completed scan collection for digest",
+			zap.String("digest", digest),
+			zap.Int("archs", len(sd.ArchStatuses)),
+			zap.Int("succeeded", len(successArchs)),
+			zap.String("machineID", vm.ID))
+	}
+}
+
+// handleSuccessfulScan reads the grype JSON result, stores it in the DB,
+// and updates package fix versions for APK packages.
+// Returns true if the result was stored successfully.
+func handleSuccessfulScan(ctx context.Context, runner buildbackend.Runner, workDir, digest, arch string) bool {
+	grypeJSONPath := filepath.Join(workDir, arch, "grype-scan.json")
+	grypeJSON, err := runner.ReadFile(grypeJSONPath)
+	if err != nil {
+		logger.Warn("failed to read grype JSON result, marking as failed",
+			zap.String("digest", digest),
+			zap.String("arch", arch),
+			zap.Error(err))
+		recordScanFailure(ctx, digest, arch,
+			externalimage.NewScanFailureError(externalimage.ErrParseScanResult,
+				fmt.Sprintf("grype JSON result missing or unreadable: %s", err.Error())),
+			false, 0, 0)
+		return false
+	}
+
+	if strings.TrimSpace(grypeJSON) == "" {
+		logger.Warn("grype JSON result is empty, marking as failed",
+			zap.String("digest", digest),
+			zap.String("arch", arch))
+		recordScanFailure(ctx, digest, arch,
+			externalimage.NewScanFailureError(externalimage.ErrParseScanResult,
+				"grype JSON result is empty"),
+			false, 0, 0)
+		return false
+	}
+
+	stored := storeBuilderScanResult(ctx, digest, arch, grypeJSON)
+	if stored {
+		sboms, sbomErr := externalimage.GetExternalImageSBOMs(ctx, digest)
+		if sbomErr == nil {
+			for _, s := range sboms {
+				if s.Arch == arch {
+					updatePackageFixVersionsForSBOM(ctx, s.SBOM)
+					break
+				}
+			}
+		}
+		logger.Info("stored scan result",
+			zap.String("digest", digest),
+			zap.String("arch", arch))
+	}
+	return stored
+}
+
+// handleFailedScan reads the grype stderr and records the scan failure.
+// Grype failures are non-retryable (same SBOM gives same result).
+func handleFailedScan(ctx context.Context, runner buildbackend.Runner, workDir, digest, arch string, exitCode int) {
+	stderrPath := filepath.Join(workDir, arch, "output", "grype.stderr")
+	stderr := ""
+	if content, err := runner.ReadFileTail(stderrPath, 10240); err == nil {
+		stderr = strings.TrimRight(content, "\n\r")
+	}
+
+	msg := fmt.Sprintf("grype exited with code %d", exitCode)
+	if stderr != "" {
+		msg = fmt.Sprintf("grype exited with code %d: %s", exitCode, stderr)
+	}
+
+	recordScanFailure(ctx, digest, arch,
+		externalimage.NewScanFailureError(externalimage.ErrScanExecutionFailed, msg),
+		false, 0, 0)
+
+	logger.Warn("scan failed",
+		zap.String("digest", digest),
+		zap.String("arch", arch),
+		zap.Int("exitCode", exitCode))
+}
+
+// killGrypeProcess reads the grype PID file and kills the grype process.
+// The PID file contains the actual grype process PID (not the bash wrapper).
+//
+// RunCommand returns immediately after the outer nohup detaches, but the
+// inner shell may not have written grype.pid yet. This function polls for
+// the PID file to appear (up to 10s) before reading it, closing the race
+// where a launch failure triggers a kill before the PID file exists.
+//
+// Before sending any signal, the function verifies that the PID still belongs
+// to a grype process. This prevents killing an unrelated process if grype
+// exited between poll cycles and the OS reused its PID for a build or other
+// process running on the same shared builder VM.
+func killGrypeProcess(ctx context.Context, runner buildbackend.Runner, workDir, arch string) {
+	pidPath := filepath.Join(workDir, arch, "output", "grype.pid")
+
+	// Wait for the PID file to appear. RunCommand returns after the outer
+	// nohup detaches, but the inner shell may not have written grype.pid yet.
+	var pidContent string
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		content, err := runner.ReadFile(pidPath)
+		if err == nil && strings.TrimSpace(content) != "" {
+			pidContent = content
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	if pidContent == "" {
+		logger.Warn("grype PID file did not appear within timeout, cannot kill process",
+			zap.String("workDir", workDir),
+			zap.String("arch", arch))
+		return
+	}
+
+	pid := strings.TrimSpace(pidContent)
+	if pid == "" {
+		return
+	}
+
+	// Verify the PID is still a grype process before killing. If grype
+	// already exited and the PID was reused by another process, skip the
+	// kill to avoid terminating an unrelated process (e.g. a build).
+	cmd := fmt.Sprintf(`ps -p %s -o comm= 2>/dev/null | grep -q grype && kill %s; sleep 5; ps -p %s -o comm= 2>/dev/null | grep -q grype && kill -9 %s; true`, pid, pid, pid, pid)
+	if _, err := runner.RunCommand(ctx, cmd); err != nil {
+		logger.Warn("failed to kill grype process",
+			zap.String("pid", pid),
+			zap.Error(err))
+	}
+}
+
+// writeExitCode writes an exit code file for a timed-out scan so the poller
+// doesn't re-check it on the next cycle.
+func writeExitCode(ctx context.Context, runner buildbackend.Runner, workDir, arch string, code int) {
+	exitCodePath := filepath.Join(workDir, arch, "output", "exit_code")
+	if err := runner.WriteFile(exitCodePath, strconv.Itoa(code)); err != nil {
+		logger.Warn("failed to write exit code for timed-out scan",
+			zap.String("workDir", workDir),
+			zap.String("arch", arch),
+			zap.Error(err))
+	}
+}
+
+// cleanupScanDir removes the scan work directory from the builder.
+func cleanupScanDir(ctx context.Context, runner buildbackend.Runner, workDir string) {
+	cmd := fmt.Sprintf("rm -rf %q", workDir)
+	if _, err := runner.RunCommand(ctx, cmd); err != nil {
+		logger.Warn("failed to clean up scan dir on builder",
+			zap.String("workDir", workDir),
+			zap.Error(err))
+	}
+}
+
+// handleMissingBuilder handles the case where a builder that had active scans
+// is no longer in machine_pool (deleted, expired, etc.). The scans on that
+// builder are lost, so the affected digests are re-enqueued for scanning on
+// a different builder. The retry_count is effectively reset to 0 since
+// scan.json is lost with the VM.
+func handleMissingBuilder(ctx context.Context, cache *scan.ScanCapacityCache, machineID string) {
+	scans := cache.GetScansForBuilder(machineID)
+	if len(scans) == 0 {
+		cache.RemoveBuilder(machineID)
+		return
+	}
+
+	logger.Warn("builder no longer in machine_pool, re-enqueuing scans",
+		zap.String("machineID", machineID),
+		zap.Int("scanCount", len(scans)))
+
+	for _, s := range scans {
+		for _, arch := range expectedArchs {
+			if err := externalimage.SetExternalImageScanStatus(ctx, externalimage.SetExternalImageScanStatusParams{
+				Digest:            s.Digest,
+				Arch:              arch,
+				Status:            externalimage.ScanStatusQueued,
+				ScanStatusMessage: "builder VM no longer exists",
+			}); err != nil {
+				logger.Warn("failed to set scan status to queued for missing builder",
+					zap.String("digest", s.Digest),
+					zap.String("arch", arch),
+					zap.Error(err))
+			}
+		}
+
+		reenqueueScan(ctx, s.Digest)
+	}
+
+	cache.RemoveBuilder(machineID)
+}
+
+// reenqueueScan enqueues a new external_image_scan work item for a digest.
+func reenqueueScan(ctx context.Context, digest string) {
+	payload, err := json.Marshal(types.ExternalImageScanPayload{Digest: digest})
+	if err != nil {
+		logger.Error(fmt.Errorf("failed to marshal re-enqueue payload: %w", err))
+		return
+	}
+
+	if err := persistence.EnqueueWork(ctx, "external_image_scan", string(payload)); err != nil {
+		logger.Error(fmt.Errorf("failed to re-enqueue external image scan: %w", err))
+		return
+	}
+
+	logger.Info("re-enqueued external image scan",
+		zap.String("digest", digest))
+}

--- a/pkg/param/param.go
+++ b/pkg/param/param.go
@@ -127,6 +127,11 @@ type Param struct {
 	MaxParallelBuilds int        `yaml:"max_parallel_builds"`
 	StaticVMs         []StaticVM `yaml:"static_vms"`
 
+	// MaxScansPerBuilder is the maximum number of concurrent external image scans
+	// per builder VM. Scans are lightweight (grype matching against a local SBOM)
+	// so this can be higher than max_parallel_builds. Default: 3.
+	MaxScansPerBuilder int `yaml:"max_scans_per_builder"`
+
 	// Authentication configuration
 	AuthMethod        string `yaml:"auth_method"`
 	AdminUserEmail    string `yaml:"admin_user_email"`
@@ -292,6 +297,10 @@ func Init(source InitSource, overrides map[string]string) (context.Context, erro
 		logger.Warn("CMX backend limits MaxParallelBuilds to 1; overriding config",
 			zap.Int("configured", p.MaxParallelBuilds))
 		p.MaxParallelBuilds = 1
+	}
+
+	if p.MaxScansPerBuilder <= 0 {
+		p.MaxScansPerBuilder = 3
 	}
 
 	normalizePoolSizeForBackend(p)

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -11,8 +11,8 @@ import (
 	syftpkg "github.com/anchore/syft/syft/pkg"
 	"github.com/securebuildhq/securebuild/pkg/anchore"
 	"github.com/securebuildhq/securebuild/pkg/externalimage"
-	"github.com/securebuildhq/securebuild/pkg/image"
 	"github.com/securebuildhq/securebuild/pkg/logger"
+	"github.com/securebuildhq/securebuild/pkg/param"
 	"github.com/securebuildhq/securebuild/pkg/persistence"
 	"github.com/securebuildhq/securebuild/pkg/security"
 	"github.com/securebuildhq/securebuild/pkg/telemetry"
@@ -52,7 +52,7 @@ func ScanExternalImage(ctx context.Context, digest string) (results map[string]s
 		startTime := time.Now()
 
 		// Parse the SBOM to extract packages
-		sbomObj, err := scanner.ParseSBOM(sbom.SBOM)
+		sbomObj, err := anchore.ParseSBOM(sbom.SBOM)
 		if err != nil {
 			logger.Warn("failed to parse SBOM",
 				zap.String("digest", digest),
@@ -352,10 +352,20 @@ func UpdateLastSecurityScanned(ctx context.Context, digest string, archs []strin
 	return nil
 }
 
-// processExternalImageScans selects external image SBOMs to scan and processes them.
+// processExternalImageScans selects external image SBOMs to scan and enqueues
+// them as external_image_scan work items for builder-based dispatch.
 // Selection uses tiered back-off based on last_submitted_at (see SelectExternalImageDigestsToScan).
+// Scheduler backpressure: only enqueues if the total in-memory scan count is below
+// PoolSize * MaxScansPerBuilder.
 // returns true if there are no more digests to scan
-func processExternalImageScans(ctx context.Context, maxToProcess int) (bool, error) {
+func processExternalImageScans(ctx context.Context, maxToProcess int, cache *ScanCapacityCache) (bool, error) {
+	if cache != nil {
+		maxConcurrent := param.GetParam(ctx).PoolSize * param.GetParam(ctx).MaxScansPerBuilder
+		if cache.GetTotalScanCount() >= maxConcurrent {
+			return false, nil
+		}
+	}
+
 	selectedDigests, err := SelectExternalImageDigestsToScan(ctx, maxToProcess)
 	if err != nil {
 		return false, err
@@ -365,159 +375,22 @@ func processExternalImageScans(ctx context.Context, maxToProcess int) (bool, err
 		return true, nil
 	}
 
-	logger.Info("processing external image scans", zap.Int("count", len(selectedDigests)))
+	logger.Info("enqueuing external image scans", zap.Int("count", len(selectedDigests)))
 
 	for _, digest := range selectedDigests {
-		// Get SBOMs to know the architectures, then mark them as running before starting scan
-		storedSBOMs, sbomErr := externalimage.GetExternalImageSBOMs(ctx, digest)
-		if sbomErr != nil {
-			logger.Warn("failed to get SBOMs for setting running status",
-				zap.String("digest", digest),
-				zap.Error(sbomErr))
-		} else {
-			for _, s := range storedSBOMs {
-				if err := externalimage.SetScanStatusRunning(ctx, digest, s.Arch); err != nil {
-					logger.Warn("failed to set scan status to running",
-						zap.String("digest", digest),
-						zap.String("arch", s.Arch),
-						zap.Error(err))
-				}
-			}
-		}
-
-		scanResults, err := ScanExternalImage(ctx, digest)
+		payload, err := json.Marshal(map[string]string{"digest": digest})
 		if err != nil {
-			logger.Warn("failed to scan external image SBOMs",
+			logger.Warn("failed to marshal scan payload",
 				zap.String("digest", digest),
 				zap.Error(err))
-
-			// Update last_security_scanned_at for arches that were scanned (scanResults
-			// keys) to prevent hot-loop retries. When ScanExternalImage returns an error,
-			// scanResults is empty, so this is a no-op and all arches remain eligible
-			// for retry — the scheduler's MaxImagesPerCycle limit and cycle interval
-			// throttle retries naturally.
-			scannedArchs := make([]string, 0, len(scanResults))
-			for arch := range scanResults {
-				scannedArchs = append(scannedArchs, arch)
-			}
-			if err := UpdateLastSecurityScanned(ctx, digest, scannedArchs, time.Now().UTC()); err != nil {
-				logger.Warn("failed to update last_security_scanned_at after scan failure",
-					zap.String("digest", digest),
-					zap.Error(err))
-			}
-
-			// Record failure for each architecture from the SBOMs
-			storedSBOMs, sbomErr := externalimage.GetExternalImageSBOMs(ctx, digest)
-			if sbomErr != nil {
-				logger.Warn("failed to get SBOMs for recording scan failure",
-					zap.String("digest", digest),
-					zap.Error(sbomErr))
-			} else {
-				for _, s := range storedSBOMs {
-					if recordErr := externalimage.SetExternalImageScanStatus(ctx, externalimage.SetExternalImageScanStatusParams{
-						Digest:            digest,
-						Arch:              s.Arch,
-						Status:            externalimage.ScanStatusFailed,
-						ScanStatusMessage: err.Error(),
-					}); recordErr != nil {
-						logger.Warn("failed to record scan failure",
-							zap.String("digest", digest),
-							zap.String("arch", s.Arch),
-							zap.Error(recordErr))
-					}
-				}
-			}
 			continue
 		}
 
-		// Helper to record scan failure for a specific arch
-		recordArchFailure := func(arch, reason string) {
-			if recordErr := externalimage.SetExternalImageScanStatus(ctx, externalimage.SetExternalImageScanStatusParams{
-				Digest:            digest,
-				Arch:              arch,
-				Status:            externalimage.ScanStatusFailed,
-				ScanStatusMessage: reason,
-			}); recordErr != nil {
-				logger.Warn("failed to record scan failure",
-					zap.String("digest", digest),
-					zap.String("arch", arch),
-					zap.Error(recordErr))
-			}
-		}
-
-		successArchs := make([]string, 0, len(scanResults))
-		for arch, scanResult := range scanResults {
-			parsedResults, err := image.ParseScanResultDetails(scanResult)
-			if err != nil {
-				logger.Warn("failed to parse scan result",
-					zap.String("digest", digest),
-					zap.String("arch", arch),
-					zap.Error(err))
-				recordArchFailure(arch, fmt.Sprintf("failed to parse scan result: %v", err))
-				continue
-			}
-
-			countsJSON, err := json.Marshal(parsedResults.Counts)
-			if err != nil {
-				logger.Warn("failed to marshal scan counts",
-					zap.String("digest", digest),
-					zap.String("arch", arch),
-					zap.Error(err))
-				recordArchFailure(arch, fmt.Sprintf("failed to marshal scan counts: %v", err))
-				continue
-			}
-
-			summaryJSON, err := json.Marshal(parsedResults)
-			if err != nil {
-				logger.Warn("failed to marshal scan summary",
-					zap.String("digest", digest),
-					zap.String("arch", arch),
-					zap.Error(err))
-				recordArchFailure(arch, fmt.Sprintf("failed to marshal scan summary: %v", err))
-				continue
-			}
-
-			if err := externalimage.SetExternalImageScanStatus(ctx, externalimage.SetExternalImageScanStatusParams{
-				Digest:               digest,
-				Arch:                 arch,
-				Status:               externalimage.ScanStatusSucceeded,
-				ParsedResults:        string(countsJSON),
-				ParsedResultsDetails: string(summaryJSON),
-				RawResult:            scanResult,
-			}); err != nil {
-				logger.Warn("failed to set external image scan status to succeeded, recording as failed",
-					zap.String("digest", digest),
-					zap.String("arch", arch),
-					zap.Error(err))
-				// If we can't save the success, record a failure so status doesn't stay "running" forever
-				recordArchFailure(arch, fmt.Sprintf("scan completed but failed to save results: %v", err))
-				continue
-			}
-			successArchs = append(successArchs, arch)
-		}
-
-		// Check for architectures in stored SBOMs that didn't get scan results
-		// This handles partial failures where scan succeeds for some arches but not others
-		// (e.g., x86_64 succeeds but aarch64 fails silently in ScanExternalImage)
-		if storedSBOMs != nil && len(storedSBOMs) > 0 {
-			for _, s := range storedSBOMs {
-				// Check if this arch got a scan result
-				if _, hasResult := scanResults[s.Arch]; !hasResult {
-					logger.Warn("no scan result for architecture with SBOM",
-						zap.String("digest", digest),
-						zap.String("arch", s.Arch))
-					recordArchFailure(s.Arch, "scan did not return results for this architecture")
-				}
-			}
-		}
-
-		// Update last_security_scanned_at for architectures whose results were
-		// successfully stored. scanResults keys are the arches that ScanExternalImage
-		// scanned successfully; successArchs are the subset that were also stored.
-		if err := UpdateLastSecurityScanned(ctx, digest, successArchs, time.Now().UTC()); err != nil {
-			logger.Warn("failed to update last_security_scanned_at",
+		if err := persistence.EnqueueWork(ctx, "external_image_scan", string(payload)); err != nil {
+			logger.Warn("failed to enqueue external image scan",
 				zap.String("digest", digest),
 				zap.Error(err))
+			continue
 		}
 	}
 

--- a/pkg/scan/scan_capacity.go
+++ b/pkg/scan/scan_capacity.go
@@ -1,0 +1,654 @@
+package scan
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/securebuildhq/securebuild/pkg/buildbackend"
+	"github.com/securebuildhq/securebuild/pkg/builder"
+	buildertypes "github.com/securebuildhq/securebuild/pkg/builder/types"
+	"github.com/securebuildhq/securebuild/pkg/logger"
+	"github.com/securebuildhq/securebuild/pkg/param"
+	"github.com/securebuildhq/securebuild/pkg/persistence"
+	"github.com/securebuildhq/securebuild/pkg/telemetry"
+	"go.uber.org/zap"
+)
+
+const (
+	// MaxScanRetryAttempts is the maximum number of times a failed scan is retried
+	// before being marked as permanently failed.
+	MaxScanRetryAttempts = 3
+
+	// ScanTimeout is the maximum duration a grype scan can run before it is
+	// considered stuck and killed.
+	ScanTimeout = 10 * time.Minute
+
+	// ScanPollerInterval is how often the scan status poller checks builders
+	// for completed scans.
+	ScanPollerInterval = 10 * time.Second
+
+	// ScanStartupGracePeriod is the grace period after a scan is dispatched
+	// before the poller starts checking for exit codes. This allows grype
+	// time to start up and begin processing.
+	ScanStartupGracePeriod = 60 * time.Second
+)
+
+// ScanMetadata is the JSON metadata file written to each scan directory on the
+// builder. It allows the poller to discover scans and know which DB rows to update.
+type ScanMetadata struct {
+	Digest     string    `json:"digest"`
+	CreatedAt  time.Time `json:"created_at"`
+	RetryCount int       `json:"retry_count"`
+}
+
+// ScanDirInfo tracks a single active scan directory on a builder.
+type ScanDirInfo struct {
+	Digest    string
+	WorkDir   string
+	CreatedAt time.Time
+}
+
+// ScanCapacityCache tracks active scans per builder, maintained from filesystem
+// scans. There is only one worker instance, so no cross-instance coordination
+// is needed.
+type ScanCapacityCache struct {
+	mu     sync.RWMutex
+	counts map[string]int           // machineID → count of active scan directories
+	scans  map[string][]ScanDirInfo // machineID → list of active scan dirs
+	ready  bool
+}
+
+// NewScanCapacityCache creates a new empty ScanCapacityCache.
+func NewScanCapacityCache() *ScanCapacityCache {
+	return &ScanCapacityCache{
+		counts: make(map[string]int),
+		scans:  make(map[string][]ScanDirInfo),
+	}
+}
+
+// IsReady returns true if the cache has been initialized from the builder
+// filesystems. Handlers check this as a safety net before dispatching scans.
+func (c *ScanCapacityCache) IsReady() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.ready
+}
+
+// setReady marks the cache as initialized.
+func (c *ScanCapacityCache) setReady(ready bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ready = ready
+}
+
+// AddScan updates the scan metadata for a builder. The capacity count was
+// already incremented by tryReserveSlot during SelectBuilderForScan, which
+// also added a placeholder entry to the scans map. This function fills in
+// the placeholder with the full scan dir info (workDir, createdAt). For
+// scans discovered during cache init (not via SelectBuilderForScan), use
+// AddScanWithCount which increments both.
+func (c *ScanCapacityCache) AddScan(machineID string, info ScanDirInfo) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i, s := range c.scans[machineID] {
+		if s.Digest == info.Digest && s.WorkDir == "" {
+			c.scans[machineID][i] = info
+			return
+		}
+	}
+	c.scans[machineID] = append(c.scans[machineID], info)
+}
+
+// AddScanWithCount records scan metadata AND increments the capacity count.
+// Used by InitScanCapacityCache for scans discovered on builder filesystems
+// during startup (not dispatched via SelectBuilderForScan).
+func (c *ScanCapacityCache) AddScanWithCount(machineID string, info ScanDirInfo) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.scans[machineID] = append(c.scans[machineID], info)
+	c.counts[machineID]++
+}
+
+// RemoveScan removes a scan for a builder by digest.
+func (c *ScanCapacityCache) RemoveScan(machineID, digest string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	scans := c.scans[machineID]
+	for i, s := range scans {
+		if s.Digest == digest {
+			c.scans[machineID] = append(scans[:i], scans[i+1:]...)
+			c.counts[machineID]--
+			if c.counts[machineID] <= 0 {
+				delete(c.counts, machineID)
+				delete(c.scans, machineID)
+			}
+			return
+		}
+	}
+}
+
+// RemoveBuilder removes all scans for a builder (e.g. when the builder is deleted).
+func (c *ScanCapacityCache) RemoveBuilder(machineID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.counts, machineID)
+	delete(c.scans, machineID)
+}
+
+// GetBuilderScanCount returns the number of active scans for a builder.
+func (c *ScanCapacityCache) GetBuilderScanCount(machineID string) int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.counts[machineID]
+}
+
+// GetScansForBuilder returns the list of active scan dirs for a builder.
+func (c *ScanCapacityCache) GetScansForBuilder(machineID string) []ScanDirInfo {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	result := make([]ScanDirInfo, len(c.scans[machineID]))
+	copy(result, c.scans[machineID])
+	return result
+}
+
+// GetTotalScanCount returns the total number of active scans across all builders.
+// Used by the scheduler for backpressure.
+func (c *ScanCapacityCache) GetTotalScanCount() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	total := 0
+	for _, count := range c.counts {
+		total += count
+	}
+	return total
+}
+
+// GetBuilderIDs returns the machine IDs of all builders that have active scans.
+func (c *ScanCapacityCache) GetBuilderIDs() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	ids := make([]string, 0, len(c.scans))
+	for id := range c.scans {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// tryReserveSlot atomically checks whether a builder has capacity for one
+// more scan and, if so, increments the count and adds a placeholder scan
+// entry under the write lock. The placeholder prevents the poller's
+// reconciliation from double-counting the scan via AddScanWithCount during
+// the window between reservation and AddScan. Returns true if the slot was
+// reserved.
+func (c *ScanCapacityCache) tryReserveSlot(machineID string, hasBuildAssignment bool, maxScansPerBuilder int, digest string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	current := c.counts[machineID]
+
+	if hasBuildAssignment {
+		if current >= 1 {
+			return false
+		}
+	} else {
+		if current >= maxScansPerBuilder {
+			return false
+		}
+	}
+
+	c.counts[machineID] = current + 1
+	c.scans[machineID] = append(c.scans[machineID], ScanDirInfo{Digest: digest})
+	return true
+}
+
+// ReleaseScanSlot decrements the capacity count and removes the placeholder
+// scan entry for a builder. Used when a reservation was made but the scan
+// dispatch failed before the scan was fully set up.
+func (c *ScanCapacityCache) ReleaseScanSlot(machineID string, digest string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.counts[machineID]--
+	scans := c.scans[machineID]
+	for i, s := range scans {
+		if s.Digest == digest {
+			c.scans[machineID] = append(scans[:i], scans[i+1:]...)
+			break
+		}
+	}
+	if c.counts[machineID] <= 0 {
+		delete(c.counts, machineID)
+		if len(c.scans[machineID]) == 0 {
+			delete(c.scans, machineID)
+		}
+	}
+}
+
+// ReportCapacityMetrics sends gauge metrics for total and used scan capacity.
+//
+// Total capacity = number of running builders × MaxScansPerBuilder.
+// Used capacity = sum of active scan counts across all builders (from cache).
+//
+// Gauges sent:
+//   - securebuild.external_image.scan.capacity.total
+//   - securebuild.external_image.scan.capacity.used
+//   - securebuild.external_image.scan.capacity.used (tag: machine_id=<id>) per builder
+func (c *ScanCapacityCache) ReportCapacityMetrics(ctx context.Context) {
+	maxScansPerBuilder := param.GetParam(ctx).MaxScansPerBuilder
+
+	builders, err := getRunningBuildersForScan(ctx)
+	if err != nil {
+		logger.Warn("failed to query running builders for capacity metrics",
+			zap.Error(err))
+		return
+	}
+
+	totalCapacity := len(builders) * maxScansPerBuilder
+	telemetry.Gauge(telemetry.MetricExternalImageScanCapacityTotal, float64(totalCapacity), nil)
+
+	used := c.GetTotalScanCount()
+	telemetry.Gauge(telemetry.MetricExternalImageScanCapacityUsed, float64(used), nil)
+
+	for _, b := range builders {
+		builderUsed := c.GetBuilderScanCount(b.ID)
+		telemetry.Gauge(telemetry.MetricExternalImageScanCapacityUsed, float64(builderUsed),
+			[]string{"machine_id:" + b.ID})
+	}
+}
+
+// DumpToFile writes the current cache state to a JSON file for debugging.
+// The file is written to os.TempDir()/securebuild-scan-capacity-cache.json
+// and is overwritten on each call. This provides visibility into the
+// in-memory capacity data that is not stored in the database.
+func (c *ScanCapacityCache) DumpToFile() error {
+	c.mu.RLock()
+	snapshot := struct {
+		Timestamp time.Time                `json:"timestamp"`
+		Ready     bool                     `json:"ready"`
+		Counts    map[string]int           `json:"counts"`
+		Scans     map[string][]ScanDirInfo `json:"scans"`
+	}{
+		Timestamp: time.Now().UTC(),
+		Ready:     c.ready,
+		Counts:    make(map[string]int, len(c.counts)),
+		Scans:     make(map[string][]ScanDirInfo, len(c.scans)),
+	}
+	for k, v := range c.counts {
+		snapshot.Counts[k] = v
+	}
+	for k, v := range c.scans {
+		snapshot.Scans[k] = make([]ScanDirInfo, len(v))
+		copy(snapshot.Scans[k], v)
+	}
+	c.mu.RUnlock()
+
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal cache dump: %w", err)
+	}
+
+	path := filepath.Join(os.TempDir(), "securebuild-scan-capacity-cache.json")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write cache dump to %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// InitScanCapacityCache performs a one-time full scan of all running builders
+// to discover in-flight scan directories and populate the in-memory cache.
+// This enables self-healing after a worker restart: grype processes survive
+// the restart (they run via nohup), and the poller resumes collecting results.
+func InitScanCapacityCache(ctx context.Context) (*ScanCapacityCache, error) {
+	cache := NewScanCapacityCache()
+
+	builders, err := getRunningBuildersForScan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query running builders for scan cache init: %w", err)
+	}
+
+	for _, b := range builders {
+		scans, err := ListScanDirsOnBuilder(ctx, b.BuilderVM)
+		if err != nil {
+			logger.Warn("failed to list scan dirs on builder during init, skipping",
+				zap.String("machineID", b.BuilderVM.ID),
+				zap.Error(err))
+			continue
+		}
+
+		for _, s := range scans {
+			if s.AllArchsDone {
+				continue
+			}
+			cache.AddScanWithCount(b.BuilderVM.ID, ScanDirInfo{
+				Digest:    s.Metadata.Digest,
+				WorkDir:   s.WorkDir,
+				CreatedAt: s.Metadata.CreatedAt,
+			})
+		}
+	}
+
+	cache.setReady(true)
+	logger.Info("scan capacity cache initialized",
+		zap.Int("builders", len(builders)),
+		zap.Int("activeScans", cache.GetTotalScanCount()))
+
+	return cache, nil
+}
+
+// builderForScan is a running builder with its build assignment status.
+type builderForScan struct {
+	buildertypes.BuilderVM
+	HasBuildAssignment bool
+}
+
+// SelectBuilderForScan finds a builder VM that can accept a new scan and
+// atomically reserves a capacity slot. Priority: idle builders first (no
+// build assignments), then busy builders.
+// Capacity rules:
+//   - Idle builders (no machine_assignment rows): up to maxScansPerBuilder concurrent scans
+//   - Busy builders (has machine_assignment rows): at most 1 concurrent scan
+//
+// The reservation is atomic: the capacity count is incremented AND a
+// placeholder scan entry is added to the scans map under the cache write
+// lock before returning. This prevents concurrent handlers from all
+// selecting the same builder and exceeding MaxScansPerBuilder, and ensures
+// the poller's reconciliation can see the reserved digest without
+// double-counting it via AddScanWithCount.
+// If the caller fails to dispatch the scan, it must call ReleaseScanSlot
+// to undo the reservation.
+func SelectBuilderForScan(ctx context.Context, cache *ScanCapacityCache, digest string) (buildertypes.BuilderVM, error) {
+	if cache == nil || !cache.IsReady() {
+		return buildertypes.BuilderVM{}, fmt.Errorf("scan capacity cache is not ready")
+	}
+
+	maxScansPerBuilder := param.GetParam(ctx).MaxScansPerBuilder
+
+	builders, err := getRunningBuildersForScan(ctx)
+	if err != nil {
+		return buildertypes.BuilderVM{}, fmt.Errorf("failed to query running builders for scan: %w", err)
+	}
+
+	for _, b := range builders {
+		if cache.tryReserveSlot(b.ID, b.HasBuildAssignment, maxScansPerBuilder, digest) {
+			return b.BuilderVM, nil
+		}
+	}
+
+	return buildertypes.BuilderVM{}, fmt.Errorf("no builder available for scan (all at capacity)")
+}
+
+// GetRunningBuilders returns all running builder VMs from the machine pool,
+// ordered by idle-first (no build assignments first).
+func GetRunningBuilders(ctx context.Context) ([]buildertypes.BuilderVM, error) {
+	builders, err := getRunningBuildersForScan(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]buildertypes.BuilderVM, 0, len(builders))
+	for _, b := range builders {
+		result = append(result, b.BuilderVM)
+	}
+	return result, nil
+}
+
+// getRunningBuildersForScan queries all running builders, ordered by idle-first
+// (no build assignments first), then by oldest builder first.
+func getRunningBuildersForScan(ctx context.Context) ([]builderForScan, error) {
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+
+	query := `
+		SELECT mp.id, mp.created_at, mp.expires_at, mp.private_key, mp.username,
+		       mp.status, mp.ip_address, mp.port, mp.architecture,
+		       mp.last_uptime, mp.last_uptime_updated_at, mp.cleanup_locked_at,
+		       mp.is_on_demand, mp.type,
+		       EXISTS (SELECT 1 FROM machine_assignment ma WHERE ma.machine_id = mp.id) AS has_build_assignment
+		FROM machine_pool mp
+		WHERE mp.status = 'running'
+		  AND mp.cleanup_locked_at IS NULL
+		  AND mp.is_on_demand = false
+		ORDER BY
+		  CASE WHEN EXISTS (
+		    SELECT 1 FROM machine_assignment ma WHERE ma.machine_id = mp.id
+		  ) THEN 1 ELSE 0 END,
+		  mp.created_at ASC
+	`
+
+	rows, err := conn.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query running builders: %w", err)
+	}
+	defer rows.Close()
+
+	var result []builderForScan
+	for rows.Next() {
+		var b builderForScan
+		var ipAddress sql.NullString
+		var port sql.NullInt64
+		var architecture sql.NullString
+		var lastUptime sql.NullString
+		var lastUptimeUpdatedAt sql.NullTime
+		var cleanupLockedAt sql.NullTime
+		var expiresAt sql.NullTime
+		var hasBuildAssignment bool
+
+		err := rows.Scan(
+			&b.ID, &b.CreatedAt, &expiresAt, &b.PrivateKey, &b.Username,
+			&b.Status, &ipAddress, &port, &architecture,
+			&lastUptime, &lastUptimeUpdatedAt, &cleanupLockedAt,
+			&b.IsOnDemand, &b.Type,
+			&hasBuildAssignment,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan builder row: %w", err)
+		}
+
+		if ipAddress.Valid {
+			b.IPAddress = ipAddress.String
+		}
+		if port.Valid {
+			b.Port = int(port.Int64)
+		}
+		if architecture.Valid {
+			b.Architecture = architecture.String
+		}
+		if lastUptime.Valid {
+			b.LastUptime = lastUptime.String
+		}
+		if lastUptimeUpdatedAt.Valid {
+			b.LastUptimeUpdatedAt = &lastUptimeUpdatedAt.Time
+		}
+		if cleanupLockedAt.Valid {
+			b.CleanupLockedAt = &cleanupLockedAt.Time
+		}
+		if expiresAt.Valid {
+			b.ExpiresAt = &expiresAt.Time
+		}
+		b.HasBuildAssignment = hasBuildAssignment
+
+		result = append(result, b)
+	}
+
+	return result, nil
+}
+
+// ScanDirStatus represents the status of a scan directory on a builder.
+type ScanDirStatus struct {
+	WorkDir      string
+	Metadata     ScanMetadata
+	ArchStatuses map[string]*ArchScanStatus
+	AllArchsDone bool
+}
+
+// ArchScanStatus represents the status of a single architecture's scan.
+type ArchScanStatus struct {
+	Done      bool
+	ExitCode  string
+	GrypeJSON string
+	Stderr    string
+}
+
+// ResolveScanBaseDir returns the base scans directory for a builder.
+// For local builders, uses os.TempDir()/securebuild/scans.
+// For CMX/static, uses $HOME/scans (resolved via GetRemoteHome).
+func ResolveScanBaseDir(ctx context.Context, vm buildertypes.BuilderVM) (string, error) {
+	if vm.Type == "local" {
+		return filepath.Join(os.TempDir(), "securebuild", "scans"), nil
+	}
+	homeDir, err := builder.GetRemoteHome(ctx, vm)
+	if err != nil {
+		return "", fmt.Errorf("failed to get remote home: %w", err)
+	}
+	return filepath.Join(homeDir, "scans"), nil
+}
+
+// ResolveScanWorkDir returns the work directory for a scan on a builder.
+// For local builders, uses os.TempDir()/securebuild/scans/<digest>.
+// For CMX/static, uses $HOME/scans/<digest> (resolved via GetRemoteHome).
+func ResolveScanWorkDir(ctx context.Context, vm buildertypes.BuilderVM, digest string) (string, error) {
+	baseDir, err := ResolveScanBaseDir(ctx, vm)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(baseDir, digest), nil
+}
+
+// ListScanDirsOnBuilder connects to a builder and discovers all scan directories
+// by listing scan.json files. For each scan, it checks whether each architecture's
+// grype process has completed (exit_code file exists). Completed scans are not
+// counted toward capacity (the poller will collect them on the next cycle).
+func ListScanDirsOnBuilder(ctx context.Context, vm buildertypes.BuilderVM) ([]ScanDirStatus, error) {
+	baseDir, err := ResolveScanBaseDir(ctx, vm)
+	if err != nil {
+		return nil, err
+	}
+
+	runner, err := buildbackend.NewRunner(ctx, vm)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create runner: %w", err)
+	}
+	defer runner.Close()
+
+	return ListScanDirsWithRunner(ctx, runner, baseDir)
+}
+
+// ListScanDirsWithRunner lists scan directories using an existing runner.
+// This allows the poller to reuse a runner for both listing and reading results.
+func ListScanDirsWithRunner(ctx context.Context, runner buildbackend.Runner, baseDir string) ([]ScanDirStatus, error) {
+	cmd := fmt.Sprintf(`if [ ! -d %q ]; then exit 0; fi
+find %q -name scan.json 2>/dev/null | sort | while IFS= read -r f; do
+  dir=$(dirname "$f")
+  echo "@@SCAN@@|$dir"
+  cat "$f"
+  echo ""
+  echo "@@META_END@@"
+  for arch in x86_64 aarch64; do
+    if [ -d "$dir/$arch" ]; then
+      exitFile="$dir/$arch/output/exit_code"
+      if [ -f "$exitFile" ]; then
+        echo "@@DONE@@|$arch|$(cat "$exitFile")"
+      else
+        echo "@@PENDING@@|$arch"
+      fi
+    fi
+  done
+  echo "@@SCAN_END@@"
+done`, baseDir, baseDir)
+
+	output, err := runner.RunCommand(ctx, cmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list scan dirs: %w", err)
+	}
+
+	return parseScanDirListing(output), nil
+}
+
+// parseScanDirListing parses the output of the scan dir listing command.
+func parseScanDirListing(output string) []ScanDirStatus {
+	var scans []ScanDirStatus
+	lines := strings.Split(output, "\n")
+
+	i := 0
+	for i < len(lines) {
+		line := strings.TrimSpace(lines[i])
+		if !strings.HasPrefix(line, "@@SCAN@@|") {
+			i++
+			continue
+		}
+
+		workDir := strings.TrimPrefix(line, "@@SCAN@@|")
+		i++
+
+		var metadataLines []string
+		for i < len(lines) {
+			l := strings.TrimSpace(lines[i])
+			if l == "@@META_END@@" {
+				i++
+				break
+			}
+			metadataLines = append(metadataLines, lines[i])
+			i++
+		}
+
+		metadataJSON := strings.TrimSpace(strings.Join(metadataLines, "\n"))
+		var meta ScanMetadata
+		if metadataJSON != "" {
+			if err := json.Unmarshal([]byte(metadataJSON), &meta); err != nil {
+				logger.Warn("failed to parse scan.json during listing",
+					zap.String("workDir", workDir),
+					zap.Error(err))
+			}
+		}
+
+		status := &ScanDirStatus{
+			WorkDir:      workDir,
+			Metadata:     meta,
+			ArchStatuses: make(map[string]*ArchScanStatus),
+			AllArchsDone: true,
+		}
+
+		hasAnyArch := false
+		for i < len(lines) {
+			l := strings.TrimSpace(lines[i])
+			if l == "@@SCAN_END@@" {
+				i++
+				break
+			}
+			if strings.HasPrefix(l, "@@DONE@@|") {
+				hasAnyArch = true
+				parts := strings.SplitN(strings.TrimPrefix(l, "@@DONE@@|"), "|", 2)
+				if len(parts) == 2 {
+					arch := parts[0]
+					exitCode := parts[1]
+					status.ArchStatuses[arch] = &ArchScanStatus{
+						Done:     true,
+						ExitCode: exitCode,
+					}
+				}
+			} else if strings.HasPrefix(l, "@@PENDING@@|") {
+				hasAnyArch = true
+				arch := strings.TrimPrefix(l, "@@PENDING@@|")
+				status.ArchStatuses[arch] = &ArchScanStatus{
+					Done: false,
+				}
+				status.AllArchsDone = false
+			}
+			i++
+		}
+
+		if !hasAnyArch {
+			status.AllArchsDone = false
+		}
+
+		scans = append(scans, *status)
+	}
+
+	return scans
+}

--- a/pkg/scan/scheduler.go
+++ b/pkg/scan/scheduler.go
@@ -22,6 +22,12 @@ const (
 	// ExternalImageCheckInterval is how long the scheduler pauses if there are no external images to scan
 	ExternalImageCheckInterval = 15 * time.Second
 
+	// ExternalImageEnqueueInterval is how long the scheduler pauses after enqueuing
+	// scan work items, before the next selection cycle. This gives handlers time to
+	// claim the work items and transition scan status to "running", preventing the
+	// tight loop from re-enqueuing the same digests thousands of times.
+	ExternalImageEnqueueInterval = 5 * time.Second
+
 	// MaxImagesPerCycle limits how many images are processed in each scheduler cycle
 	MaxImagesPerCycle = 25
 
@@ -36,19 +42,36 @@ func GetRandomizedScanInterval() time.Duration {
 	return ScanInterval + time.Duration(randomMinutes)*time.Minute
 }
 
-func StartScheduler(ctx context.Context) error {
+func StartScheduler(ctx context.Context, cache *ScanCapacityCache) error {
 	logger.Info("Starting scan scheduler")
 
-	// Periodic metrics reporter for scan backlog and running scan counts
+	// Periodic metrics reporter for scan backlog, running scan counts,
+	// and scan capacity gauges. Also dumps the in-memory capacity cache
+	// to a temp file for debugging visibility.
 	go func() {
 		ticker := time.NewTicker(MetricsReportInterval)
 		defer ticker.Stop()
+		// Report immediately on startup so metrics are available without
+		// waiting for the first tick.
+		ReportScanMetrics(ctx)
+		if cache != nil {
+			cache.ReportCapacityMetrics(ctx)
+			if err := cache.DumpToFile(); err != nil {
+				logger.Warn("failed to dump scan capacity cache to file", zap.Error(err))
+			}
+		}
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
 				ReportScanMetrics(ctx)
+				if cache != nil {
+					cache.ReportCapacityMetrics(ctx)
+					if err := cache.DumpToFile(); err != nil {
+						logger.Warn("failed to dump scan capacity cache to file", zap.Error(err))
+					}
+				}
 			}
 		}
 	}()
@@ -68,16 +91,24 @@ func StartScheduler(ctx context.Context) error {
 	}()
 
 	for {
-		noImages, err := processExternalImageScans(ctx, MaxImagesPerCycle)
+		noImages, err := processExternalImageScans(ctx, MaxImagesPerCycle, cache)
 		if err != nil {
 			logger.Error(fmt.Errorf("failed to process external image scans: %w", err))
 		}
-		if noImages {
-			select {
-			case <-ctx.Done():
-				return nil
-			case <-time.After(ExternalImageCheckInterval):
-			}
+
+		// Always pause between cycles. When images were enqueued, the sleep
+		// gives handlers time to claim the work items and transition scan
+		// status to "running" before the next selection cycle re-selects
+		// the same digests. Without this, the tight loop re-enqueues
+		// thousands of duplicate work items before any handler claims them.
+		wait := ExternalImageCheckInterval
+		if !noImages {
+			wait = ExternalImageEnqueueInterval
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(wait):
 		}
 	}
 }

--- a/pkg/telemetry/datadog.go
+++ b/pkg/telemetry/datadog.go
@@ -24,8 +24,11 @@ const (
 	MetricExternalImageScanFailed    = "securebuild.external_image.scan.failed"
 	MetricExternalImageScanSucceeded = "securebuild.external_image.scan.succeeded"
 
-	MetricExternalImageScanBacklog = "securebuild.external_image.scan.backlog"
+	MetricExternalImageScanBacklog  = "securebuild.external_image.scan.backlog"
 	MetricExternalImageScansRunning = "securebuild.external_image.scan.running"
+
+	MetricExternalImageScanCapacityTotal = "securebuild.external_image.scan.capacity.total"
+	MetricExternalImageScanCapacityUsed  = "securebuild.external_image.scan.capacity.used"
 
 	TagChannelExternalImageSBOM = "channel:external_image_sbom"
 	TagChannelExternalImageScan = "channel:external_image_scan"


### PR DESCRIPTION
# Design: Distribute External Image CVE Scans Across Builders

## TL;DR

External image CVE scans currently run in-process in the worker (max 2 concurrent). This design distributes them across builder VMs using the same pattern as package/image builds: enqueue work → SSH to a builder → run `grype` CLI via `nohup` → poll for results → read artifacts back.

**No new database tables.** In-flight scan state lives on the builder filesystem (`$HOME/scans/<digest>/scan.json` + per-arch `output/exit_code`). An in-memory capacity cache, built on startup by scanning builder filesystems and maintained incrementally by a 10-second poller, tracks how many scans are running per builder for capacity-aware dispatch.

Key properties:
- Builders are **not assigned** to scans — scans coexist with builds on the same VM without touching `machine_assignment`
- Builders are **never recycled** after a scan — they stay in the pool
- **Idle builders preferred** and can run up to `max_scans_per_builder` scans concurrently; busy builders (running builds) are used but limited to 1 scan at a time
- **`max_scans_per_builder`** config (default 3) — counts **digests**, not (digest, arch) pairs. Both architectures of a digest scan run on the same builder. Idle builders run up to 3 digests, busy builders run 1. With N idle builders: N × 3 concurrent digest scans (vs. 2 today)
- **Worker restart is self-healing** — poller rebuilds cache from filesystem, resumes collecting results from `nohup` processes that survived the restart

## Problem

External image vulnerability scans currently run **in-process** in the worker, using grype as a Go library (`pkg/anchore/scanner.go`). The scan scheduler (`pkg/scan/scheduler.go:70-82`) is a single tight loop that calls `processExternalImageScans`, which iterates selected digests **sequentially** (`pkg/scan/scan.go:370`). The on-demand listener (`external_image_scan` channel) is registered with `maxWorkers=1` (`pkg/listener/start.go:277`). Even if both run concurrently, that's at most 2 scans in flight, and each scans architectures one-by-one. This is insufficient throughput for the backlog.

Package and image builds solved this by distributing work across a pool of builder VMs. We need to do the same for external image scans, but with important differences from the build flow.

## Key Differences from Package/Image Builds

| Concern | Build Flow | Scan Flow (this design) |
|---|---|---|
| Builder assignment | Exclusive — `machine_assignment` row per build, VM is "owned" | **Non-exclusive** — scans coexist with builds on the same VM, no assignment rows |
| Builder recycling | CMX VMs are destroyed after build completes | **No recycling** — builder stays in pool, reusable for builds |
| Work dispatch | LISTEN/NOTIFY work queue → handler → SSH to VM | LISTEN/NOTIFY work queue → handler → SSH to VM (same pattern) |
| Result collection | Poller reads `output/status` + logs via SSH | Poller reads per-arch `output/exit_code` + grype JSON via SSH (same pattern) |
| In-flight tracking | `machine_assignment` DB table | **Filesystem on builder** — scan directories with `scan.json` metadata files |
| Capacity tracking | `COUNT(machine_assignment) < maxParallel` | **In-memory cache** maintained by poller from filesystem scan |
| Capacity | 1 per CMX VM (`maxParallel=1` for builds) | Idle builders: up to `max_scans_per_builder`; busy builders: 1 scan max |
| New DB tables | — | **None** — reuses `external_image_scan` for results, filesystem for in-flight state |

## Architecture Overview

```
                    ┌──────────────────────────────────────────────────────┐
                    │                    Worker Process                     │
                    │                                                      │
                    │  ┌──────────┐   ┌──────────────┐   ┌─────────────┐   │
                    │  │ Scheduler │   │ On-Demand    │   │ SBOM Handler│   │
                    │  │ (scan.go) │   │ Listener     │   │ (rescan)    │   │
                    │  └─────┬─────┘   └──────┬───────┘   └──────┬──────┘   │
                    │        │                │                  │          │
                    │        ▼                ▼                  ▼          │
                    │  ┌──────────────────────────────────────────────┐    │
                    │  │  EnqueueWork("external_image_scan",           │    │
                    │  │      {digest, arch})                          │    │
                    │  └──────────────────────┬───────────────────────┘    │
                    │                         │                             │
                    │                         ▼                             │
                    │  ┌──────────────────────────────────────────────┐    │
                    │  │  Scan Handler (external_image_scan channel)  │    │
                    │  │  1. Check in-memory capacity map             │    │
                    │  │  2. Select builder (idle first, then busy)   │    │
                    │  │  3. Copy SBOM + scan.json to builder         │    │
                    │  │  4. Launch grype CLI via nohup               │    │
                    │  │  5. Increment in-memory scan count            │    │
                    │  └──────────────────────┬───────────────────────┘    │
                    │                         │                             │
                    │  ┌──────────────────────▼───────────────────────┐    │
                    │  │  Scan Status Poller (10s loop)               │    │
                    │  │  1. SSH to each running builder               │    │
                    │  │  2. List $HOME/scans/*/scan.json              │    │
                    │  │  3. Read output/exit_code per scan dir         │    │
                    │  │  4. If done: read grype JSON, update DB       │    │
                    │  │  5. rm -rf scan dir, update in-memory count   │    │
                    │  └──────────────────────┬───────────────────────┘    │
                    │                         │                             │
                    │  ┌──────────────────────▼───────────────────────┐    │
                    │  │  In-Memory Scan Capacity Cache                │    │
                    │  │  map[machineID] → {scanDirs, lastUpdated}     │    │
                    │  │  Built on startup, maintained incrementally   │    │
                    │  └──────────────────────────────────────────────┘    │
                    └─────────────────────────┼─────────────────────────────┘
                                              │ SSH
                    ┌─────────────────────────▼─────────────────────────────┐
                    │              Builder VM (any in pool)                 │
                    │  $HOME/scans/<digest>/                                  │
                    │    scan.json           (digest, created_at)             │
                    │    x86_64/                                              │
                    │      sbom.json         (copied from worker)            │
                    │      grype-scan.json   (grype output)                  │
                    │      output/exit_code   (grype exit code: 0=success)│
                    │      output/grype.stderr (grype stderr)                │
                    │    aarch64/                                            │
                    │      sbom.json         (copied from worker)            │
                    │      grype-scan.json   (grype output)                  │
                    │      output/exit_code   (grype exit code: 0=success)│
                    │      output/grype.stderr (grype stderr)                │
                    └───────────────────────────────────────────────────────┘
```

## No New Database Tables

This design deliberately avoids adding any new DB tables. In-flight scan state lives on the **builder filesystem**; final results continue to be stored in the existing `external_image_scan` table.

### Why no tracking table?

1. **The builder filesystem is the source of truth.** Each scan writes a `scan.json` metadata file to its work directory on the builder. The poller discovers in-flight scans by listing `scan.json` files — no DB needed.
2. **Worker restart recovery is trivial.** On startup, the poller scans all builders, reads `scan.json` files, and rebuilds its in-memory state. No migration step, no stale rows to clean up.
3. **No stale DB rows.** If the worker crashes, there are no orphaned tracking rows in the DB. The poller rebuilds from the filesystem on restart.
4. **The `machine_assignment` table is untouched.** The build cleanup loop (`pkg/builder/cleanup.go`) and build VM selection (`tryTakeVMWithAssignment`) are completely unaffected. They never see scan-related rows.

### What stays in the DB

- `external_image_scan` (existing) — final scan results: status, raw_result, parsed_results, etc. Updated by the poller when a scan completes. The handler sets `status = 'running'` when dispatching to prevent duplicate dispatch.
- `external_image_sbom` (existing) — SBOM data and `last_security_scanned_at` timestamp.
- `machine_pool` (existing) — builder VM registry. No changes.

## `scan.json` — Builder Filesystem Metadata

Each scan writes a small JSON metadata file to its work directory on the builder. This is how the poller discovers scans and knows what DB rows to update:

```json
{
  "digest": "sha256:abc123...",
  "created_at": "2026-07-16T14:30:00Z",
  "retry_count": 0
}
```

The poller reads `scan.json` from each scan directory to know:
- Which `external_image_scan` rows to update (by `digest` — both arch rows)
- When the scan started (for timeout detection, from `created_at`)
- How many times the scan has been retried (for retry limit, from `retry_count`)

The work directory is named `<digest>` (e.g. `$HOME/scans/sha256:abc123.../`). All architectures for that digest scan under this directory, each in its own subdirectory (`x86_64/`, `aarch64/`). One scan directory = one digest = one capacity unit. This guarantees both architectures run on the same builder, and `max_scans_per_builder` counts digests, not (digest, arch) pairs.

## Configuration

Add to `pkg/param/param.go`:

```go
// MaxScansPerBuilder is the maximum number of concurrent external image scans
// per builder VM. Scans are lightweight (grype matching against a local SBOM)
// so this can be higher than max_parallel_builds. Default: 3.
MaxScansPerBuilder int `yaml:"max_scans_per_builder"`
```

In `securebuild-config.yaml` and `config-cmx.yaml`:

```yaml
max_scans_per_builder: 3
```

Normalization: if `MaxScansPerBuilder <= 0`, set to `3` (default > 1 per requirement #4).

## In-Memory Scan Capacity Cache

### `ScanCapacityCache`

```go
// ScanCapacityCache tracks active scans per builder, maintained from filesystem scans.
// There is only one worker instance, so no cross-instance coordination is needed.
type ScanCapacityCache struct {
    mu     sync.RWMutex
    counts map[string]int  // machineID → count of active scan directories
    scans  map[string][]ScanDirInfo  // machineID → list of active scan dirs
}

type ScanDirInfo struct {
    Digest    string
    WorkDir   string
    CreatedAt time.Time
}
```

### Building the cache on startup

Before the poller loop starts, `InitScanCapacityCache` performs a one-time full scan:

```
1. Query all running builders from machine_pool WHERE status = 'running'
2. For each builder:
   a. SSH to builder
   b. List $HOME/scans/*/scan.json
   c. Read each scan.json
   d. Populate cache: counts[machineID] = N, scans[machineID] = [scan infos]
3. Also check output/exit_code for each found scan dir:
   - If exit_code file doesn't exist yet: scan is still running, count toward capacity
   - If exit_code file exists (grype finished): don't count toward capacity (will be collected by poller)
```

This takes a few seconds at most (one SSH session per builder, one `find` + `cat` per scan dir).

### Incremental maintenance

The poller updates the cache every 10 seconds as it processes scan results:

- **Scan completes** → poller removes it from `scans[machineID]`, decrements `counts[machineID]`, `rm -rf` the work dir
- **Scan still running** → stays in cache (count unchanged)
- **Builder disappeared** → poller removes all scans for that `machineID` from the cache (they'll be marked failed in the DB)

### Using the cache for builder selection

`SelectBuilderForScan` reads the cache to find builders under capacity:

```go
func (c *ScanCapacityCache) GetBuilderScanCount(machineID string) int {
    c.mu.RLock()
    defer c.mu.RUnlock()
    return c.counts[machineID]
}
```

The cache is maintained by the poller from filesystem scans, so it stays consistent with what has been observed. To avoid over-dispatching before the cache is populated, `InitScanCapacityCache` must complete before the `external_image_scan` handler processes any messages. This is enforced by startup ordering (see [Startup order](#startup-order-in-cmdclirungo)) — `InitScanCapacityCache` runs before listeners start, so the cache is always populated when the handler runs.

As a safety net, the handler also checks a `cache.IsReady()` flag. If the cache is not ready (e.g. init failed or is still in progress), the handler returns a normal error. The listener retries the message by setting `processing_started_at = NULL` and incrementing `attempt_count` (`pkg/listener/listener.go:480-486`), re-delivering it on the next 5-second poll cycle. Up to `MaxRetryAttempts = 5` retries are allowed before the message is discarded — more than enough for a cache init that takes seconds.

Builder VMs can be deleted out of band (e.g. CMX VM expiry, manual deletion, pool maintenance reaping). The poller detects this when a builder that was previously in the cache no longer appears in `machine_pool` or is unreachable via SSH. In both cases, the poller:
- Marks all in-flight scans for that builder as failed in `external_image_scan` (reason: "builder VM no longer exists")
- Removes all scan entries for that `machineID` from the cache
- The affected digests remain eligible for rescan by the scheduler

The cache never retains entries for builders that are gone — every poll cycle reconciles against the current `machine_pool` query.

## Builder Selection

### `SelectBuilderForScan`

```go
// SelectBuilderForScan finds a builder VM that can accept a new scan.
// Priority: idle builders first (no build assignments), then busy builders.
// Capacity rules:
//   - Idle builders (no machine_assignment rows): up to maxScansPerBuilder concurrent scans
//   - Busy builders (has machine_assignment rows): at most 1 concurrent scan
// Uses the in-memory ScanCapacityCache for scan counts.
func SelectBuilderForScan(ctx context.Context, cache *ScanCapacityCache) (*types.BuilderVM, error)
```

**Query strategy** — query running builders from `machine_pool`, ordered by idle-first, then filter by scan capacity using the in-memory cache:

```sql
SELECT mp.id, mp.ip_address, mp.port, mp.private_key, mp.username,
       mp.architecture, mp.type, mp.status, mp.created_at,
       EXISTS (SELECT 1 FROM machine_assignment ma WHERE ma.machine_id = mp.id) AS has_build_assignment
FROM machine_pool mp
WHERE mp.status = 'running'
  AND mp.cleanup_locked_at IS NULL
  AND mp.is_on_demand = false
ORDER BY
  -- Idle builders first (no build assignments), then busy builders
  CASE WHEN EXISTS (
    SELECT 1 FROM machine_assignment ma WHERE ma.machine_id = mp.id
  ) THEN 1 ELSE 0 END,
  -- Among same priority, oldest builder first
  mp.created_at ASC
```

In Go, after fetching the ordered list, iterate and pick the first builder where:
- If the builder is **idle** (no build assignment): `cache.GetBuilderScanCount(builder.ID) < maxScansPerBuilder`
- If the builder is **busy** (has build assignment): `cache.GetBuilderScanCount(builder.ID) < 1` (i.e. no scans running)

This satisfies requirements #1 (any existing builder), #3 (idle first, busy OK), and #4 (configurable capacity — idle builders get the full budget, busy builders are limited to 1 to avoid overloading a VM that's already compiling).

**Note:** We do **not** insert into `machine_assignment` for scans (requirement #2 — builders are not "assigned" to scans). The build cleanup loop (`cleanup.go`) and build VM selection (`tryTakeVMWithAssignment`) are completely unaffected — they query `machine_assignment`, which has no scan rows.

## Scan Dispatch Flow

### Step 1: Enqueue scan work

The scheduler and on-demand paths already enqueue `external_image_scan` work per digest. The payload stays per-digest — the handler dispatches **both architectures to the same builder**:

```json
{"digest": "<digest>"}
```

The scheduler (`processExternalImageScans`) changes to enqueue one work item per digest, instead of calling `ScanExternalImage` in-process. The payload is unchanged from the current format — only the handler behavior changes.

**Why both archs on the same builder:** This guarantees that all architectures for a digest are scanned together on one builder, simplifying capacity accounting (1 digest = 1 capacity unit) and ensuring consistent results. The handler launches grype for each architecture in parallel within the same work directory.

### Step 2: Handler — `HandleExternalImageScanOnBuilder`

New handler replaces the current `HandleExternalImageScan` logic. Registered with higher concurrency (e.g. `param.PoolSize * MaxScansPerBuilder`) since each handler just dispatches to a builder and returns quickly.

```
1. Parse payload: {digest}
2. Idempotency check: if external_image_scan already has status 'running' or 'succeeded'
   for this digest (all archs) and was scanned recently (4h), skip (return nil).
3. Load SBOMs from external_image_sbom WHERE digest=$1
   - If no SBOMs at all: mark scan status failed, return NonRetryableError
   - If only one architecture (e.g. only x86_64, no aarch64): scan only the
     architectures that have SBOMs. Missing architectures are normal for
     external images (e.g. single-arch images) — mark the missing arch's
     external_image_scan row as failed with "no SBOM for this architecture"
     and proceed with the archs that do have SBOMs.
4. SelectBuilderForScan(ctx, cache)
   - If no builder available: return normal error (listener retries the queue message)
5. Resolve work_dir on builder:
   - CMX/static: $HOME/scans/<digest>
   - local: os.TempDir()/securebuild/scans/<digest>
6. Create Runner for the builder VM
7. runner.MkdirAll(workDir)
8. Write scan.json metadata file:
   runner.WriteFile(workDir + "/scan.json", json.Marshal({digest, created_at, retry_count: 0}))
9. For each architecture (x86_64, aarch64):
   a. runner.MkdirAll(workDir + "/" + arch + "/output")
   b. runner.WriteFile(workDir + "/" + arch + "/sbom.json", sbomContent)
   c. Write initial exit_code absence (no file — grype hasn't finished yet)
   d. Launch grype via nohup, capturing the PID:
      nohup bash -c '
        cd <work_dir>/<arch>
        set -euo pipefail
        grype sbom:./sbom.json --output json > grype-scan.json 2> output/grype.stderr
        echo $? > output/exit_code
      ' > scan.log 2>&1 &
      echo $! > output/grype.pid
10. Update external_image_scan status to "running" for all archs of this digest
11. Increment in-memory cache: cache.AddScan(machineID, scanDirInfo{digest, workDir})
12. Return nil — queue message is marked as completed and removed from the work queue
```

**Queue message lifecycle — asynchronous dispatch:**

Unlike the current in-process scan (where the handler blocks until the scan completes and errors propagate to the queue), the builder-based handler returns immediately after launching grype. The queue message is marked as completed on successful dispatch. Scan failures are detected later by the poller and re-enqueued as a **new** work item.

- **Handler returns nil** → message completed, removed from queue. Grype runs asynchronously on the builder.
- **Handler returns NonRetryableError** → message completed with error, not retried (e.g. no SBOM exists).
- **Handler returns normal error** → message stays in queue, retried by listener (e.g. no builder available).
- **Poller detects scan failure** (builder deleted, grype exit code != 0, timeout) → poller re-enqueues a new `external_image_scan` work item for the digest, if retries remain (see below).

### Poller Retry Logic

`scan.json` includes a `retry_count` field (starts at 0). The poller increments it each time it re-enqueues a failed scan:

```
When a scan fails (builder deleted, grype non-zero exit, timeout):
1. Read retry_count from scan.json
2. If retry_count >= MaxScanRetryAttempts (e.g. 3):
   - Mark external_image_scan as failed (final, no more retries)
   - Clean up: rm -rf {work_dir} on builder (if possible)
   - Remove from in-memory cache
3. If retry_count < MaxScanRetryAttempts:
   - Update external_image_scan status to "queued" (eligible for scheduler/poller to pick up)
   - Clean up: rm -rf {work_dir} on builder (fresh directory will be created on retry)
   - Remove from in-memory cache
   - Enqueue new work item: persistence.EnqueueWork(ctx, "external_image_scan", {"digest": "<digest>"})
   - The next dispatch will create a fresh scan.json with retry_count incremented
```

**What counts as retryable vs. non-retryable:**

| Failure | Retryable? | Reason |
|---|---|---|
| Builder VM deleted mid-scan | Yes | Transient — scheduler will dispatch to a different builder |
| Builder unreachable (SSH timeout) | Yes | Transient — VM may recover or be reaped |
| Grype exit code != 0 | No | Likely a data/DB issue — re-running on the same SBOM gives the same result. Mark as failed. (Note: OOM-kill produces exit code 137, which is also non-retryable — same SBOM will OOM again.) |
| Missing architecture SBOM (no x86_64 or aarch64) | No | Image doesn't have that architecture — not a transient failure. Mark as failed for the missing arch only. |
| Timeout (grype still running after 10 min) | No | Grype is stuck (not killed — no exit code means process is alive). Kill the grype process, mark as failed. A stuck grype won't benefit from a retry on the same SBOM. |
| Grype JSON missing/unparseable | No | Data corruption — mark as failed |

**Grype command details:**

The grype CLI is already installed on every builder VM during `InstallBuildEnv` (`pkg/builder/pool.go:1294-1341`). The command scans an SBOM file (not a live image), so no registry access or Docker is needed:

```bash
grype sbom:./sbom.json --output json > grype-scan.json 2> output/grype.stderr
```

This uses grype's default vulnerability database (downloaded to `~/.cache/grype/db` on the builder). This matches the current behavior for external images (`NewGrypeScanner(ctx, false)` at `pkg/scan/scan.go:43`).

**Why grype CLI instead of the Go library?**

The Go library approach (`pkg/anchore/scanner.go`) loads the vulnerability DB into the worker process's memory. Running many concurrent scans in-process would require either multiple DB loads (expensive, ~1GB each) or sharing a single provider with locking (serialization). The CLI approach lets each scan run independently on a builder with its own DB cache, and the worker only needs to copy files and read results — no grype dependency in the worker process.

### Step 3: Status Poller — `StartExternalImageScanStatusChecker`

New poller, modeled after `StartBuildPackageStatusChecker` (`pkg/listener/update-build-package-status.go:38`) and `StartBuildImageStatusChecker` (`pkg/listener/update-build-image-status.go:40`):

```
Loop every 10 seconds:
1. Query running builders from machine_pool WHERE status = 'running'
2. For each builder:
   a. Create Runner (or reuse cached SSH connection for this builder)
   b. List scan directories: find $HOME/scans -name scan.json
   c. For each scan.json found:
      - Read scan.json → {digest, created_at}
      - For each arch subdirectory (x86_64/, aarch64/):
        - Check if {work_dir}/{arch}/output/exit_code exists
          - If file doesn't exist yet and created_at < 60s ago: skip (still starting)
          - If file doesn't exist and created_at > 60s ago: mark as failed (timeout)
          - If file exists: grype finished, read exit code
            - exit_code == "0": success
            - exit_code != "0": failed (capture exit code in error message)
        - If exit_code file doesn't exist: continue (still running, keep in cache)
        - If exit_code file exists (grype finished):
          - Read {work_dir}/{arch}/grype-scan.json
          - Read {work_dir}/{arch}/output/grype.stderr (tail 10KB)
          - If exit_code == 0:
            - Parse scan result via image.ParseScanResultDetails(scanJSON)
            - SetExternalImageScanStatus(digest, arch, succeeded, rawResult, ...)
            - UpdatePackageFixVersions (see below)
          - If exit_code != 0:
            - If retryable (timeout) and retries remain: set status to "queued", re-enqueue
            - If non-retryable (grype data error) or retries exhausted:
              SetExternalImageScanStatus(digest, arch, failed, message=stderr)
          - Update last_security_scanned_at on external_image_sbom for this arch
      - Only after ALL arch subdirectories are complete:
        - Clean up: rm -rf {work_dir} on builder
        - Update in-memory cache: cache.RemoveScan(machineID, digest)
3. Handle builders that disappeared (were in cache but no longer in machine_pool):
   - For each scan in cache for a missing builder:
     - Read retry_count from scan.json
     - If retries remain: set external_image_scan status to "queued",
       re-enqueue new external_image_scan work item
     - If retries exhausted: mark external_image_scan as failed
     - Remove from cache (work dir is gone with the VM — nothing to clean up)
```

**Timeout handling:** If a scan's `created_at` (from `scan.json`) is older than a configurable timeout (e.g. 10 minutes) and no `exit_code` file exists yet, the grype process is still running. The poller kills it before cleaning up:

```
1. Read {work_dir}/{arch}/output/grype.pid
2. SSH to builder, verify the PID is actually a grype process:
   ps -p <pid> -o comm= | grep -q grype
   - If the PID doesn't exist or the process name isn't grype (PID was reused):
     skip the kill — grype already exited (maybe wrote exit_code between poll cycles)
   - If the process is grype: kill <pid>, then kill -9 <pid> after 5s if still alive
3. Mark external_image_scan as failed for that arch ("scan timed out after 10 minutes")
4. Proceed with cleanup (rm -rf work dir, update cache)
```

This prevents zombie grype processes from lingering on the builder. The timeout is non-retryable — a stuck grype will get stuck again on the same SBOM.

**APK fix-version update:** The current in-process scan also calls `security.UpdatePackageFixVersions` for APK packages (`pkg/scan/scan.go:81-97`). This requires parsing the SBOM in the worker. Since the worker already reads the grype JSON result, it can also read the SBOM (already in the DB via `external_image_sbom.sbom`) and run `UpdatePackageFixVersions` locally. This is a lightweight DB operation and doesn't need to run on the builder.

### Step 4: Cleanup

Scan cleanup is **lightweight** and handled by the poller itself (not the `builder.StartVMCleanup` loop):

1. When a scan completes (success or failure), the poller:
   - Deletes the work directory on the builder via `runner.RunCommand("rm -rf <work_dir>")`
   - Removes the scan from the in-memory cache
2. The builder VM is **never** deleted or recycled (requirement #2). It stays in `machine_pool` and remains available for builds.

The `builder.StartVMCleanup` loop (`pkg/builder/cleanup.go`) is **not modified** — it only queries `machine_assignment` rows for `build_package` and `build_image` task types. Scan work directories are cleaned by the scan poller. If a CMX builder is eventually recycled after a build, any leftover scan directories are destroyed with the VM — no leak.

## Worker Restart Recovery (Requirement #5)

There is no active monitor process for scans and no DB tracking table to migrate. State is entirely on the builder filesystem. On worker restart:

### `InitScanCapacityCache` (called at startup)

```
1. Query all running builders from machine_pool WHERE status = 'running'
2. For each builder:
   a. SSH to builder
   b. Find scan.json files: find $HOME/scans -name scan.json
    c. For each scan.json:
       - Read scan.json → {digest, created_at}
       - Read output/exit_code
       - If no exit_code file: scan still running, add to in-memory cache (counts toward capacity)
       - If exit_code file exists: scan finished, leave for the poller to collect on first iteration
            (don't count toward capacity — it's already done)
   d. If builder is unreachable: skip (poller will retry, or builder will be reaped by pool maintenance)
3. Start the poller loop — it will:
   - Collect any completed scans found during init
   - Continue polling active scans
   - Maintain the cache incrementally from here on
```

Because grype runs as a `nohup` background process on the builder, a worker restart does **not** kill in-flight scans. The poller simply resumes checking for `exit_code` files from the builders. This is the same pattern used by package builds (`update-build-package-status.go`).

### Startup order (in `cmd/cli/run.go`)

The `external_image_scan` listener must not process messages until the cache is populated. Startup ordering guarantees this:

```go
// 1. Initialize scan capacity cache from builder filesystem (blocks until complete)
scanCache, err := scan.InitScanCapacityCache(ctx)
if err != nil {
    logger.Error(...)
}

// 2. Start scan status poller (uses scanCache)
go func() {
    if err := listener.StartExternalImageScanStatusChecker(ctx, scanCache); err != nil {
        logger.Error(...)
    }
}()

// 3. Start listeners (existing code) — the external_image_scan handler
//    receives scanCache and uses cache.IsReady() as a safety net
listener.StartListeners(ctx)
```

Because `InitScanCapacityCache` is synchronous and runs before `StartListeners`, the cache is always populated by the time the handler processes its first message. The `cache.IsReady()` check in the handler is a defensive guard for edge cases (e.g. init partially failed).

The `external_image_scan` listener handler is given a reference to `scanCache` for builder selection.

## Files to Create

| File | Purpose |
|---|---|
| `pkg/scan/scan_capacity.go` | `ScanCapacityCache` struct, `InitScanCapacityCache`, `AddScan`, `RemoveScan`, `GetBuilderScanCount`, `GetScansForBuilder` |
| `pkg/listener/external-image-scan-builder.go` | `HandleExternalImageScanOnBuilder` — dispatch scan to builder |
| `pkg/listener/update-external-image-scan-status.go` | `StartExternalImageScanStatusChecker` — poller loop |

## Files to Modify

| File | Change |
|---|---|
| `pkg/param/param.go` | Add `MaxScansPerBuilder` field |
| `pkg/scan/scan.go` | Change `processExternalImageScans` to enqueue per-digest work items instead of calling `ScanExternalImage` in-process |
| `pkg/listener/start.go` | Change `external_image_scan` handler to call `HandleExternalImageScanOnBuilder`; increase `maxWorkers`; add `StartExternalImageScanStatusChecker`; pass `scanCache` to handler |
| `pkg/listener/external-image-sbom.go` | `RunScanForDigest` changes to enqueue per-digest scan work items instead of calling `ScanExternalImage` |
| `cmd/cli/run.go` | Call `scan.InitScanCapacityCache` at startup; start scan status poller |
| `securebuild-config.yaml`, `config-cmx.yaml` | Add `max_scans_per_builder: 3` |

## What Gets Removed / Deprecated

| Component | Fate |
|---|---|
| `pkg/anchore/scanner.go` (`GrypeScanner`, `ScanSBOMForCVEs`) | **Keep** — still used by catalog image scans (`scanCatalogImageSBOMs`) which run in-process and use the custom DB. Only external image scans move to builders. |
| `pkg/scan/scan.go` `ScanExternalImage` | **Remove** — replaced by builder dispatch. The in-process grype library call is no longer used for external images. |
| `pkg/scan/scheduler.go` `processExternalImageScans` in-process loop | **Modify** — still selects digests to scan, but enqueues work items instead of scanning directly. The tight loop can remain (it just enqueues, which is fast). |

## Capacity Analysis

With the default configuration:

- `PoolSize` = N builders per architecture (e.g. 4)
- `MaxScansPerBuilder` = 3 (default) — counts **digests**, not (digest, arch) pairs. Applies to idle builders; busy builders limited to 1
- If all builders are idle: N × 3 = 12 concurrent digest scans (with 4 builders)
- If all builders are busy with builds: N × 1 = 4 concurrent digest scans (still better than 2 today)
- Mixed (2 idle, 2 busy): 2×3 + 2×1 = 8 concurrent digest scans

Each digest scan runs grype for both architectures in parallel on the same builder. Each grype run is CPU-bound but lightweight (typically 10-60 seconds). This is much less resource-intensive than a package build (which runs melange with bubblewrap, compilation, etc.), so running 3 digest scans (6 grype processes) concurrently on an idle builder is feasible.

The handler concurrency (`maxWorkers` for the `external_image_scan` channel) should be set to `PoolSize * MaxScansPerBuilder` to allow dispatching up to that many scans before backpressure. If no builder is available, the handler returns an error and the listener retries with backoff.

## Edge Cases

1. **No builders available:** `SelectBuilderForScan` returns an error. The listener handler returns a retryable error, and the work item is retried after backoff. This is the same behavior as `TakeVMWithAssignment` for builds.

2. **Builder disappears mid-scan (CMX VM expired/deleted):** The poller's SSH read fails. The builder is no longer in `machine_pool` (pool maintenance reaps expired VMs). The poller detects the missing builder, reads `retry_count` from `scan.json` (if the VM was reachable before deletion), and re-enqueues a new `external_image_scan` work item if retries remain. If the VM is completely unreachable, the poller relies on the in-memory cache's copy of `retry_count`. The digest's `external_image_scan` status is set back to `queued` so the scheduler or the new work item can dispatch it to a different builder.

   **Note on losing `retry_count`:** If a builder is deleted out of band, `scan.json` (including `retry_count`) is lost with it. The re-enqueued work item starts with `retry_count: 0`, effectively resetting the retry counter. This is acceptable because idle builders remain in the pool for ~48 hours before being recycled — builder deletion during an active scan is rare. Losing a retry count once in 48 hours is not a concern; the scan will simply get its full retry budget back and re-attempt on a fresh builder.

3. **Grype DB not present on builder:** Grype CLI auto-downloads the DB on first run. If the builder has no internet access, the scan fails with a clear error in `grype.stderr`. The poller captures this and marks the scan as failed. `InstallBuildEnv` already installs grype, and the DB download happens automatically.

4. **Duplicate scans:** If the same digest is enqueued twice (e.g. scheduler + on-demand), the `external_image_scan` table has a primary key on `(digest, arch)`. The handler checks if status is already `running` for any arch of this digest before dispatching. The existing `WasScannedRecently` check (`external-image-sbom.go:303`) provides a 4-hour idempotency window.

5. **Partial architecture failure:** Both architectures run on the same builder in parallel. If x86_64 succeeds but aarch64 fails, each is tracked independently in `external_image_scan` (which has `(digest, arch)` primary key). The poller stores each arch's result as it completes, but only cleans up the scan directory (and frees capacity) once **all** archs are done.

6. **Worker crash during dispatch:** If the worker crashes after launching grype on the builder but before incrementing the in-memory cache, the grype processes run to completion and write `scan.json` + per-arch `output/exit_code`. On restart, `InitScanCapacityCache` discovers the scan directory (keyed by `<digest>`). The poller collects results on its first iteration. No data loss — the filesystem is the source of truth.

7. **Orphaned scan directories:** If a scan directory exists on a builder but the corresponding `external_image_scan` row was deleted (e.g. image removed from tracking), the poller reads `scan.json`, tries to update `external_image_scan`, gets a no-op or error, and still cleans up the directory. Orphaned directories don't accumulate.

## Decisions

1. **No `builder-cmd/cli/scan.go` subcommand.** The raw shell approach (nohup + grype CLI) is sufficient. No builder binary needed for scans.

2. **Scheduler backpressure.** The scheduler checks the total in-memory scan count across all builders before enqueuing. Only enqueue if the count is below `PoolSize * MaxScansPerBuilder`. This provides natural backpressure without a DB query.

3. **Use the default grype DB on builders.** No custom DB. The default DB auto-download behavior is preserved.

4. **No SSH connection caching needed.** With ~24 builders, the number of SSH connections is not a concern. The poller opens a connection per builder per cycle, runs all commands, and closes it. Ensure connections are properly closed after each use (no leaks). On network error (SSH timeout, connection refused, broken pipe), the poller retries the connection with backoff (e.g. 3 attempts with 2s/4s/8s delays) before treating the builder as unreachable. This handles transient network blips without false-positive scan failures.
