### PR TITLE
Include stale images for scan scheduling

### DIFF
--- a/pkg/listener/external-image-scan-builder.go
+++ b/pkg/listener/external-image-scan-builder.go
@@ -383,15 +383,22 @@ func storeBuilderScanResult(ctx context.Context, digest, arch, scanResult string
 }
 
 // isScanAlreadyRunning checks if any external_image_scan row for the digest
-// has status 'running'. This prevents duplicate dispatch when the scheduler
-// enqueues multiple work items before the first handler sets the status.
+// has a recent 'running' status. This prevents duplicate dispatch when the
+// scheduler enqueues multiple work items before the first handler sets the
+// status. Stale 'running' rows (older than scan.ScanStalenessThreshold) are
+// ignored so that orphaned scans from crashed workers or disappeared builders
+// can be recovered by a new dispatch.
 func isScanAlreadyRunning(ctx context.Context, digest string) bool {
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
+	staleThreshold := fmt.Sprintf("%d minutes", int(scan.ScanStalenessThreshold.Minutes()))
+
 	var count int
 	err := conn.QueryRow(ctx,
-		`SELECT COUNT(*) FROM external_image_scan WHERE digest = $1 AND status = 'running'`,
+		`SELECT COUNT(*) FROM external_image_scan
+		 WHERE digest = $1 AND status = 'running'
+		   AND scan_status_updated_at > NOW() - interval '`+staleThreshold+`'`,
 		digest).Scan(&count)
 	if err != nil {
 		logger.Warn("failed to check if scan is already running, proceeding",
@@ -402,20 +409,41 @@ func isScanAlreadyRunning(ctx context.Context, digest string) bool {
 	return count > 0
 }
 
-// claimScanForDispatch atomically transitions scan rows from "queued" to
-// "running" for the given digest and architectures. Returns (true, nil) if at
-// least one row was claimed, (false, nil) if another handler already claimed
-// it, or (false, err) if the claim failed due to a database error. On DB
-// error, the caller returns the error so the listener retries the message
-// instead of dispatching without a durable claim.
+// claimScanForDispatch atomically transitions scan rows to "running" for the
+// given digest and architectures. This handles:
+//   - First scans: rows in "queued" status
+//   - Re-scans: rows in "succeeded" or "failed" status from a previous scan
+//   - Stale recovery: rows in "running" status older than ScanStalenessThreshold
+//     (orphaned by crashed workers or disappeared builders)
+//
+// Recent "running" rows are excluded so we don't double-dispatch a scan that's
+// genuinely in flight. The isScanAlreadyRunning check above provides a fast
+// path to discard duplicates before reaching this query.
+//
+// Previous scan results (parsed_results, raw_result, scan_completed_at) are
+// NOT cleared here. They remain in the row until the new scan completes and
+// overwrites them. If the dispatch fails and reverts to "queued", the prior
+// results are preserved so the API can still serve the last successful scan
+// while waiting for the retry.
+//
+// Returns (true, nil) if at least one row was claimed, (false, nil) if another
+// handler already claimed it, or (false, err) if the claim failed due to a
+// database error. On DB error, the caller returns the error so the listener
+// retries the message instead of dispatching without a durable claim.
 func claimScanForDispatch(ctx context.Context, digest string, archs []string) (bool, error) {
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
+	staleThreshold := fmt.Sprintf("%d minutes", int(scan.ScanStalenessThreshold.Minutes()))
+
 	tag, err := conn.Exec(ctx,
 		`UPDATE external_image_scan
-		 SET status = 'running', scan_status_updated_at = NOW(), scan_attempted_at = COALESCE(scan_attempted_at, NOW())
-		 WHERE digest = $1 AND arch = ANY($2::text[]) AND status = 'queued'`,
+		 SET status = 'running',
+		     scan_status_updated_at = NOW(),
+		     scan_status_message = NULL,
+		     scan_attempted_at = COALESCE(scan_attempted_at, NOW())
+		 WHERE digest = $1 AND arch = ANY($2::text[])
+		   AND (status != 'running' OR scan_status_updated_at <= NOW() - interval '`+staleThreshold+`')`,
 		digest, archs)
 	if err != nil {
 		return false, fmt.Errorf("failed to claim scan rows: %w", err)

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -238,6 +238,13 @@ var scanTiers = []scanTier{
 	{name: "stale", submittedAfter: "90 days", submittedBefore: "30 days", rescanInterval: "7 days"},
 }
 
+// ScanStalenessThreshold is how old a 'queued' or 'running' scan row must be
+// before the scheduler considers it stale and re-selects the digest. This
+// handles rows orphaned by lost queue messages, worker crashes, or builder
+// disappearances. Must be longer than ScanTimeout (10 min) + poller interval
+// (10 s) to avoid re-enqueueing scans that are still legitimately in flight.
+const ScanStalenessThreshold = 1 * time.Hour
+
 // SelectExternalImageDigestsToScan returns a prioritized list of external image digests to scan.
 //
 // Priority order:
@@ -263,11 +270,23 @@ func SelectExternalImageDigestsToScan(ctx context.Context, maxToProcess int) ([]
 	selectedDigests := make([]string, 0, maxToProcess)
 	seen := map[string]struct{}{}
 
-	// Tier 1: Digests with SBOMs but no scans yet (first scan, highest priority)
+	// Tier 1: Digests with SBOMs but no scans yet (first scan, highest priority).
+	// Exclude digests that have a recent scan in 'running' or 'queued' status
+	// so the scheduler doesn't re-enqueue digests that are already in flight.
+	// Stale rows (older than ScanStalenessThreshold) are ignored so that
+	// orphaned queue messages or crashed workers don't permanently block a
+	// digest from being scanned.
+	staleThreshold := fmt.Sprintf("%d minutes", int(ScanStalenessThreshold.Minutes()))
 	rows, err := conn.Query(ctx, `
 		SELECT s.digest
 		FROM external_image_sbom s
 		WHERE s.last_security_scanned_at IS NULL
+		  AND NOT EXISTS (
+		    SELECT 1 FROM external_image_scan sc
+		    WHERE sc.digest = s.digest
+		      AND sc.status IN ('running', 'queued')
+		      AND sc.scan_status_updated_at > NOW() - interval '`+staleThreshold+`'
+		  )
 		GROUP BY s.digest
 		ORDER BY random()
 		LIMIT $1
@@ -307,10 +326,16 @@ func SelectExternalImageDigestsToScan(ctx context.Context, maxToProcess int) ([]
 			JOIN tier_tags t ON t.digest = s.digest
 			WHERE s.last_security_scanned_at IS NOT NULL
 			  AND s.last_security_scanned_at < $2::timestamptz - interval '%s'
+			  AND NOT EXISTS (
+			    SELECT 1 FROM external_image_scan sc
+			    WHERE sc.digest = s.digest
+			      AND sc.status IN ('running', 'queued')
+			      AND sc.scan_status_updated_at > NOW() - interval '%s'
+			  )
 			GROUP BY s.digest
 			ORDER BY random()
 			LIMIT $1
-		`, tier.submittedAfter, tier.submittedBefore, tier.rescanInterval)
+		`, tier.submittedAfter, tier.submittedBefore, tier.rescanInterval, staleThreshold)
 
 		rows, err := conn.Query(ctx, query, remaining, referenceTime)
 		if err != nil {


### PR DESCRIPTION
# External Image Scan Throughput Fix

## Problem

After deploying the distributed external image scan feature, throughput was extremely low: only a small number of scans dispatched over 30 minutes despite having many running builders with significant concurrent scan capacity. Only a few builders were utilized, and only first-time scans (tier-1) ever dispatched — zero re-scans completed.

## Root Causes

### 1. Scheduler re-enqueued in-flight digests every 5 seconds

`SelectExternalImageDigestsToScan` selected digests based on `last_security_scanned_at` being NULL (tier-1) or older than the rescan interval (tiers 2-4). However, `last_security_scanned_at` is only updated when a scan **completes** (~2 minutes after dispatch). During those 2 minutes, the scheduler re-selected the same digests every 5 seconds, generating a large volume of duplicate work items.

These duplicates were discarded by `isScanAlreadyRunning` and `claimScanForDispatch`, but each discard still consumed a listener worker. The vast majority of listener capacity was wasted processing discards instead of dispatching real scans.

### 2. `claimScanForDispatch` only claimed `queued` rows, blocking re-scans

The claim query used `WHERE status = 'queued'`, which only works for first-time scans (where `InitializeScanStatusQueued` creates rows with `queued` status). For re-scans, the scan rows were in `succeeded` or `failed` status from the previous scan cycle, and `InitializeScanStatusQueued` only resets rows from `unknown`/`pending_sbom`/`generating_sbom` — never from `succeeded`/`failed`.

As a result, every re-scan work item had its claim match 0 rows, returning `false` ("already claimed by another handler"), and the scan was never dispatched. Only never-scanned tier-1 digests ever dispatched — they were the only ones with `queued` rows.

## Fixes

### Fix 1: Exclude in-flight digests from scheduler selection

Added `NOT EXISTS (SELECT 1 FROM external_image_scan sc WHERE sc.digest = s.digest AND sc.status IN ('running', 'queued'))` to both the tier-1 and tier 2-4 selection queries in `SelectExternalImageDigestsToScan`.

This ensures the scheduler only selects digests that don't already have a scan in progress, so each 5-second cycle enqueues genuinely new work instead of duplicates.

**File:** `pkg/scan/scan.go` — `SelectExternalImageDigestsToScan`

### Fix 2: Claim any non-running scan row

Changed `claimScanForDispatch` from `WHERE status = 'queued'` to `WHERE status != 'running'`, so it claims rows in any non-running status (`queued`, `succeeded`, `failed`). Also clears previous scan results (`scan_completed_at`, `parsed_results`, `parsed_results_details`, `raw_result`, `scan_status_message`) since a fresh scan is starting.

The `isScanAlreadyRunning` check before the claim still prevents double-dispatch of running scans.

**File:** `pkg/listener/external-image-scan-builder.go` — `claimScanForDispatch`

## How the fixes work together

| Component | Without fix | With fix |
|---|---|---|
| **Scheduler selection** | Re-selects running digests every 5s → flood of duplicate work items | Only selects digests with no running/queued scan rows |
| **Claim** | Only claims `queued` rows → re-scans never dispatch | Claims any non-running row → re-scans dispatch correctly |
| **Listener workers** | Wasted processing discards | Process real dispatches |
