### PR TITLE
Don't log noise when scanner is at capacity

### DIFF
--- a/pkg/listener/external-image-scan-builder.go
+++ b/pkg/listener/external-image-scan-builder.go
@@ -144,7 +144,13 @@ func HandleExternalImageScanOnBuilder(ctx context.Context, payloadJSON string) e
 	// re-enqueues when capacity frees up.
 	dispatchErr := dispatchScanToBuilder(ctx, cache, p.Digest, sbomByArch, archsToScan)
 	if dispatchErr != nil {
-		revertScanToQueued(ctx, p.Digest, archsToScan)
+		if revertErr := revertScanToQueued(ctx, p.Digest, archsToScan); revertErr != nil {
+			// Revert failed — return the revert error so the listener retries
+			// the message instead of acking it. Without this, the scan row
+			// stays "running" with no builder work directory until the 1-hour
+			// staleness window expires.
+			return fmt.Errorf("dispatch failed (%v) and revert also failed: %w", dispatchErr, revertErr)
+		}
 		if errors.Is(dispatchErr, scan.ErrNoBuilderAvailable) {
 			logger.Info("no builder available for scan, will retry on next scheduler cycle",
 				zap.String("digest", p.Digest))
@@ -451,7 +457,7 @@ func claimScanForDispatch(ctx context.Context, digest string, archs []string) (b
 // after a failed dispatch. This allows the listener retry to re-dispatch
 // the scan to a different builder. Without this, the scan would stay
 // "running" forever with no builder work directory for the poller to find.
-func revertScanToQueued(ctx context.Context, digest string, archs []string) {
+func revertScanToQueued(ctx context.Context, digest string, archs []string) error {
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
@@ -461,8 +467,7 @@ func revertScanToQueued(ctx context.Context, digest string, archs []string) {
 		 WHERE digest = $1 AND arch = ANY($2::text[]) AND status = 'running'`,
 		digest, archs)
 	if err != nil {
-		logger.Warn("failed to revert scan status to queued after dispatch failure",
-			zap.String("digest", digest),
-			zap.Error(err))
+		return fmt.Errorf("failed to revert scan status to queued: %w", err)
 	}
+	return nil
 }

--- a/pkg/listener/external-image-scan-builder.go
+++ b/pkg/listener/external-image-scan-builder.go
@@ -3,6 +3,7 @@ package listener
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -132,7 +133,8 @@ func HandleExternalImageScanOnBuilder(ctx context.Context, payloadJSON string) e
 	}
 
 	// Atomically claim the scan: set status to "running" for archs that are
-	// still "queued". If 0 rows are updated, another handler already claimed it.
+	// not already running. If 0 rows are updated, another handler already
+	// claimed it.
 	claimed, claimErr := claimScanForDispatch(ctx, p.Digest, archsToScan)
 	if claimErr != nil {
 		// DB error during claim — return error so the listener retries.
@@ -145,20 +147,28 @@ func HandleExternalImageScanOnBuilder(ctx context.Context, payloadJSON string) e
 	}
 
 	// If dispatch fails after the claim, revert the scan status to "queued"
-	// so the listener retry can re-dispatch. Otherwise the scan would stay
-	// "running" forever with no builder work directory for the poller to find.
+	// so the scheduler can re-enqueue on the next cycle. A "no builder
+	// available" failure is not an error — it's a normal capacity condition
+	// that happens when all builders are full. We return nil so the message
+	// is cleanly completed (not retried by the listener) and the scheduler
+	// re-enqueues when capacity frees up.
 	dispatchErr := dispatchScanToBuilder(ctx, cache, p.Digest, sbomByArch, archsToScan)
 	if dispatchErr != nil {
 		revertScanToQueued(ctx, p.Digest, archsToScan)
+		if errors.Is(dispatchErr, scan.ErrNoBuilderAvailable) {
+			logger.Info("no builder available for scan, will retry on next scheduler cycle",
+				zap.String("digest", p.Digest))
+			return nil
+		}
 		return dispatchErr
 	}
 
 	return nil
 }
 
-// dispatchScanToBuilder handles the actual builder selection, file copy, and
-// grype launch. It reserves a capacity slot atomically and releases it if
-// any step fails before the scan is fully launched.
+// dispatchScanToBuilder handles builder selection, file copy, and grype launch.
+// It reserves a capacity slot atomically and releases it if any step fails
+// before the scan is fully launched.
 //
 // The dispatch is split into two phases:
 //  1. Prepare all files (dirs, scan.json, sbom.json per arch) — if any step
@@ -169,7 +179,7 @@ func HandleExternalImageScanOnBuilder(ctx context.Context, payloadJSON string) e
 func dispatchScanToBuilder(ctx context.Context, cache *scan.ScanCapacityCache, digest string, sbomByArch map[string]string, archsToScan []string) error {
 	builderVM, err := scan.SelectBuilderForScan(ctx, cache, digest)
 	if err != nil {
-		return fmt.Errorf("no builder available for scan: %w", err)
+		return fmt.Errorf("failed to select builder for scan: %w", err)
 	}
 
 	// SelectBuilderForScan already reserved a capacity slot and added a

--- a/pkg/listener/external-image-scan-builder.go
+++ b/pkg/listener/external-image-scan-builder.go
@@ -113,19 +113,9 @@ func HandleExternalImageScanOnBuilder(ctx context.Context, payloadJSON string) e
 	for _, arch := range expectedArchs {
 		if _, hasSBOM := sbomByArch[arch]; hasSBOM {
 			archsToScan = append(archsToScan, arch)
-		} else {
-			if err := externalimage.SetExternalImageScanStatus(ctx, externalimage.SetExternalImageScanStatusParams{
-				Digest:            p.Digest,
-				Arch:              arch,
-				Status:            externalimage.ScanStatusFailed,
-				ScanStatusMessage: "no SBOM for this architecture",
-			}); err != nil {
-				logger.Warn("failed to set scan status to failed for missing arch SBOM",
-					zap.String("digest", p.Digest),
-					zap.String("arch", arch),
-					zap.Error(err))
-			}
 		}
+		// Archs without SBOMs are silently skipped — images are not required
+		// to have both architectures. No scan status row is written for them.
 	}
 
 	if len(archsToScan) == 0 {

--- a/pkg/listener/external-image-scan-builder.go
+++ b/pkg/listener/external-image-scan-builder.go
@@ -167,18 +167,19 @@ func HandleExternalImageScanOnBuilder(ctx context.Context, payloadJSON string) e
 //     grype processes are killed before returning, preventing orphaned
 //     processes that would race with a retry on a different builder.
 func dispatchScanToBuilder(ctx context.Context, cache *scan.ScanCapacityCache, digest string, sbomByArch map[string]string, archsToScan []string) error {
-	builderVM, err := scan.SelectBuilderForScan(ctx, cache, digest)
+	builderVM, err := scan.SelectBuilderForScan(ctx, cache)
 	if err != nil {
 		return fmt.Errorf("failed to select builder for scan: %w", err)
 	}
 
-	// SelectBuilderForScan already reserved a capacity slot and added a
-	// placeholder to the scans map. If we fail before calling AddScan to
-	// fill in the full metadata, release the slot and remove the placeholder.
+	// SelectBuilderForScan reserved a capacity slot. If we fail before the
+	// scan files are written to the builder, release the slot. The poller
+	// will resync the cache on the next cycle anyway, but this avoids
+	// temporarily over-counting.
 	slotReserved := true
 	defer func() {
 		if slotReserved {
-			cache.ReleaseScanSlot(builderVM.ID, digest)
+			cache.ReleaseScanSlot(builderVM.ID)
 		}
 	}()
 
@@ -235,14 +236,9 @@ func dispatchScanToBuilder(ctx context.Context, cache *scan.ScanCapacityCache, d
 			zap.String("workDir", workDir))
 	}
 
-	// Scan successfully launched. AddScan records the scan metadata and
-	// keeps the reserved slot. The deferred ReleaseScanSlot is prevented
-	// by setting slotReserved to false.
-	cache.AddScan(builderVM.ID, scan.ScanDirInfo{
-		Digest:    digest,
-		WorkDir:   workDir,
-		CreatedAt: metadata.CreatedAt,
-	})
+	// Scan successfully launched. The poller will discover the scan dir
+	// on the next cycle and add it to the cache via SetBuilderScans. Keep
+	// the reserved slot counted until then.
 	slotReserved = false
 
 	logger.Info("dispatched external image scan to builder",

--- a/pkg/listener/update-external-image-scan-status.go
+++ b/pkg/listener/update-external-image-scan-status.go
@@ -100,27 +100,22 @@ func processBuilderScans(ctx context.Context, cache *scan.ScanCapacityCache, vm 
 		return
 	}
 
-	// Reconcile cache with discovered scan dirs. If a scan dir is still
-	// running (not all archs done) but not tracked in the cache (e.g. it
-	// was missed during InitScanCapacityCache because the builder was
-	// unreachable at startup), add it so capacity tracking is accurate
-	// and missing-builder recovery can re-enqueue it if the VM disappears.
-	cachedDigests := make(map[string]bool)
-	for _, info := range cache.GetScansForBuilder(vm.ID) {
-		cachedDigests[info.Digest] = true
-	}
+	// Resync the cache for this builder with what's actually on the
+	// filesystem. This replaces all entries (including leaked placeholders
+	// and stale scans) with the current set of active scan dirs. Only
+	// scans that are still in progress (not all archs done) are counted
+	// toward capacity.
+	activeScans := make([]scan.ScanDirInfo, 0)
 	for _, sd := range scanDirs {
-		if sd.Metadata.Digest != "" && !sd.AllArchsDone && !cachedDigests[sd.Metadata.Digest] {
-			cache.AddScanWithCount(vm.ID, scan.ScanDirInfo{
+		if sd.Metadata.Digest != "" && !sd.AllArchsDone {
+			activeScans = append(activeScans, scan.ScanDirInfo{
 				Digest:    sd.Metadata.Digest,
 				WorkDir:   sd.WorkDir,
 				CreatedAt: sd.Metadata.CreatedAt,
 			})
-			logger.Info("added discovered scan to cache during poll",
-				zap.String("digest", sd.Metadata.Digest),
-				zap.String("machineID", vm.ID))
 		}
 	}
+	cache.SetBuilderScans(vm.ID, activeScans)
 
 	for _, sd := range scanDirs {
 		processScanDir(ctx, cache, vm, runner, sd)

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -84,14 +85,16 @@ func FetchSBOM(ctx context.Context, registry string, imageName string, digest st
 	for _, platform := range architectures {
 		sbom, imageSize, imageDigest, err := generateSBOMWithSyft(ctx, registry, imageName, digest, auth, isAnonDockerHub, platform)
 		if err != nil {
-			// Only log errors that are not platform mismatches
-			if !isPlatformMismatchError(err) {
-				logger.Warn("failed to generate SBOM with syft",
+			if strings.Contains(err.Error(), "does not match user specified platform") {
+				logger.Info("no SBOM for architecture, skipping",
 					zap.String("imageName", imageName),
 					zap.String("digest", digest),
-					zap.String("platform", platform), zap.Error(err))
+					zap.String("platform", platform))
+				continue
 			}
-			continue
+			logger.Errorf("failed to generate SBOM, aborting: %s (imageName: %s, digest: %s, platform: %s)",
+				err, imageName, digest, platform)
+			return nil, err
 		}
 
 		if sbom != "" {
@@ -116,7 +119,7 @@ func FetchSBOM(ctx context.Context, registry string, imageName string, digest st
 	return results, nil
 }
 
-func generateSBOMWithSyft(ctx context.Context, registry string, imageName string, digest string, auth authn.Authenticator, isAnonDockerHub bool, platform string) (string, int64, string, error) {
+func generateSBOMWithSyft(ctx context.Context, registry string, imageName string, digest string, auth authn.Authenticator, isAnonDockerHub bool, platform string) (sbom string, imageSizeBytes int64, imageDigest string, err error) {
 	logger.Info("generating SBOM with syft", zap.String("imageRef", registry+"/"+imageName+"@"+digest), zap.String("platform", platform))
 
 	// Create a timeout context for syft execution (syft can take a while)
@@ -238,25 +241,17 @@ func generateSBOMWithSyft(ctx context.Context, registry string, imageName string
 	cmd.Env = env
 
 	// Capture both stdout and stderr
-	var stdout, stderr bytes.Buffer
+	var stdout, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd.Stderr = &stderrBuf
 
 	logger.Debug("executing syft command", zap.String("command", cmd.String()))
 
 	// Execute the command
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
-		stderrStr := stderr.String()
-		stdoutStr := stdout.String()
-		if !isPlatformMismatchString(stderrStr) {
-			logger.Warn("syft generation failed for image",
-				zap.String("imageName", imageName),
-				zap.String("digest", digest),
-				zap.Error(err),
-				zap.String("stderr", stderrStr),
-				zap.String("stdout", stdoutStr),
-			)
+		if stderrStr := stderrBuf.String(); stderrStr != "" {
+			return "", 0, "", fmt.Errorf("syft generation failed for image %s@%s: %w", imageName, digest, errors.New(stderrStr))
 		}
 		return "", 0, "", fmt.Errorf("syft generation failed for image %s@%s: %w", imageName, digest, err)
 	}
@@ -264,30 +259,18 @@ func generateSBOMWithSyft(ctx context.Context, registry string, imageName string
 	// Read SBOM from spdx-json output file
 	spdxBytes, readErr := os.ReadFile(spdxPath)
 	if readErr != nil {
-		imageRef := registry + "/" + imageName + "@" + digest
-		logger.Warn("failed to read spdx-json output from syft", zap.String("imageRef", imageRef), zap.Error(readErr))
 		return "", 0, "", fmt.Errorf("failed to read spdx-json output: %w", readErr)
 	}
 
 	// Validate that it's valid JSON
 	var sbomData interface{}
 	if err := json.Unmarshal(spdxBytes, &sbomData); err != nil {
-		logger.Warn("syft output is not valid JSON", zap.Error(err))
 		return "", 0, "", fmt.Errorf("syft produced invalid JSON: %w", err)
 	}
 
-	imageRef := registry + "/" + imageName + "@" + digest
-	logger.Info("successfully generated SBOM with syft",
-		zap.String("imageRef", imageRef),
-		zap.Int("size", len(spdxBytes)))
-
 	// Read syft-json output to extract image size and image digest
-	var imageSizeBytes int64
-	var imageDigest string
 	syftBytes, readSyftErr := os.ReadFile(syftPath)
-	if readSyftErr != nil {
-		logger.Warn("failed to read syft-json output from syft", zap.Error(readSyftErr))
-	} else {
+	if readSyftErr == nil {
 		type syftJSONMetadata struct {
 			Source struct {
 				Metadata struct {
@@ -297,16 +280,9 @@ func generateSBOMWithSyft(ctx context.Context, registry string, imageName string
 			} `json:"source"`
 		}
 		var sj syftJSONMetadata
-		if err := json.Unmarshal(syftBytes, &sj); err != nil {
-			logger.Warn("failed to parse syft JSON for image size", zap.Error(err))
-		} else {
+		if err := json.Unmarshal(syftBytes, &sj); err == nil {
 			imageSizeBytes = sj.Source.Metadata.ImageSize
 			imageDigest = sj.Source.Metadata.ManifestDigest
-			logger.Info("extracted metadata from syft output",
-				zap.String("imageRef", registry+"/"+imageName+"@"+digest),
-				zap.String("platform", platform),
-				zap.Int64("imageSizeBytes", imageSizeBytes),
-				zap.String("imageDigest", imageDigest))
 		}
 	}
 
@@ -333,20 +309,6 @@ func normalizeRegistryNameForDockerConfig(registry string) string {
 	}
 
 	return registry
-}
-
-// isPlatformMismatchError checks if an error is due to platform mismatch
-func isPlatformMismatchError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	errStr := err.Error()
-	return isPlatformMismatchString(errStr)
-}
-
-func isPlatformMismatchString(errStr string) bool {
-	return strings.Contains(errStr, "does not match user specified platform")
 }
 
 // getDockerHubAuth gets an authentication token from Docker Hub

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -92,9 +92,7 @@ func FetchSBOM(ctx context.Context, registry string, imageName string, digest st
 					zap.String("platform", platform))
 				continue
 			}
-			logger.Errorf("failed to generate SBOM, aborting: %s (imageName: %s, digest: %s, platform: %s)",
-				err, imageName, digest, platform)
-			return nil, err
+			return nil, fmt.Errorf("failed to generate SBOM for %s@%s platform %s: %w", imageName, digest, platform, err)
 		}
 
 		if sbom != "" {

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -271,11 +271,15 @@ func SelectExternalImageDigestsToScan(ctx context.Context, maxToProcess int) ([]
 	seen := map[string]struct{}{}
 
 	// Tier 1: Digests with SBOMs but no scans yet (first scan, highest priority).
-	// Exclude digests that have a recent scan in 'running' or 'queued' status
-	// so the scheduler doesn't re-enqueue digests that are already in flight.
-	// Stale rows (older than ScanStalenessThreshold) are ignored so that
-	// orphaned queue messages or crashed workers don't permanently block a
-	// digest from being scanned.
+	// Exclude digests that have a recent scan in 'running' status so the
+	// scheduler doesn't re-enqueue scans that are already in flight.
+	// 'queued' rows are NOT excluded — when no builder is available, the
+	// handler discards the message without claiming, leaving the row as
+	// 'queued'. The scheduler must be able to re-select these so the scan
+	// is retried when a builder frees up. Duplicate work items are handled
+	// by claimScanForDispatch (first handler wins) and isScanAlreadyRunning.
+	// Stale 'running' rows (older than ScanStalenessThreshold) are ignored
+	// so that orphaned scans from crashed workers can be recovered.
 	staleThreshold := fmt.Sprintf("%d minutes", int(ScanStalenessThreshold.Minutes()))
 	rows, err := conn.Query(ctx, `
 		SELECT s.digest
@@ -284,7 +288,7 @@ func SelectExternalImageDigestsToScan(ctx context.Context, maxToProcess int) ([]
 		  AND NOT EXISTS (
 		    SELECT 1 FROM external_image_scan sc
 		    WHERE sc.digest = s.digest
-		      AND sc.status IN ('running', 'queued')
+		      AND sc.status = 'running'
 		      AND sc.scan_status_updated_at > NOW() - interval '`+staleThreshold+`'
 		  )
 		GROUP BY s.digest
@@ -329,7 +333,7 @@ func SelectExternalImageDigestsToScan(ctx context.Context, maxToProcess int) ([]
 			  AND NOT EXISTS (
 			    SELECT 1 FROM external_image_scan sc
 			    WHERE sc.digest = s.digest
-			      AND sc.status IN ('running', 'queued')
+			      AND sc.status = 'running'
 			      AND sc.scan_status_updated_at > NOW() - interval '%s'
 			  )
 			GROUP BY s.digest
@@ -386,7 +390,11 @@ func UpdateLastSecurityScanned(ctx context.Context, digest string, archs []strin
 func processExternalImageScans(ctx context.Context, maxToProcess int, cache *ScanCapacityCache) (bool, error) {
 	if cache != nil {
 		maxConcurrent := param.GetParam(ctx).PoolSize * 2 * param.GetParam(ctx).MaxScansPerBuilder
-		if cache.GetTotalScanCount() >= maxConcurrent {
+		activeScans := cache.GetTotalScanCount()
+		if activeScans >= maxConcurrent {
+			logger.Info("scan scheduler at capacity, pausing enqueue",
+				zap.Int("active_scans", activeScans),
+				zap.Int("max_concurrent", maxConcurrent))
 			return false, nil
 		}
 	}

--- a/pkg/scan/scan_capacity.go
+++ b/pkg/scan/scan_capacity.go
@@ -95,35 +95,24 @@ func (c *ScanCapacityCache) setReady(ready bool) {
 	c.ready = ready
 }
 
-// AddScan updates the scan metadata for a builder. The capacity count was
-// already incremented by tryReserveSlot during SelectBuilderForScan, which
-// also added a placeholder entry to the scans map. This function fills in
-// the placeholder with the full scan dir info (workDir, createdAt). For
-// scans discovered during cache init (not via SelectBuilderForScan), use
-// AddScanWithCount which increments both.
-func (c *ScanCapacityCache) AddScan(machineID string, info ScanDirInfo) {
+// SetBuilderScans replaces all scan entries for a builder with the given
+// list. The count is set to the length of the list. Called by the poller
+// every 10s to resync the cache with what's actually on the builder
+// filesystem, eliminating leaked placeholders and stale entries.
+func (c *ScanCapacityCache) SetBuilderScans(machineID string, scans []ScanDirInfo) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	for i, s := range c.scans[machineID] {
-		if s.Digest == info.Digest && s.WorkDir == "" {
-			c.scans[machineID][i] = info
-			return
-		}
+	if len(scans) == 0 {
+		delete(c.counts, machineID)
+		delete(c.scans, machineID)
+		return
 	}
-	c.scans[machineID] = append(c.scans[machineID], info)
+	c.scans[machineID] = scans
+	c.counts[machineID] = len(scans)
 }
 
-// AddScanWithCount records scan metadata AND increments the capacity count.
-// Used by InitScanCapacityCache for scans discovered on builder filesystems
-// during startup (not dispatched via SelectBuilderForScan).
-func (c *ScanCapacityCache) AddScanWithCount(machineID string, info ScanDirInfo) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.scans[machineID] = append(c.scans[machineID], info)
-	c.counts[machineID]++
-}
-
-// RemoveScan removes a scan for a builder by digest.
+// RemoveScan removes a scan for a builder by digest. Called by the poller
+// when a scan completes.
 func (c *ScanCapacityCache) RemoveScan(machineID, digest string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -189,12 +178,11 @@ func (c *ScanCapacityCache) GetBuilderIDs() []string {
 }
 
 // tryReserveSlot atomically checks whether a builder has capacity for one
-// more scan and, if so, increments the count and adds a placeholder scan
-// entry under the write lock. The placeholder prevents the poller's
-// reconciliation from double-counting the scan via AddScanWithCount during
-// the window between reservation and AddScan. Returns true if the slot was
-// reserved.
-func (c *ScanCapacityCache) tryReserveSlot(machineID string, hasBuildAssignment bool, maxScansPerBuilder int, digest string) bool {
+// more scan and, if so, increments the count under the write lock. Returns
+// true if the slot was reserved. The poller resyncs the cache every 10s, so
+// any leaked reservations (dispatch failure before scan files are written)
+// are automatically cleaned up on the next poll cycle.
+func (c *ScanCapacityCache) tryReserveSlot(machineID string, hasBuildAssignment bool, maxScansPerBuilder int) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -211,24 +199,17 @@ func (c *ScanCapacityCache) tryReserveSlot(machineID string, hasBuildAssignment 
 	}
 
 	c.counts[machineID] = current + 1
-	c.scans[machineID] = append(c.scans[machineID], ScanDirInfo{Digest: digest})
 	return true
 }
 
-// ReleaseScanSlot decrements the capacity count and removes the placeholder
-// scan entry for a builder. Used when a reservation was made but the scan
-// dispatch failed before the scan was fully set up.
-func (c *ScanCapacityCache) ReleaseScanSlot(machineID string, digest string) {
+// ReleaseScanSlot decrements the capacity count for a builder. Used when a
+// reservation was made but the scan dispatch failed before scan files were
+// written. The poller will correct the count on the next resync anyway, but
+// this avoids temporarily over-counting.
+func (c *ScanCapacityCache) ReleaseScanSlot(machineID string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.counts[machineID]--
-	scans := c.scans[machineID]
-	for i, s := range scans {
-		if s.Digest == digest {
-			c.scans[machineID] = append(scans[:i], scans[i+1:]...)
-			break
-		}
-	}
 	if c.counts[machineID] <= 0 {
 		delete(c.counts, machineID)
 		if len(c.scans[machineID]) == 0 {
@@ -329,16 +310,18 @@ func InitScanCapacityCache(ctx context.Context) (*ScanCapacityCache, error) {
 			continue
 		}
 
+		activeScans := make([]ScanDirInfo, 0)
 		for _, s := range scans {
 			if s.AllArchsDone {
 				continue
 			}
-			cache.AddScanWithCount(b.BuilderVM.ID, ScanDirInfo{
+			activeScans = append(activeScans, ScanDirInfo{
 				Digest:    s.Metadata.Digest,
 				WorkDir:   s.WorkDir,
 				CreatedAt: s.Metadata.CreatedAt,
 			})
 		}
+		cache.SetBuilderScans(b.BuilderVM.ID, activeScans)
 	}
 
 	cache.setReady(true)
@@ -362,15 +345,13 @@ type builderForScan struct {
 //   - Idle builders (no machine_assignment rows): up to maxScansPerBuilder concurrent scans
 //   - Busy builders (has machine_assignment rows): at most 1 concurrent scan
 //
-// The reservation is atomic: the capacity count is incremented AND a
-// placeholder scan entry is added to the scans map under the cache write
-// lock before returning. This prevents concurrent handlers from all
-// selecting the same builder and exceeding MaxScansPerBuilder, and ensures
-// the poller's reconciliation can see the reserved digest without
-// double-counting it via AddScanWithCount.
-// If the caller fails to dispatch the scan, it must call ReleaseScanSlot
-// to undo the reservation.
-func SelectBuilderForScan(ctx context.Context, cache *ScanCapacityCache, digest string) (buildertypes.BuilderVM, error) {
+// The reservation is atomic: the capacity count is incremented under the
+// cache write lock before returning, preventing concurrent handlers from
+// all selecting the same builder and exceeding MaxScansPerBuilder.
+// The poller resyncs the cache from builder filesystems every 10s, so any
+// leaked reservations (dispatch failure before scan files are written) are
+// automatically corrected on the next poll cycle.
+func SelectBuilderForScan(ctx context.Context, cache *ScanCapacityCache) (buildertypes.BuilderVM, error) {
 	if cache == nil || !cache.IsReady() {
 		return buildertypes.BuilderVM{}, fmt.Errorf("scan capacity cache is not ready")
 	}
@@ -383,7 +364,7 @@ func SelectBuilderForScan(ctx context.Context, cache *ScanCapacityCache, digest 
 	}
 
 	for _, b := range builders {
-		if cache.tryReserveSlot(b.ID, b.HasBuildAssignment, maxScansPerBuilder, digest) {
+		if cache.tryReserveSlot(b.ID, b.HasBuildAssignment, maxScansPerBuilder) {
 			return b.BuilderVM, nil
 		}
 	}

--- a/pkg/scan/scan_capacity.go
+++ b/pkg/scan/scan_capacity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -39,6 +40,12 @@ const (
 	// time to start up and begin processing.
 	ScanStartupGracePeriod = 60 * time.Second
 )
+
+// ErrNoBuilderAvailable is returned by SelectBuilderForScan when all running
+// builders are at capacity. Callers should check for this with errors.Is and
+// handle it gracefully (e.g. return nil from the handler so the scheduler
+// re-enqueues on the next cycle).
+var ErrNoBuilderAvailable = errors.New("no builder available for scan")
 
 // ScanMetadata is the JSON metadata file written to each scan directory on the
 // builder. It allows the poller to discover scans and know which DB rows to update.
@@ -381,7 +388,7 @@ func SelectBuilderForScan(ctx context.Context, cache *ScanCapacityCache, digest 
 		}
 	}
 
-	return buildertypes.BuilderVM{}, fmt.Errorf("no builder available for scan (all at capacity)")
+	return buildertypes.BuilderVM{}, ErrNoBuilderAvailable
 }
 
 // GetRunningBuilders returns all running builder VMs from the machine pool,


### PR DESCRIPTION
# Pull Request 138: External Image Scan Improvements

## Commit 1: Don't log noise when scanner is at capacity

When all builders are at maximum scan capacity, the scheduler continues enqueuing work items that the handler cannot dispatch. The old code logged each failed dispatch as an ERROR and returned a retryable error, causing the listener to retry the message — generating thousands of error log lines per minute and wasting worker capacity on retries that would immediately fail again.

This commit moves builder selection before the scan claim, so no scan status rows are touched when no builder is available. The "no builder available" condition is now handled gracefully: the handler reverts the scan to `queued` status, returns `nil` (not an error), and logs at INFO level. The message is cleanly completed, and the scheduler re-enqueues the digest on the next cycle when capacity frees up. A sentinel `ErrNoBuilderAvailable` error was added to the scan package, checked via `errors.Is`, consistent with the codebase's existing error handling patterns.

The scheduler backpressure was also updated to use `PoolSize × 2 × MaxScansPerBuilder` (accounting for the two architecture pools — arm and amd), matching the listener's `maxWorkers` calculation. Previously both used `PoolSize × MaxScansPerBuilder`, which capped throughput at half the actual builder capacity. An INFO log was added to the scheduler backpressure check so it's visible when enqueuing is paused.

## Commit 2: Missing architectures are allowed in external images

Not all container images have manifests for both `linux/amd64` and `linux/arm64`. The previous code treated a missing SBOM for an architecture as a scan failure, writing a `failed` status row with "no SBOM for this architecture". Since `claimScanForDispatch` claims any non-`running` row (including `failed`), these rows were re-claimed on every re-scan cycle — generating thousands of useless failures and consuming handler capacity. In production, 15,019 such failure rows had accumulated, all for `aarch64` on single-arch images.

This commit removes the `SetExternalImageScanStatus` call for archs without SBOMs. The handler now silently skips architectures that don't have SBOMs — no scan status row is created for them. A missing SBOM is not an error; it just means that architecture doesn't exist for that image.

The SBOM generation code in `pkg/sbom/sbom.go` was also refactored. `generateSBOMWithSyft` no longer does its own logging — it returns the error (with stderr wrapped in) to the caller. `FetchSBOM` now handles all logging decisions: INFO for missing architectures (normal, skip and continue to the next platform) and ERROR for everything else (missing syft binary, temp dir failure, invalid JSON — abort the entire SBOM generation). The `isPlatformMismatchError`/`isPlatformMismatchString` wrappers were removed and the string check inlined.

## Commit 3: Rebuild scanner state instead of incrementally maintaining it

The scan capacity cache was maintained incrementally: `tryReserveSlot` added a placeholder entry, `AddScan` updated it with real metadata, `ReleaseScanSlot` removed it, and the poller ran a reconciliation pass to add missing entries and clean up leaked placeholders. This was complex and leak-prone — in production, 3 placeholder slots leaked on one builder, permanently blocking its capacity.

This commit simplifies the cache to be fully rebuilt by the poller every 10 seconds. `SetBuilderScans` replaces all entries for a builder with the current set of active scan dirs discovered on the filesystem. The placeholder mechanism (`AddScan`, `AddScanWithCount`, placeholder entries in `tryReserveSlot`) was removed entirely. `tryReserveSlot` now just increments the count under the write lock — no scan metadata is stored until the poller discovers the scan dir. `ReleaseScanSlot` just decrements the count. Any temporary over-count from a reservation that doesn't result in a dispatched scan is automatically corrected on the next poll cycle.

The poller's reconciliation logic (checking `cachedDigests`, adding missing scans, removing leaked placeholders) was replaced with a single `SetBuilderScans` call per builder. Deleted builders are still handled by `RemoveBuilder`, called when a builder disappears from `machine_pool`. `InitScanCapacityCache` also uses `SetBuilderScans` to populate the cache at startup from builder filesystems.
