### PR TITLE
Fix running scans counts

### DIFF
--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -12,7 +12,6 @@ import (
 	"github.com/securebuildhq/securebuild/pkg/anchore"
 	"github.com/securebuildhq/securebuild/pkg/externalimage"
 	"github.com/securebuildhq/securebuild/pkg/logger"
-	"github.com/securebuildhq/securebuild/pkg/param"
 	"github.com/securebuildhq/securebuild/pkg/persistence"
 	"github.com/securebuildhq/securebuild/pkg/security"
 	"github.com/securebuildhq/securebuild/pkg/telemetry"
@@ -384,21 +383,10 @@ func UpdateLastSecurityScanned(ctx context.Context, digest string, archs []strin
 // processExternalImageScans selects external image SBOMs to scan and enqueues
 // them as external_image_scan work items for builder-based dispatch.
 // Selection uses tiered back-off based on last_submitted_at (see SelectExternalImageDigestsToScan).
-// Scheduler backpressure: only enqueues if the total in-memory scan count is below
-// PoolSize * 2 * MaxScansPerBuilder (×2 for the two architecture pools).
+// Builder-level capacity is enforced by SelectBuilderForScan in the handler via
+// tryReserveSlot, which returns ErrNoBuilderAvailable when all builders are full.
 // returns true if there are no more digests to scan
-func processExternalImageScans(ctx context.Context, maxToProcess int, cache *ScanCapacityCache) (bool, error) {
-	if cache != nil {
-		maxConcurrent := param.GetParam(ctx).PoolSize * 2 * param.GetParam(ctx).MaxScansPerBuilder
-		activeScans := cache.GetTotalScanCount()
-		if activeScans >= maxConcurrent {
-			logger.Info("scan scheduler at capacity, pausing enqueue",
-				zap.Int("active_scans", activeScans),
-				zap.Int("max_concurrent", maxConcurrent))
-			return false, nil
-		}
-	}
-
+func processExternalImageScans(ctx context.Context, maxToProcess int) (bool, error) {
 	selectedDigests, err := SelectExternalImageDigestsToScan(ctx, maxToProcess)
 	if err != nil {
 		return false, err
@@ -434,13 +422,20 @@ func processExternalImageScans(ctx context.Context, maxToProcess int, cache *Sca
 //
 // For each tier (including never-scanned), it counts digests that have not been
 // scanned within their respective rescan interval — i.e., digests that are
-// eligible for scanning right now. It also counts how many scans are currently
-// in the 'running' status.
+// eligible for scanning right now. It also reports how many scans are currently
+// active on builders.
 //
 // Gauges sent:
 //   - securebuild.external_image.scan.backlog  (tag: tier=<never_scanned|active|recent|stale>)
 //   - securebuild.external_image.scan.running
-func ReportScanMetrics(ctx context.Context) {
+//
+// The running scan count is sourced from the in-memory ScanCapacityCache (scans
+// map), which reflects scan directories the poller has actually observed on
+// builder filesystems. This is more accurate than querying the DB for
+// status='running' rows, which can be inflated by rows that have been claimed
+// to 'running' but whose grype process already completed and hasn't been
+// collected by the poller yet.
+func ReportScanMetrics(ctx context.Context, cache *ScanCapacityCache) {
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
@@ -487,13 +482,13 @@ func ReportScanMetrics(ctx context.Context) {
 			[]string{telemetry.TagScanTier + ":" + tier.name})
 	}
 
-	// Running scans: count of external_image_scan rows with status = 'running'
+	// Running scans: count of active scan directories across all builders,
+	// sourced from the in-memory cache (scans map). This reflects scans the
+	// poller has actually observed on builder filesystems and excludes
+	// completed-but-uncollected scans that would inflate a DB-based count.
 	var runningCount int
-	if err := conn.QueryRow(ctx, `
-		SELECT COUNT(*) FROM external_image_scan WHERE status = 'running'
-	`).Scan(&runningCount); err != nil {
-		logger.Warn("failed to count running scans", zap.Error(err))
-	} else {
-		telemetry.Gauge(telemetry.MetricExternalImageScansRunning, float64(runningCount), nil)
+	if cache != nil {
+		runningCount = cache.GetTotalActiveScanCount()
 	}
+	telemetry.Gauge(telemetry.MetricExternalImageScansRunning, float64(runningCount), nil)
 }

--- a/pkg/scan/scan_capacity.go
+++ b/pkg/scan/scan_capacity.go
@@ -166,6 +166,22 @@ func (c *ScanCapacityCache) GetTotalScanCount() int {
 	return total
 }
 
+// GetTotalActiveScanCount returns the total number of active scan directories
+// across all builders, based on the scans map (not the counts map). This is
+// more accurate than GetTotalScanCount because counts can be temporarily
+// inflated by tryReserveSlot reservations between poller resync cycles, while
+// scans only reflects scan directories the poller has actually observed on
+// builder filesystems.
+func (c *ScanCapacityCache) GetTotalActiveScanCount() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	total := 0
+	for _, scans := range c.scans {
+		total += len(scans)
+	}
+	return total
+}
+
 // GetBuilderIDs returns the machine IDs of all builders that have active scans.
 func (c *ScanCapacityCache) GetBuilderIDs() []string {
 	c.mu.RLock()

--- a/pkg/scan/scheduler.go
+++ b/pkg/scan/scheduler.go
@@ -53,7 +53,7 @@ func StartScheduler(ctx context.Context, cache *ScanCapacityCache) error {
 		defer ticker.Stop()
 		// Report immediately on startup so metrics are available without
 		// waiting for the first tick.
-		ReportScanMetrics(ctx)
+		ReportScanMetrics(ctx, cache)
 		if cache != nil {
 			cache.ReportCapacityMetrics(ctx)
 			if err := cache.DumpToFile(); err != nil {
@@ -65,7 +65,7 @@ func StartScheduler(ctx context.Context, cache *ScanCapacityCache) error {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				ReportScanMetrics(ctx)
+				ReportScanMetrics(ctx, cache)
 				if cache != nil {
 					cache.ReportCapacityMetrics(ctx)
 					if err := cache.DumpToFile(); err != nil {
@@ -91,7 +91,7 @@ func StartScheduler(ctx context.Context, cache *ScanCapacityCache) error {
 	}()
 
 	for {
-		noImages, err := processExternalImageScans(ctx, MaxImagesPerCycle, cache)
+		noImages, err := processExternalImageScans(ctx, MaxImagesPerCycle)
 		if err != nil {
 			logger.Error(fmt.Errorf("failed to process external image scans: %w", err))
 		}


### PR DESCRIPTION
### 1. Remove scheduler backpressure check (`pkg/scan/scan.go`)

Removed the `GetTotalScanCount() >= maxConcurrent` check from `processExternalImageScans`. Builder-level capacity is enforced by `SelectBuilderForScan` -> `tryReserveSlot` in the handler, which checks each builder's real-time count under a write lock and returns `ErrNoBuilderAvailable` when all builders are genuinely full. The global check was strictly more restrictive (due to inflated counts) and prevented the handler from ever getting work to test against real capacity.

### 2. Fix running scan metric (`pkg/scan/scan.go`)

Changed `ReportScanMetrics` to accept `*ScanCapacityCache` and use `cache.GetTotalActiveScanCount()` (summing `len(scans[id])` — actual scan directories observed on builder filesystems) instead of the DB query for the `securebuild.external_image.scan.running` gauge.
