### PR TITLE
Include old images in scanning

### DIFF
--- a/integration/worker/external_image/scan_tier_test.go
+++ b/integration/worker/external_image/scan_tier_test.go
@@ -25,7 +25,7 @@ var (
 	activeDigest    = "sha256:active-tier-digest-12345678901234567890123456789012"
 	recentDigest    = "sha256:recent-tier-digest-12345678901234567890123456789012"
 	staleDigest     = "sha256:stale-tier-digest-12345678901234567890123456789012"
-	excludedDigest  = "sha256:excluded-tier-digest-12345678901234567890123456789012"
+	inactiveDigest  = "sha256:inactive-tier-digest-12345678901234567890123456789012"
 	neverScannedDg  = "sha256:never-scanned-digest-12345678901234567890123456789012"
 	freshDigest     = "sha256:fresh-active-digest-12345678901234567890123456789012"
 	activeScannedDg = "sha256:active-scanned-digest-12345678901234567890123456789012"
@@ -74,7 +74,7 @@ func setupTierTestDB(t *testing.T) (context.Context, func()) {
 
 // TestSelectExternalImageDigestsToScanTiers verifies that the tiered back-off
 // scheduling selects digests from the correct tier based on last_submitted_at
-// and that images >90 days old are excluded from the scheduler.
+// and that images >90 days old are included in the inactive tier.
 func TestSelectExternalImageDigestsToScanTiers(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -92,7 +92,7 @@ func TestSelectExternalImageDigestsToScanTiers(t *testing.T) {
 		assert.Contains(t, digests, activeDigest, "active tier digest should be selected")
 		assert.Contains(t, digests, recentDigest, "recent tier digest should be selected")
 		assert.Contains(t, digests, staleDigest, "stale tier digest should be selected")
-		assert.NotContains(t, digests, excludedDigest, "excluded digest (>90 days) should NOT be selected")
+		assert.Contains(t, digests, inactiveDigest, "inactive tier digest should be selected")
 	})
 
 	t.Run("Never-scanned prioritized over rescans when capacity=1", func(t *testing.T) {
@@ -126,11 +126,11 @@ func TestSelectExternalImageDigestsToScanTiers(t *testing.T) {
 		assert.NotContains(t, digests, staleDigest, "stale tier should not be reached with capacity 3")
 	})
 
-	t.Run("Excluded digest (>90 days) never selected", func(t *testing.T) {
+	t.Run("Inactive digest (>90 days) is selected", func(t *testing.T) {
 		digests, err := scan.SelectExternalImageDigestsToScan(ctx, 25)
 		require.NoError(t, err)
 
-		assert.NotContains(t, digests, excludedDigest, "excluded digest should never be selected")
+		assert.Contains(t, digests, inactiveDigest, "inactive tier digest should be selected")
 	})
 }
 

--- a/integration/worker/external_image/testdata/seed-data/external-image-sbom.yaml
+++ b/integration/worker/external_image/testdata/seed-data/external-image-sbom.yaml
@@ -24,7 +24,7 @@ seedData:
         - column: last_security_scanned_at
           value:
             str: "2026-01-15T07:00:00Z"
-    # Recent tier SBOM — scanned 2 days before reference (stale for 24h interval)
+    # Recent tier SBOM — scanned 2 days before reference (stale for 4h interval)
     - columns:
         - column: digest
           value:
@@ -44,7 +44,7 @@ seedData:
         - column: last_security_scanned_at
           value:
             str: "2026-01-13T12:00:00Z"
-    # Stale tier SBOM — scanned 10 days before reference (stale for 7d interval)
+    # Stale tier SBOM — scanned 10 days before reference (stale for 24h interval)
     - columns:
         - column: digest
           value:
@@ -64,11 +64,11 @@ seedData:
         - column: last_security_scanned_at
           value:
             str: "2026-01-05T00:00:00Z"
-    # Excluded tier SBOM — scanned 30 days before reference (stale, but >90d excluded)
+    # Inactive tier SBOM — scanned 30 days before reference (stale for 24h interval)
     - columns:
         - column: digest
           value:
-            str: "sha256:excluded-tier-digest-12345678901234567890123456789012"
+            str: "sha256:inactive-tier-digest-12345678901234567890123456789012"
         - column: arch
           value:
             str: "x86_64"

--- a/integration/worker/external_image/testdata/seed-data/external-image-tag.yaml
+++ b/integration/worker/external_image/testdata/seed-data/external-image-tag.yaml
@@ -82,7 +82,7 @@ seedData:
         - column: next_scan_at
           value:
             str: "2025-12-02T00:00:00Z"
-    # Excluded tier: submitted 100 days before reference (>90 days)
+    # Inactive tier: submitted 100 days before reference (>90 days)
     - columns:
         - column: registry
           value:
@@ -92,7 +92,7 @@ seedData:
             str: "library/tier-test"
         - column: image_tag
           value:
-            str: "excluded"
+            str: "inactive"
         - column: created_at
           value:
             str: "2025-10-06T00:00:00Z"
@@ -101,7 +101,7 @@ seedData:
             str: "2025-10-06T00:00:00Z"
         - column: digest
           value:
-            str: "sha256:excluded-tier-digest-12345678901234567890123456789012"
+            str: "sha256:inactive-tier-digest-12345678901234567890123456789012"
         - column: next_check_digest_at
           value:
             str: "2025-10-07T00:00:00Z"

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -217,24 +217,25 @@ func getRegistryHostname(imageURL string) (string, error) {
 // scanTier defines a back-off tier for rescan scheduling.
 // Each tier has a last_submitted_at window and a rescan interval.
 // Tiers are queried in priority order; higher tiers are filled before
-// lower tiers contribute digests. Images submitted >90 days ago (tier 5)
-// are excluded from the scheduler entirely (on-demand only).
+// lower tiers contribute digests.
 //
 // submittedAfter is the minimum age (e.g. "7 days" means submitted more than 7 days ago).
+// An empty submittedAfter means no lower bound (all images older than submittedBefore).
 // submittedBefore is the maximum age (e.g. "0 days" means submitted less than 0 days ago = now).
 // The tier window is: ref - submittedBefore < last_submitted_at <= ref - submittedAfter
 // For active: submitted 0-7 days ago → last_submitted > ref-7d AND last_submitted <= ref-0d
 type scanTier struct {
 	name            string
-	submittedAfter  string // minimum age: last_submitted_at > ref - interval
+	submittedAfter  string // minimum age: last_submitted_at > ref - interval; empty = unbounded
 	submittedBefore string // maximum age: last_submitted_at <= ref - interval
 	rescanInterval  string // rescan threshold: last_security_scanned_at < ref - interval
 }
 
 var scanTiers = []scanTier{
 	{name: "active", submittedAfter: "7 days", submittedBefore: "0 days", rescanInterval: "4 hours"},
-	{name: "recent", submittedAfter: "30 days", submittedBefore: "7 days", rescanInterval: "24 hours"},
-	{name: "stale", submittedAfter: "90 days", submittedBefore: "30 days", rescanInterval: "7 days"},
+	{name: "recent", submittedAfter: "30 days", submittedBefore: "7 days", rescanInterval: "4 hours"},
+	{name: "stale", submittedAfter: "90 days", submittedBefore: "30 days", rescanInterval: "24 hours"},
+	{name: "inactive", submittedAfter: "", submittedBefore: "90 days", rescanInterval: "24 hours"},
 }
 
 // ScanStalenessThreshold is how old a 'queued' or 'running' scan row must be
@@ -248,10 +249,10 @@ const ScanStalenessThreshold = 1 * time.Hour
 //
 // Priority order:
 //  1. Never scanned: digests with SBOMs but no scans yet
-//  2. Active tier:  last_submitted < 7 days,    rescan if older than 4 hours
-//  3. Recent tier:  last_submitted 7-30 days,   rescan if older than 24 hours
-//  4. Stale tier:   last_submitted 30-90 days,  rescan if older than 7 days
-//  5. Excluded:     last_submitted > 90 days    — not scanned by scheduler
+//  2. Active tier:   last_submitted 0-7 days,    rescan if older than 4 hours
+//  3. Recent tier:   last_submitted 7-30 days,   rescan if older than 4 hours
+//  4. Stale tier:    last_submitted 30-90 days,  rescan if older than 24 hours
+//  5. Inactive tier: last_submitted >90 days,    rescan if older than 24 hours
 //
 // Each tier uses ORDER BY random() for fair distribution within the tier.
 // After each query, remaining capacity is evaluated; if 0, lower tiers are skipped.
@@ -310,18 +311,22 @@ func SelectExternalImageDigestsToScan(ctx context.Context, maxToProcess int) ([]
 
 	remaining := maxToProcess - len(selectedDigests)
 
-	// Tiers 2-4: Back-off tiers based on last_submitted_at
+	// Tiers 2-5: Back-off tiers based on last_submitted_at
 	for _, tier := range scanTiers {
 		if remaining <= 0 {
 			break
+		}
+
+		tierTagsWhere := fmt.Sprintf("last_submitted_at <= $2::timestamptz - interval '%s'", tier.submittedBefore)
+		if tier.submittedAfter != "" {
+			tierTagsWhere = fmt.Sprintf("last_submitted_at > $2::timestamptz - interval '%s' AND %s", tier.submittedAfter, tierTagsWhere)
 		}
 
 		query := fmt.Sprintf(`
 			WITH tier_tags AS (
 				SELECT digest
 				FROM external_image_tag
-				WHERE last_submitted_at > $2::timestamptz - interval '%s'
-				  AND last_submitted_at <= $2::timestamptz - interval '%s'
+				WHERE %s
 				GROUP BY digest
 			)
 			SELECT s.digest
@@ -338,7 +343,7 @@ func SelectExternalImageDigestsToScan(ctx context.Context, maxToProcess int) ([]
 			GROUP BY s.digest
 			ORDER BY random()
 			LIMIT $1
-		`, tier.submittedAfter, tier.submittedBefore, tier.rescanInterval, staleThreshold)
+		`, tierTagsWhere, tier.rescanInterval, staleThreshold)
 
 		rows, err := conn.Query(ctx, query, remaining, referenceTime)
 		if err != nil {
@@ -426,7 +431,7 @@ func processExternalImageScans(ctx context.Context, maxToProcess int) (bool, err
 // active on builders.
 //
 // Gauges sent:
-//   - securebuild.external_image.scan.backlog  (tag: tier=<never_scanned|active|recent|stale>)
+//   - securebuild.external_image.scan.backlog  (tag: tier=<never_scanned|active|recent|stale|inactive>)
 //   - securebuild.external_image.scan.running
 //
 // The running scan count is sourced from the in-memory ScanCapacityCache (scans
@@ -458,12 +463,16 @@ func ReportScanMetrics(ctx context.Context, cache *ScanCapacityCache) {
 	// the tier's rescan interval, within the tier's last_submitted_at window.
 	for _, tier := range scanTiers {
 		var count int
+		tierTagsWhere := fmt.Sprintf("last_submitted_at <= $1::timestamptz - interval '%s'", tier.submittedBefore)
+		if tier.submittedAfter != "" {
+			tierTagsWhere = fmt.Sprintf("last_submitted_at > $1::timestamptz - interval '%s' AND %s", tier.submittedAfter, tierTagsWhere)
+		}
+
 		query := fmt.Sprintf(`
 			WITH tier_tags AS (
 				SELECT digest
 				FROM external_image_tag
-				WHERE last_submitted_at > $1::timestamptz - interval '%s'
-				  AND last_submitted_at <= $1::timestamptz - interval '%s'
+				WHERE %s
 				GROUP BY digest
 			)
 			SELECT COUNT(DISTINCT s.digest)
@@ -471,7 +480,7 @@ func ReportScanMetrics(ctx context.Context, cache *ScanCapacityCache) {
 			JOIN tier_tags t ON t.digest = s.digest
 			WHERE s.last_security_scanned_at IS NOT NULL
 			  AND s.last_security_scanned_at < $1::timestamptz - interval '%s'
-		`, tier.submittedAfter, tier.submittedBefore, tier.rescanInterval)
+		`, tierTagsWhere, tier.rescanInterval)
 
 		if err := conn.QueryRow(ctx, query, referenceTime).Scan(&count); err != nil {
 			logger.Warn("failed to count tier backlog", zap.String("tier", tier.name), zap.Error(err))

--- a/securebuild-api/lib/externalimage/externalimage.ts
+++ b/securebuild-api/lib/externalimage/externalimage.ts
@@ -692,35 +692,6 @@ export async function resetScanStatus(digest: string): Promise<void> {
 }
 
 /**
- * Update the digest for an existing tag.
- * This is used during rescan when the registry returns a new digest for a tag.
- *
- * @param registry - The registry (e.g., "docker.io", "ghcr.io")
- * @param imageName - The image name (e.g., "library/nginx")
- * @param imageTag - The image tag (e.g., "latest")
- * @param digest - The new digest from the registry
- */
-export async function updateTagDigest(registry: string, imageName: string, imageTag: string, digest: string): Promise<void> {
-  const db = getDB(await getParam("DB_URI"))
-
-  // Set next check/scan times to 4 hours from now to prevent duplicate work
-  // from the background monitor picking up this tag immediately
-  const inFourHours = new Date(Date.now() + 4 * 60 * 60 * 1000)
-
-  const query = `
-    UPDATE external_image_tag
-    SET digest = $4, next_check_digest_at = $5, next_scan_at = $5
-    WHERE registry = $1 AND image_name = $2 AND image_tag = $3
-  `
-  const result = await db.query(query, [registry, imageName, imageTag, digest, inFourHours])
-
-  if (result.rowCount === 0) {
-    throw new Error(`Tag not found: ${registry}/${imageName}:${imageTag}`)
-  }
-}
-
-
-/**
  * Initialize SBOM status as 'pending' for a digest.
  * Uses ON CONFLICT DO NOTHING to avoid overwriting existing status.
  * This should be called when an image is first tracked and SBOM work is enqueued.


### PR DESCRIPTION
Including images older than 90 days in periodic scanning and decrease scan interval for newer images.