### PR TITLE
Process external image scans faster

### DIFF
--- a/pkg/listener/external-image-scan-builder.go
+++ b/pkg/listener/external-image-scan-builder.go
@@ -8,8 +8,6 @@ import (
 	"path/filepath"
 	"time"
 
-	syftpkg "github.com/anchore/syft/syft/pkg"
-	"github.com/securebuildhq/securebuild/pkg/anchore"
 	"github.com/securebuildhq/securebuild/pkg/buildbackend"
 	"github.com/securebuildhq/securebuild/pkg/externalimage"
 	image "github.com/securebuildhq/securebuild/pkg/image"
@@ -17,7 +15,6 @@ import (
 	"github.com/securebuildhq/securebuild/pkg/logger"
 	"github.com/securebuildhq/securebuild/pkg/persistence"
 	"github.com/securebuildhq/securebuild/pkg/scan"
-	"github.com/securebuildhq/securebuild/pkg/security"
 	"go.uber.org/zap"
 )
 
@@ -316,30 +313,6 @@ func buildGrypeLaunchCommand(workDir, arch string) string {
   wait $grype_pid
   echo $? > output/exit_code
 ' > %q 2>&1 < /dev/null &`, archDir, filepath.Join(archDir, "scan.log"))
-}
-
-// updatePackageFixVersionsForSBOM parses the SBOM and updates package fix
-// versions for APK packages. This is called by the poller after a successful
-// scan, using the SBOM from the DB (not from the builder).
-func updatePackageFixVersionsForSBOM(ctx context.Context, sbomJSON string) {
-	sbomObj, err := anchore.ParseSBOM(sbomJSON)
-	if err != nil {
-		logger.Warn("failed to parse SBOM for fix-version update",
-			zap.Error(err))
-		return
-	}
-
-	for pkg := range sbomObj.Artifacts.Packages.Enumerate() {
-		if pkg.Type != syftpkg.ApkPkg {
-			continue
-		}
-		if err := security.UpdatePackageFixVersions(ctx, sbomObj, pkg); err != nil {
-			logger.Warn("failed to update package fix versions",
-				zap.String("package", pkg.Name),
-				zap.String("version", pkg.Version),
-				zap.Error(err))
-		}
-	}
 }
 
 // storeBuilderScanResult parses and stores a successful scan result for a

--- a/pkg/listener/update-external-image-scan-status.go
+++ b/pkg/listener/update-external-image-scan-status.go
@@ -124,9 +124,15 @@ func processBuilderScans(ctx context.Context, cache *scan.ScanCapacityCache, vm 
 	}
 	cache.SetBuilderScans(vm.ID, activeScans)
 
+	var scanWG sync.WaitGroup
 	for _, sd := range scanDirs {
-		processScanDir(ctx, cache, vm, runner, sd)
+		scanWG.Add(1)
+		go func(sd scan.ScanDirStatus) {
+			defer scanWG.Done()
+			processScanDir(ctx, cache, vm, runner, sd)
+		}(sd)
 	}
+	scanWG.Wait()
 }
 
 // processScanDir processes a single scan directory on a builder.
@@ -206,8 +212,7 @@ func processScanDir(ctx context.Context, cache *scan.ScanCapacityCache, vm build
 	}
 }
 
-// handleSuccessfulScan reads the grype JSON result, stores it in the DB,
-// and updates package fix versions for APK packages.
+// handleSuccessfulScan reads the grype JSON result and stores it in the DB.
 // Returns true if the result was stored successfully.
 func handleSuccessfulScan(ctx context.Context, runner buildbackend.Runner, workDir, digest, arch string) bool {
 	grypeJSONPath := filepath.Join(workDir, arch, "grype-scan.json")
@@ -237,15 +242,6 @@ func handleSuccessfulScan(ctx context.Context, runner buildbackend.Runner, workD
 
 	stored := storeBuilderScanResult(ctx, digest, arch, grypeJSON)
 	if stored {
-		sboms, sbomErr := externalimage.GetExternalImageSBOMs(ctx, digest)
-		if sbomErr == nil {
-			for _, s := range sboms {
-				if s.Arch == arch {
-					updatePackageFixVersionsForSBOM(ctx, s.SBOM)
-					break
-				}
-			}
-		}
 		logger.Info("stored scan result",
 			zap.String("digest", digest),
 			zap.String("arch", arch))

--- a/pkg/param/param.go
+++ b/pkg/param/param.go
@@ -132,6 +132,11 @@ type Param struct {
 	// so this can be higher than max_parallel_builds. Default: 3.
 	MaxScansPerBuilder int `yaml:"max_scans_per_builder"`
 
+	// MaxImagesPerCycle limits how many images are enqueued per scheduler cycle.
+	// Higher values increase dispatch throughput at the cost of more queue
+	// messages per cycle. Default: 25.
+	MaxImagesPerCycle int `yaml:"max_images_per_cycle"`
+
 	// Authentication configuration
 	AuthMethod        string `yaml:"auth_method"`
 	AdminUserEmail    string `yaml:"admin_user_email"`
@@ -301,6 +306,10 @@ func Init(source InitSource, overrides map[string]string) (context.Context, erro
 
 	if p.MaxScansPerBuilder <= 0 {
 		p.MaxScansPerBuilder = 3
+	}
+
+	if p.MaxImagesPerCycle <= 0 {
+		p.MaxImagesPerCycle = 25
 	}
 
 	normalizePoolSizeForBackend(p)

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -8,12 +8,10 @@ import (
 	"sync"
 	"time"
 
-	syftpkg "github.com/anchore/syft/syft/pkg"
 	"github.com/securebuildhq/securebuild/pkg/anchore"
 	"github.com/securebuildhq/securebuild/pkg/externalimage"
 	"github.com/securebuildhq/securebuild/pkg/logger"
 	"github.com/securebuildhq/securebuild/pkg/persistence"
-	"github.com/securebuildhq/securebuild/pkg/security"
 	"github.com/securebuildhq/securebuild/pkg/telemetry"
 	"github.com/securebuildhq/securebuild/pkg/util"
 	"go.uber.org/zap"
@@ -50,16 +48,6 @@ func ScanExternalImage(ctx context.Context, digest string) (results map[string]s
 	for _, sbom := range sboms {
 		startTime := time.Now()
 
-		// Parse the SBOM to extract packages
-		sbomObj, err := anchore.ParseSBOM(sbom.SBOM)
-		if err != nil {
-			logger.Warn("failed to parse SBOM",
-				zap.String("digest", digest),
-				zap.String("arch", sbom.Arch),
-				zap.Error(err))
-			continue
-		}
-
 		// Scan the SBOM using Grype library and get official JSON
 		grypeJSON, err := scanner.ScanSBOMForCVEs(ctx, sbom.SBOM)
 		duration := time.Since(startTime)
@@ -74,26 +62,6 @@ func ScanExternalImage(ctx context.Context, digest string) (results map[string]s
 		}
 
 		results[sbom.Arch] = grypeJSON
-
-		// Update package fixed versions for APK packages in this SBOM
-		// This helps us discover which package versions contain fixed artifact versions
-		for pkg := range sbomObj.Artifacts.Packages.Enumerate() {
-			// Only process APK packages (OS packages), not language dependencies
-			if pkg.Type != syftpkg.ApkPkg {
-				continue
-			}
-
-			err := security.UpdatePackageFixVersions(ctx, sbomObj, pkg)
-			if err != nil {
-				logger.Warn("failed to update package fix versions",
-					zap.String("digest", digest),
-					zap.String("arch", sbom.Arch),
-					zap.String("package", pkg.Name),
-					zap.String("version", pkg.Version),
-					zap.Error(err))
-				// Continue processing other packages even if one fails
-			}
-		}
 
 		logger.Debug("successfully scanned SBOM",
 			zap.String("digest", digest),

--- a/pkg/scan/scheduler.go
+++ b/pkg/scan/scheduler.go
@@ -29,11 +29,6 @@ const (
 	// tight loop from re-enqueuing the same digests thousands of times.
 	ExternalImageEnqueueInterval = 5 * time.Second
 
-	// DefaultMaxImagesPerCycle is the default limit for how many images are
-	// processed in each scheduler cycle. Overridden by the MaxImagesPerCycle
-	// param at runtime.
-	DefaultMaxImagesPerCycle = 25
-
 	// MetricsReportInterval is how often scan backlog and running scan gauges are sent
 	MetricsReportInterval = 1 * time.Minute
 )
@@ -94,9 +89,6 @@ func StartScheduler(ctx context.Context, cache *ScanCapacityCache) error {
 	}()
 
 	maxImagesPerCycle := param.GetParam(ctx).MaxImagesPerCycle
-	if maxImagesPerCycle <= 0 {
-		maxImagesPerCycle = DefaultMaxImagesPerCycle
-	}
 
 	for {
 		noImages, err := processExternalImageScans(ctx, maxImagesPerCycle)
@@ -123,9 +115,6 @@ func StartScheduler(ctx context.Context, cache *ScanCapacityCache) error {
 
 func processPeriodicScans(ctx context.Context) error {
 	maxImagesPerCycle := param.GetParam(ctx).MaxImagesPerCycle
-	if maxImagesPerCycle <= 0 {
-		maxImagesPerCycle = DefaultMaxImagesPerCycle
-	}
 
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()

--- a/pkg/scan/scheduler.go
+++ b/pkg/scan/scheduler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/securebuildhq/securebuild/pkg/logger"
+	"github.com/securebuildhq/securebuild/pkg/param"
 	"github.com/securebuildhq/securebuild/pkg/persistence"
 	"go.uber.org/zap"
 )
@@ -28,8 +29,10 @@ const (
 	// tight loop from re-enqueuing the same digests thousands of times.
 	ExternalImageEnqueueInterval = 5 * time.Second
 
-	// MaxImagesPerCycle limits how many images are processed in each scheduler cycle
-	MaxImagesPerCycle = 25
+	// DefaultMaxImagesPerCycle is the default limit for how many images are
+	// processed in each scheduler cycle. Overridden by the MaxImagesPerCycle
+	// param at runtime.
+	DefaultMaxImagesPerCycle = 25
 
 	// MetricsReportInterval is how often scan backlog and running scan gauges are sent
 	MetricsReportInterval = 1 * time.Minute
@@ -90,8 +93,13 @@ func StartScheduler(ctx context.Context, cache *ScanCapacityCache) error {
 		}
 	}()
 
+	maxImagesPerCycle := param.GetParam(ctx).MaxImagesPerCycle
+	if maxImagesPerCycle <= 0 {
+		maxImagesPerCycle = DefaultMaxImagesPerCycle
+	}
+
 	for {
-		noImages, err := processExternalImageScans(ctx, MaxImagesPerCycle)
+		noImages, err := processExternalImageScans(ctx, maxImagesPerCycle)
 		if err != nil {
 			logger.Error(fmt.Errorf("failed to process external image scans: %w", err))
 		}
@@ -114,6 +122,11 @@ func StartScheduler(ctx context.Context, cache *ScanCapacityCache) error {
 }
 
 func processPeriodicScans(ctx context.Context) error {
+	maxImagesPerCycle := param.GetParam(ctx).MaxImagesPerCycle
+	if maxImagesPerCycle <= 0 {
+		maxImagesPerCycle = DefaultMaxImagesPerCycle
+	}
+
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
@@ -128,7 +141,7 @@ func processPeriodicScans(ctx context.Context) error {
 		LIMIT $2
 	`
 
-	rows, err := conn.Query(ctx, query, now, MaxImagesPerCycle)
+	rows, err := conn.Query(ctx, query, now, maxImagesPerCycle)
 	if err != nil {
 		return fmt.Errorf("failed to query catalog images for scanning: %w", err)
 	}


### PR DESCRIPTION
# Grype Scan Throughput Troubleshooting Analysis

## Problem

Scans sit on builders for long periods with no grype processes running. Configuration allows 32 scans per builder, but throughput is far below capacity. ~150K backlogged scans in the inactive tier.

## The Observed Pattern

The `ps.log` from builder `8a992cd9` shows a clear **bursty pattern**:

| Time | What's happening | Load Avg |
|------|-----------------|----------|
| 17:45-17:46 | ~17 grype processes running | 4.98 -> 6.77 |
| 17:46-17:52 | **6 minutes: zero grype running** | 6.26 -> 0.01 |
| 17:52-17:53 | ~25 grype processes running | 0.57 -> 5.89 |
| 17:53-17:56 | **3+ minutes: zero grype running** | 5.11 -> 0.29 |

Grype finishes in seconds, but then the builder sits **idle for 3-6 minutes** before the next batch arrives. The `cat .../grype-scan.json` commands scattered through the idle periods are the poller reading results -- but it visits this builder only every **2-5 minutes**, not every 10 seconds as configured.

## The Bottleneck: The Scan Status Poller

The poller (`pollScanStatus` in `pkg/listener/update-external-image-scan-status.go:49`) runs every 10 seconds and polls all builders in parallel. However, **each builder's goroutine processes completed scans sequentially**, and that processing is extremely expensive:

**`processBuilderScans` per builder per cycle:**
1. SSH connect + `find` to list scan dirs
2. `SetBuilderScans` -- frees capacity in cache (fast, in-memory)
3. **For each completed scan dir (sequential):**
   - `handleSuccessfulScan` -> `runner.ReadFile` (SSH read of grype JSON, potentially MB-sized)
   - `storeBuilderScanResult` -> parse grype JSON (CPU) + `SetExternalImageScanStatus` (DB write)
   - **`updatePackageFixVersionsForSBOM`** -> `GetExternalImageSBOMs` (DB) + parse full SBOM (CPU) + **`UpdatePackageFixVersions` per APK package** (DB query each -- N+1 pattern)
   - `cleanupScanDir` (SSH rm)
   - `UpdateLastSecurityScanned` (DB)

The killer is `updatePackageFixVersionsForSBOM` (`pkg/listener/external-image-scan-builder.go:324`). For every completed scan arch, it iterates over **every APK package** in the SBOM (20-100+ packages) and calls `UpdatePackageFixVersions`, each acquiring a DB connection. With 32 completed scans x 2 archs x ~50 packages = **~3,200 DB queries** per builder per poll cycle.

## `UpdatePackageFixVersions` Should Not Run for External Image Scans

`UpdatePackageFixVersions` enriches the `cve_package_fix` table with `package_fixed_version` data. That table is populated exclusively by `StoreCVEMatches`, which is only called for **SecureBuild-built images** (via `saveVulnerabilityFeedData` in the build completion and catalog scan paths). The purpose is SecDB vulnerability feed generation for SecureBuild's own APK package catalog (`image`, `image_apko`, `image_apko_version` tables).

External images are arbitrary third-party images from external registries. The external image scan path **never calls `StoreCVEMatches`** -- it only calls `UpdatePackageFixVersions`, which queries `cve_package_fix` by `package_name`:

```sql
SELECT cve_id, artifact_name, artifact_type, artifact_fixed_version
FROM cve_package_fix
WHERE package_name = $1
```

This query almost always returns zero rows for external image packages, because:
- The `package_name` values in `cve_package_fix` are SecureBuild APK package names (e.g., `redis-8.0`, `bash-5.2`), not arbitrary external package names
- Even when names match by coincidence (e.g., `glibc`), the SBOM ownership relationships used by `UpdatePackageFixVersions` (`OwnershipByFileOverlapRelationship`) are SBOM-format-dependent and may not apply to external images

### Call site inventory

| Call site | Image type | Calls `StoreCVEMatches` first? | Correct? |
|-----------|-----------|-------------------------------|----------|
| `update-build-image-status.go:747` (via `saveVulnerabilityFeedData`) | SecureBuild-built | Yes (line 735) | Yes |
| `scan-catalog-image.go:87` (via `saveVulnerabilityFeedData`) | SecureBuild catalog | Yes (line 735) | Yes |
| `external-image-scan-builder.go:324` (poller result collection) | External image | **No** | **No** |
| `scan/scan.go:86` (legacy in-process path) | External image | **No** | **No** |

### Impact

The external image scan path is running thousands of DB queries per scan that almost always return zero rows, while consuming DB connections, CPU for SBOM parsing, and blocking the poller from visiting the next builder. Removing these calls would eliminate the 3-5 minute idle gaps between grype batches shown in `ps.log`.

## The Cascade Effect

```
T=0:   Poller visits builder, lists 32 completed scans, frees capacity
T=0+:  Scheduler dispatches 25-32 new scans -> grype starts on builder
T=10s: New grype processes finish (grype on SBOM is fast: 5-30s)
T=0 to T=3-5min: Poller STILL processing the 32 OLD results sequentially
       (reading JSONs over SSH, storing to DB, parsing SBOMs, 3000+ DB queries
        for package fix versions)
T=3-5min: Poller finishes old results, next cycle visits builder
T=3-5min: Discovers the new completed scans, frees capacity again
T=3-5min+: Next batch dispatched -> REPEAT
```

This creates the exact bursty pattern in `ps.log`. The builder is idle for the entire duration the poller spends processing the previous batch.

## Compounding Factors

### 1. Scheduler throughput: 25 scans per 5-second cycle

(`pkg/scan/scheduler.go:32,29`)

With 768 total capacity (24 builders x 32), it takes 30+ cycles (150+ seconds) to fill all builders. By the time the last builders are filled, the first scans have finished and the builder is idle waiting for the poller.

### 2. `SelectBuilderForScan` queries all builders from DB on every handler call

(`pkg/scan/scan_capacity.go:400`)

Each handler invocation calls `getRunningBuildersForScan` which runs a full SQL query joining `machine_pool` with `machine_assignment`. With up to 768 concurrent handlers, that's 768 identical DB queries per dispatch wave.

### 3. Sequential scan dir processing within each builder

(`pkg/listener/update-external-image-scan-status.go:127`)

```go
for _, sd := range scanDirs {
    processScanDir(ctx, cache, vm, runner, sd)
}
```

No parallelism within a builder -- 32 completed scans are processed one at a time, each involving SSH reads, DB writes, and SBOM parsing.

### 4. Catalog image scans compete for the same resources

(`status.log` shows a `syft` process running on the worker)

The `scan_catalog_image` channel runs grype in-process on the worker (not on builders). Its `UpdatePackageFixVersions` calls and DB operations are correct for catalog images (they are SecureBuild-built), but they compete with the external image scan pipeline for DB connections and CPU.

## Summary of the Stall

The pipeline stalls because **grype finishes in seconds but result collection takes minutes**, and **no new scans can be dispatched until the poller completes its current cycle and revisits the builder**. The `updatePackageFixVersionsForSBOM` N+1 DB query pattern is the dominant cost, amplified by sequential per-builder processing.

## Throughput Estimate

With ~32 scans per builder per 3-5 minute poll cycle, and ~24 builders:
- **~150-256 scans/minute** effective throughput
- **150K / 200 = ~12.5 hours** to clear the backlog (optimistic)

The actual throughput is likely lower because not all builders are always full, the scheduler can't fill them fast enough, and DB contention slows everything during result collection.

## Potential Fixes

1. **Remove `updatePackageFixVersionsForSBOM` from the external image scan path entirely** -- it should only run for SecureBuild-built images (build completion and catalog scan paths). Remove the call from `pkg/listener/external-image-scan-builder.go:324` (used by the poller in `update-external-image-scan-status.go:244`) and the call in `pkg/scan/scan.go:86` (legacy in-process path). The `updatePackageFixVersionsForSBOM` function can be deleted.
2. **Process scan dirs in parallel within each builder** -- use a worker pool per builder for `processScanDir`
3. **Increase scheduler throughput** -- more scans per cycle (e.g., 100+) and shorter interval (e.g., 1s)
4. **Cache the builder list** in `SelectBuilderForScan` instead of querying the DB on every handler call
