### PR TITLE
Limit number of ssh connections

### DIFF
--- a/pkg/buildbackend/runner.go
+++ b/pkg/buildbackend/runner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -19,6 +20,15 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
 )
+
+// ErrSSH is a sentinel error used to mark failures from SSH connection or
+// session operations (dial, NewSession). It is NOT returned for remote
+// command execution failures (e.g., cat failing on a missing file) — those
+// are file-level errors, not SSH errors.
+//
+// Callers can distinguish transient SSH outages from permanent scan failures
+// with errors.Is(err, buildbackend.ErrSSH).
+var ErrSSH = errors.New("ssh error")
 
 // Runner abstracts command execution and file operations on a build machine.
 // It can be backed by local process execution or SSH.
@@ -271,7 +281,7 @@ type SSHRunner struct {
 func NewSSHRunner(ctx context.Context, vm buildertypes.BuilderVM) (*SSHRunner, error) {
 	client, err := dialSSH(ctx, vm)
 	if err != nil {
-		return nil, fmt.Errorf("SSH connection to %s (%s:%d): %w", vm.ID, vm.IPAddress, vm.Port, err)
+		return nil, fmt.Errorf("SSH connection to %s (%s:%d): %w: %w", vm.ID, vm.IPAddress, vm.Port, ErrSSH, err)
 	}
 	return &SSHRunner{client: client, vmID: vm.ID}, nil
 }
@@ -288,7 +298,7 @@ func (r *SSHRunner) Close() error {
 func (r *SSHRunner) RunCommand(ctx context.Context, command string) (string, error) {
 	sess, err := r.client.NewSession()
 	if err != nil {
-		return "", fmt.Errorf("failed to create SSH session: %w", err)
+		return "", fmt.Errorf("failed to create SSH session: %w: %w", ErrSSH, err)
 	}
 	defer sess.Close()
 
@@ -302,7 +312,7 @@ func (r *SSHRunner) RunCommand(ctx context.Context, command string) (string, err
 func (r *SSHRunner) RunBackgroundCommand(ctx context.Context, command string, executionID string) error {
 	sess, err := r.client.NewSession()
 	if err != nil {
-		return fmt.Errorf("failed to create SSH session: %w", err)
+		return fmt.Errorf("failed to create SSH session: %w: %w", ErrSSH, err)
 	}
 	defer sess.Close()
 
@@ -328,7 +338,7 @@ func (r *SSHRunner) WriteBinaryFile(path string, data []byte) error {
 func (r *SSHRunner) ReadFile(path string) (string, error) {
 	sess, err := r.client.NewSession()
 	if err != nil {
-		return "", fmt.Errorf("failed to create SSH session: %w", err)
+		return "", fmt.Errorf("failed to create SSH session: %w: %w", ErrSSH, err)
 	}
 	defer sess.Close()
 
@@ -342,7 +352,7 @@ func (r *SSHRunner) ReadFile(path string) (string, error) {
 func (r *SSHRunner) ReadFileTail(path string, maxBytes int) (string, error) {
 	sess, err := r.client.NewSession()
 	if err != nil {
-		return "", fmt.Errorf("failed to create SSH session: %w", err)
+		return "", fmt.Errorf("failed to create SSH session: %w: %w", ErrSSH, err)
 	}
 	defer sess.Close()
 
@@ -356,7 +366,7 @@ func (r *SSHRunner) ReadFileTail(path string, maxBytes int) (string, error) {
 func (r *SSHRunner) FileExists(path string) (bool, error) {
 	sess, err := r.client.NewSession()
 	if err != nil {
-		return false, fmt.Errorf("failed to create SSH session: %w", err)
+		return false, fmt.Errorf("failed to create SSH session: %w: %w", ErrSSH, err)
 	}
 	defer sess.Close()
 
@@ -370,7 +380,7 @@ func (r *SSHRunner) FileExists(path string) (bool, error) {
 func (r *SSHRunner) MkdirAll(path string) error {
 	sess, err := r.client.NewSession()
 	if err != nil {
-		return fmt.Errorf("failed to create SSH session: %w", err)
+		return fmt.Errorf("failed to create SSH session: %w: %w", ErrSSH, err)
 	}
 	defer sess.Close()
 

--- a/pkg/gitspec/pull.go
+++ b/pkg/gitspec/pull.go
@@ -14,8 +14,8 @@ import (
 
 // SpecContent holds the content pulled from a git repo at a specific tag.
 type SpecContent struct {
-	Content    string
-	CommitSHA  string
+	Content         string
+	CommitSHA       string
 	AdditionalFiles []AdditionalFile
 }
 

--- a/pkg/image/tag_reassignment.go
+++ b/pkg/image/tag_reassignment.go
@@ -15,9 +15,9 @@ import (
 
 // APKOTagInfo represents an APKO with its tags
 type APKOTagInfo struct {
-	ID      string
-	Tags    []string
-	GitTag  string // empty if not a linked image
+	ID     string
+	Tags   []string
+	GitTag string // empty if not a linked image
 }
 
 // countVersionParts counts how many numeric parts a version string has (major, major.minor, or major.minor.patch)

--- a/pkg/image/types/types.go
+++ b/pkg/image/types/types.go
@@ -29,11 +29,11 @@ type ImageAPKO struct {
 }
 
 type ImageAPKOVersion struct {
-	ID          string
-	ImageApkoID string
-	APKOYAML    string
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	ID           string
+	ImageApkoID  string
+	APKOYAML     string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
 	GitRemote    string
 	ApkoFilePath string
 	GitCommitSHA string

--- a/pkg/listener/build-apko.go
+++ b/pkg/listener/build-apko.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 
 	"github.com/google/go-github/v61/github"
+	"github.com/securebuildhq/securebuild/pkg/gitspec"
 	image "github.com/securebuildhq/securebuild/pkg/image"
 	imagetypes "github.com/securebuildhq/securebuild/pkg/image/types"
-	"github.com/securebuildhq/securebuild/pkg/gitspec"
 	"github.com/securebuildhq/securebuild/pkg/logger"
 	"github.com/securebuildhq/securebuild/pkg/param"
 	"github.com/securebuildhq/securebuild/pkg/persistence"

--- a/pkg/listener/external-image-scan-builder.go
+++ b/pkg/listener/external-image-scan-builder.go
@@ -316,33 +316,26 @@ func buildGrypeLaunchCommand(workDir, arch string) string {
 }
 
 // storeBuilderScanResult parses and stores a successful scan result for a
-// single architecture. Returns true if the result was stored successfully.
-func storeBuilderScanResult(ctx context.Context, digest, arch, scanResult string) bool {
+// single architecture. Returns an error if parsing, marshalling, or DB
+// storage fails. The error is wrapped in a ScanFailureError with the
+// appropriate error code for the caller to pass to recordScanFailure.
+func storeBuilderScanResult(ctx context.Context, digest, arch, scanResult string) error {
 	parsedResults, err := image.ParseScanResultDetails(scanResult)
 	if err != nil {
-		recordScanFailure(ctx, digest, arch,
-			externalimage.NewScanFailureError(externalimage.ErrParseScanResult,
-				fmt.Sprintf("failed to parse scan result: %s", err.Error())),
-			false, 0, 0)
-		return false
+		return externalimage.NewScanFailureError(externalimage.ErrParseScanResult,
+			fmt.Sprintf("failed to parse scan result: %s", err.Error()))
 	}
 
 	countsJSON, err := json.Marshal(parsedResults.Counts)
 	if err != nil {
-		recordScanFailure(ctx, digest, arch,
-			externalimage.NewScanFailureError(externalimage.ErrMarshalScanCounts,
-				fmt.Sprintf("failed to marshal scan counts: %s", err.Error())),
-			false, 0, 0)
-		return false
+		return externalimage.NewScanFailureError(externalimage.ErrMarshalScanCounts,
+			fmt.Sprintf("failed to marshal scan counts: %s", err.Error()))
 	}
 
 	summaryJSON, err := json.Marshal(parsedResults)
 	if err != nil {
-		recordScanFailure(ctx, digest, arch,
-			externalimage.NewScanFailureError(externalimage.ErrMarshalScanSummary,
-				fmt.Sprintf("failed to marshal scan summary: %s", err.Error())),
-			false, 0, 0)
-		return false
+		return externalimage.NewScanFailureError(externalimage.ErrMarshalScanSummary,
+			fmt.Sprintf("failed to marshal scan summary: %s", err.Error()))
 	}
 
 	if err := externalimage.SetExternalImageScanStatus(ctx, externalimage.SetExternalImageScanStatusParams{
@@ -353,14 +346,11 @@ func storeBuilderScanResult(ctx context.Context, digest, arch, scanResult string
 		ParsedResultsDetails: string(summaryJSON),
 		RawResult:            scanResult,
 	}); err != nil {
-		recordScanFailure(ctx, digest, arch,
-			externalimage.NewScanFailureError(externalimage.ErrSaveScanStatus,
-				fmt.Sprintf("scan completed but failed to save results: %s", err.Error())),
-			false, 0, 0)
-		return false
+		return externalimage.NewScanFailureError(externalimage.ErrSaveScanStatus,
+			fmt.Sprintf("scan completed but failed to save results: %s", err.Error()))
 	}
 
-	return true
+	return nil
 }
 
 // isScanAlreadyRunning checks if any external_image_scan row for the digest

--- a/pkg/listener/package-family-update-check.go
+++ b/pkg/listener/package-family-update-check.go
@@ -46,10 +46,10 @@ import (
 )
 
 type PackageFamilyUpdateCheckPayload struct {
-	PackageFamilyID    string `json:"packageFamilyId"`
-	Tag                string `json:"tag,omitempty"`
-	Force              bool   `json:"force,omitempty"`
-	SkipImageCreation  bool   `json:"skip_image_creation,omitempty"`
+	PackageFamilyID   string `json:"packageFamilyId"`
+	Tag               string `json:"tag,omitempty"`
+	Force             bool   `json:"force,omitempty"`
+	SkipImageCreation bool   `json:"skip_image_creation,omitempty"`
 }
 
 type GitHubVersionResult struct {
@@ -1085,10 +1085,10 @@ func generateImageAPKOsForGitLinkedVersion(ctx context.Context, githubClient *gi
 	}
 
 	type linkedImage struct {
-		ImageID       string
-		GitRemote     string
-		ApkoFilePath  sql.NullString
-		TagTemplate   sql.NullString
+		ImageID      string
+		GitRemote    string
+		ApkoFilePath sql.NullString
+		TagTemplate  sql.NullString
 	}
 
 	var linkedImages []linkedImage
@@ -1263,6 +1263,7 @@ func createLinkedImageAPKO(ctx context.Context, imageID, gitRemote, apkoFilePath
 
 	return apkoID, nil
 }
+
 // pinCorePackageInApkoYAML finds the core package in the APKO YAML and pins it to the
 // specified version using the ~version syntax. Uses the same package detection logic
 // as IsPackageCoreForAPKO (matching by family name, package name, and provides).

--- a/pkg/listener/update-external-image-scan-status.go
+++ b/pkg/listener/update-external-image-scan-status.go
@@ -124,11 +124,22 @@ func processBuilderScans(ctx context.Context, cache *scan.ScanCapacityCache, vm 
 	}
 	cache.SetBuilderScans(vm.ID, activeScans)
 
+	// Process scan dirs concurrently with a bounded worker pool. The
+	// SSHRunner shares a single SSH connection, and each processScanDir
+	// call creates multiple SSH sessions (ReadFile, cleanup, etc.). Too
+	// many concurrent goroutines exceed the SSH server's MaxSessions
+	// limit (default 10 on Ubuntu), causing "ssh: rejected: connect
+	// failed (open failed)" errors that mark completed scans as failed
+	// and prevent scan dir cleanup.
+	const maxConcurrentScanDirs = 5
+	sem := make(chan struct{}, maxConcurrentScanDirs)
 	var scanWG sync.WaitGroup
 	for _, sd := range scanDirs {
 		scanWG.Add(1)
 		go func(sd scan.ScanDirStatus) {
 			defer scanWG.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
 			processScanDir(ctx, cache, vm, runner, sd)
 		}(sd)
 	}
@@ -165,7 +176,22 @@ func processScanDir(ctx context.Context, cache *scan.ScanCapacityCache, vm build
 			}
 
 			if exitCode == 0 {
-				if handled := handleSuccessfulScan(ctx, runner, sd.WorkDir, digest, arch); handled {
+				err := handleSuccessfulScan(ctx, runner, sd.WorkDir, digest, arch)
+				if err != nil {
+					if isSSHError(err) {
+						logger.Warn("transient SSH error reading grype result, will retry next cycle",
+							zap.String("digest", digest),
+							zap.String("arch", arch),
+							zap.Error(err))
+						allDone = false
+					} else {
+						logger.Warn("failed to handle successful scan",
+							zap.String("digest", digest),
+							zap.String("arch", arch),
+							zap.Error(err))
+						recordScanFailure(ctx, digest, arch, err, false, 0, 0)
+					}
+				} else {
 					successArchs = append(successArchs, arch)
 				}
 			} else {
@@ -213,40 +239,31 @@ func processScanDir(ctx context.Context, cache *scan.ScanCapacityCache, vm build
 }
 
 // handleSuccessfulScan reads the grype JSON result and stores it in the DB.
-// Returns true if the result was stored successfully.
-func handleSuccessfulScan(ctx context.Context, runner buildbackend.Runner, workDir, digest, arch string) bool {
+// Returns nil on success. On failure, returns an error:
+//   - SSH errors (transient): the caller should retry on the next poll cycle
+//     without marking the scan as failed or cleaning up the scan dir.
+//   - All other errors (permanent): the caller should call recordScanFailure
+//     and clean up the scan dir.
+func handleSuccessfulScan(ctx context.Context, runner buildbackend.Runner, workDir, digest, arch string) error {
 	grypeJSONPath := filepath.Join(workDir, arch, "grype-scan.json")
 	grypeJSON, err := runner.ReadFile(grypeJSONPath)
 	if err != nil {
-		logger.Warn("failed to read grype JSON result, marking as failed",
-			zap.String("digest", digest),
-			zap.String("arch", arch),
-			zap.Error(err))
-		recordScanFailure(ctx, digest, arch,
-			externalimage.NewScanFailureError(externalimage.ErrParseScanResult,
-				fmt.Sprintf("grype JSON result missing or unreadable: %s", err.Error())),
-			false, 0, 0)
-		return false
+		return err
 	}
 
 	if strings.TrimSpace(grypeJSON) == "" {
-		logger.Warn("grype JSON result is empty, marking as failed",
-			zap.String("digest", digest),
-			zap.String("arch", arch))
-		recordScanFailure(ctx, digest, arch,
-			externalimage.NewScanFailureError(externalimage.ErrParseScanResult,
-				"grype JSON result is empty"),
-			false, 0, 0)
-		return false
+		return externalimage.NewScanFailureError(externalimage.ErrParseScanResult,
+			"grype JSON result is empty")
 	}
 
-	stored := storeBuilderScanResult(ctx, digest, arch, grypeJSON)
-	if stored {
-		logger.Info("stored scan result",
-			zap.String("digest", digest),
-			zap.String("arch", arch))
+	if err := storeBuilderScanResult(ctx, digest, arch, grypeJSON); err != nil {
+		return err
 	}
-	return stored
+
+	logger.Info("stored scan result",
+		zap.String("digest", digest),
+		zap.String("arch", arch))
+	return nil
 }
 
 // handleFailedScan reads the grype stderr and records the scan failure.
@@ -398,4 +415,19 @@ func reenqueueScan(ctx context.Context, digest string) {
 
 	logger.Info("re-enqueued external image scan",
 		zap.String("digest", digest))
+}
+
+// isSSHError returns true if the error is caused by an SSH connection or
+// session failure (e.g., MaxSessions exceeded, connection dropped). These
+// are transient: the grype output is on the builder, we just can't read it
+// right now. The poller will retry on the next cycle with a fresh SSH
+// connection.
+func isSSHError(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "ssh:") ||
+		strings.Contains(msg, "SSH") ||
+		strings.Contains(msg, "handshake failed") ||
+		strings.Contains(msg, "connect failed") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "EOF")
 }

--- a/pkg/listener/update-external-image-scan-status.go
+++ b/pkg/listener/update-external-image-scan-status.go
@@ -3,6 +3,7 @@ package listener
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -175,22 +176,22 @@ func processScanDir(ctx context.Context, cache *scan.ScanCapacityCache, vm build
 				exitCode = 1
 			}
 
-			if exitCode == 0 {
-				err := handleSuccessfulScan(ctx, runner, sd.WorkDir, digest, arch)
-				if err != nil {
-					if isSSHError(err) {
-						logger.Warn("transient SSH error reading grype result, will retry next cycle",
-							zap.String("digest", digest),
-							zap.String("arch", arch),
-							zap.Error(err))
-						allDone = false
-					} else {
-						logger.Warn("failed to handle successful scan",
-							zap.String("digest", digest),
-							zap.String("arch", arch),
-							zap.Error(err))
-						recordScanFailure(ctx, digest, arch, err, false, 0, 0)
-					}
+		if exitCode == 0 {
+			err := handleSuccessfulScan(ctx, runner, sd.WorkDir, digest, arch)
+			if err != nil {
+				if errors.Is(err, buildbackend.ErrSSH) {
+					logger.Warn("transient SSH error reading grype result, will retry next cycle",
+						zap.String("digest", digest),
+						zap.String("arch", arch),
+						zap.Error(err))
+					allDone = false
+				} else {
+					logger.Warn("failed to handle successful scan",
+						zap.String("digest", digest),
+						zap.String("arch", arch),
+						zap.Error(err))
+					recordScanFailure(ctx, digest, arch, err, false, 0, 0)
+				}
 				} else {
 					successArchs = append(successArchs, arch)
 				}
@@ -415,19 +416,4 @@ func reenqueueScan(ctx context.Context, digest string) {
 
 	logger.Info("re-enqueued external image scan",
 		zap.String("digest", digest))
-}
-
-// isSSHError returns true if the error is caused by an SSH connection or
-// session failure (e.g., MaxSessions exceeded, connection dropped). These
-// are transient: the grype output is on the builder, we just can't read it
-// right now. The poller will retry on the next cycle with a fresh SSH
-// connection.
-func isSSHError(err error) bool {
-	msg := err.Error()
-	return strings.Contains(msg, "ssh:") ||
-		strings.Contains(msg, "SSH") ||
-		strings.Contains(msg, "handshake failed") ||
-		strings.Contains(msg, "connect failed") ||
-		strings.Contains(msg, "connection refused") ||
-		strings.Contains(msg, "EOF")
 }


### PR DESCRIPTION
- limit number of ssh connections when reading scan results from builders (sshd default on Ubuntu is 10)
- treat ssh errors as transient when reading scan results