### PR TITLE
Use tar/gzip to read scan results from VMs instead of copying individual files

### DIFF
--- a/pkg/buildbackend/runner.go
+++ b/pkg/buildbackend/runner.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -20,15 +19,6 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
 )
-
-// ErrSSH is a sentinel error used to mark failures from SSH connection or
-// session operations (dial, NewSession). It is NOT returned for remote
-// command execution failures (e.g., cat failing on a missing file) — those
-// are file-level errors, not SSH errors.
-//
-// Callers can distinguish transient SSH outages from permanent scan failures
-// with errors.Is(err, buildbackend.ErrSSH).
-var ErrSSH = errors.New("ssh error")
 
 // Runner abstracts command execution and file operations on a build machine.
 // It can be backed by local process execution or SSH.
@@ -281,7 +271,7 @@ type SSHRunner struct {
 func NewSSHRunner(ctx context.Context, vm buildertypes.BuilderVM) (*SSHRunner, error) {
 	client, err := dialSSH(ctx, vm)
 	if err != nil {
-		return nil, fmt.Errorf("SSH connection to %s (%s:%d): %w: %w", vm.ID, vm.IPAddress, vm.Port, ErrSSH, err)
+		return nil, fmt.Errorf("SSH connection to %s (%s:%d): %w: %w", vm.ID, vm.IPAddress, vm.Port, builder.ErrSSH, err)
 	}
 	return &SSHRunner{client: client, vmID: vm.ID}, nil
 }
@@ -298,7 +288,7 @@ func (r *SSHRunner) Close() error {
 func (r *SSHRunner) RunCommand(ctx context.Context, command string) (string, error) {
 	sess, err := r.client.NewSession()
 	if err != nil {
-		return "", fmt.Errorf("failed to create SSH session: %w: %w", ErrSSH, err)
+		return "", fmt.Errorf("failed to create SSH session: %w: %w", builder.ErrSSH, err)
 	}
 	defer sess.Close()
 
@@ -312,7 +302,7 @@ func (r *SSHRunner) RunCommand(ctx context.Context, command string) (string, err
 func (r *SSHRunner) RunBackgroundCommand(ctx context.Context, command string, executionID string) error {
 	sess, err := r.client.NewSession()
 	if err != nil {
-		return fmt.Errorf("failed to create SSH session: %w: %w", ErrSSH, err)
+		return fmt.Errorf("failed to create SSH session: %w: %w", builder.ErrSSH, err)
 	}
 	defer sess.Close()
 
@@ -338,7 +328,7 @@ func (r *SSHRunner) WriteBinaryFile(path string, data []byte) error {
 func (r *SSHRunner) ReadFile(path string) (string, error) {
 	sess, err := r.client.NewSession()
 	if err != nil {
-		return "", fmt.Errorf("failed to create SSH session: %w: %w", ErrSSH, err)
+		return "", fmt.Errorf("failed to create SSH session: %w: %w", builder.ErrSSH, err)
 	}
 	defer sess.Close()
 
@@ -352,7 +342,7 @@ func (r *SSHRunner) ReadFile(path string) (string, error) {
 func (r *SSHRunner) ReadFileTail(path string, maxBytes int) (string, error) {
 	sess, err := r.client.NewSession()
 	if err != nil {
-		return "", fmt.Errorf("failed to create SSH session: %w: %w", ErrSSH, err)
+		return "", fmt.Errorf("failed to create SSH session: %w: %w", builder.ErrSSH, err)
 	}
 	defer sess.Close()
 
@@ -366,7 +356,7 @@ func (r *SSHRunner) ReadFileTail(path string, maxBytes int) (string, error) {
 func (r *SSHRunner) FileExists(path string) (bool, error) {
 	sess, err := r.client.NewSession()
 	if err != nil {
-		return false, fmt.Errorf("failed to create SSH session: %w: %w", ErrSSH, err)
+		return false, fmt.Errorf("failed to create SSH session: %w: %w", builder.ErrSSH, err)
 	}
 	defer sess.Close()
 
@@ -380,7 +370,7 @@ func (r *SSHRunner) FileExists(path string) (bool, error) {
 func (r *SSHRunner) MkdirAll(path string) error {
 	sess, err := r.client.NewSession()
 	if err != nil {
-		return fmt.Errorf("failed to create SSH session: %w: %w", ErrSSH, err)
+		return fmt.Errorf("failed to create SSH session: %w: %w", builder.ErrSSH, err)
 	}
 	defer sess.Close()
 

--- a/pkg/builder/pool.go
+++ b/pkg/builder/pool.go
@@ -782,7 +782,17 @@ func InstallBuildEnv(ctx context.Context, vmID string) error {
 	// Install Docker
 	{
 		if err := installDocker(ctx, vm); err != nil {
-			return fmt.Errorf("failed to install docker on VM %s: %w", vmID, err)
+			return fmt.Errorf("failed to install docker on VM %s: %w", vm.ID, err)
+		}
+	}
+
+	// Configure SSH MaxSessions for CMX VMs to allow many concurrent
+	// poller sessions for scan result collection.
+	{
+		if err := configureSSHMaxSessions(ctx, vm); err != nil {
+			logger.Warn("failed to configure SSH MaxSessions, proceeding with default",
+				zap.String("vmID", vmID),
+				zap.Error(err))
 		}
 	}
 
@@ -1449,6 +1459,55 @@ sudo docker --version
 	if err != nil {
 		return fmt.Errorf("failed to install docker on VM %s: %w", vm.ID, err)
 	}
+
+	return nil
+}
+
+// configureSSHMaxSessions raises MaxSessions on CMX builder VMs so the
+// scan poller can open many concurrent SSH sessions (for reading grype
+// results, cleaning up scan dirs, etc.) without hitting the default
+// limit of 10. Local and static VMs are skipped.
+func configureSSHMaxSessions(ctx context.Context, vm types.BuilderVM) error {
+	if vm.Type == "local" {
+		return nil
+	}
+
+	client, err := GetSSHClient(ctx, vm)
+	if err != nil {
+		return fmt.Errorf("failed to get ssh client for VM %s: %w", vm.ID, err)
+	}
+	defer client.Close()
+
+	cmd := `sudo sed -i 's/^#\?MaxSessions.*/MaxSessions 500/' /etc/ssh/sshd_config && sudo systemctl restart sshd`
+
+	stdoutCh := make(chan string)
+	stderrCh := make(chan string)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for line := range stdoutCh {
+			logger.Debug("configure MaxSessions stdout", zap.String("vmID", vm.ID), zap.String("output", line))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for line := range stderrCh {
+			logger.Debug("configure MaxSessions stderr", zap.String("vmID", vm.ID), zap.String("output", line))
+		}
+	}()
+
+	err = RunCommand(ctx, client.Client, vm.ID, cmd, stdoutCh, stderrCh)
+	wg.Wait()
+
+	if err != nil {
+		return fmt.Errorf("failed to configure MaxSessions on VM %s: %w", vm.ID, err)
+	}
+
+	logger.Info("configured MaxSessions on builder VM",
+		zap.String("vmID", vm.ID),
+		zap.String("type", vm.Type),
+		zap.Int("maxSessions", 500))
 
 	return nil
 }

--- a/pkg/builder/ssh.go
+++ b/pkg/builder/ssh.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -17,6 +18,11 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
 )
+
+// ErrSSH is a sentinel error marking SSH connection or session failures
+// (dial, NewSession). Callers can distinguish transient SSH outages from
+// permanent errors with errors.Is(err, builder.ErrSSH).
+var ErrSSH = errors.New("ssh error")
 
 func GetSSHSession(ctx context.Context, id string) (*types.SSHSession, error) {
 	conn := persistence.MustGetPooledPostgresSession(ctx)
@@ -43,7 +49,7 @@ func GetSSHSession(ctx context.Context, id string) (*types.SSHSession, error) {
 func CreateRemoteTextFile(client *ssh.Client, path string, content string) error {
 	sess, err := client.NewSession()
 	if err != nil {
-		return fmt.Errorf("failed to create ssh session for %s: %w", path, err)
+		return fmt.Errorf("failed to create ssh session for %s: %w: %w", path, ErrSSH, err)
 	}
 	stdin, err := sess.StdinPipe()
 	if err != nil {
@@ -67,7 +73,7 @@ func CreateRemoteTextFile(client *ssh.Client, path string, content string) error
 func CreateRemoteBinaryFile(client *ssh.Client, path string, data []byte) error {
 	sess, err := client.NewSession()
 	if err != nil {
-		return fmt.Errorf("failed to create ssh session for %s: %w", path, err)
+		return fmt.Errorf("failed to create ssh session for %s: %w: %w", path, ErrSSH, err)
 	}
 	stdin, err := sess.StdinPipe()
 	if err != nil {
@@ -90,7 +96,7 @@ func CreateRemoteBinaryFile(client *ssh.Client, path string, data []byte) error 
 func CopyFileFromRemote(client *ssh.Client, remotePath string, localPath string) error {
 	sess, err := client.NewSession()
 	if err != nil {
-		return fmt.Errorf("failed to create ssh session: %w", err)
+		return fmt.Errorf("failed to create ssh session: %w: %w", ErrSSH, err)
 	}
 	defer sess.Close()
 
@@ -203,7 +209,7 @@ func ListRemoteFiles(client *ssh.Client, path string) ([]string, error) {
 	logger.Debug("listing remote files", zap.String("path", path))
 	sess, err := client.NewSession()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create ssh session: %w", err)
+		return nil, fmt.Errorf("failed to create ssh session: %w: %w", ErrSSH, err)
 	}
 	defer sess.Close()
 
@@ -279,7 +285,7 @@ func RunCommand(ctx context.Context, client *ssh.Client, vmID string, command st
 			// DebugVMStatus is defined in pool.go but in the same package
 			DebugVMStatus(ctx, vmID)
 		}
-		return fmt.Errorf("failed to create ssh session: %w", err)
+		return fmt.Errorf("failed to create ssh session: %w: %w", ErrSSH, err)
 	}
 	defer sess.Close()
 
@@ -482,7 +488,7 @@ func GetRemoteFileChecksum(client *ssh.Client, remotePath string) (string, error
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		sess, err := client.NewSession()
 		if err != nil {
-			lastErr = fmt.Errorf("attempt %d failed to create ssh session: %w", attempt+1, err)
+			lastErr = fmt.Errorf("attempt %d failed to create ssh session: %w: %w", attempt+1, ErrSSH, err)
 
 			if attempt < maxRetries-1 {
 				// Calculate exponential backoff delay: 2s, 4s, 8s
@@ -786,7 +792,7 @@ func CopyFileFromRemoteVerified(client *ssh.Client, remotePath string, localPath
 func AnalyzeAPKStructure(client *ssh.Client, remotePath string) error {
 	sess, err := client.NewSession()
 	if err != nil {
-		return fmt.Errorf("failed to create ssh session: %w", err)
+		return fmt.Errorf("failed to create ssh session: %w: %w", ErrSSH, err)
 	}
 	defer sess.Close()
 
@@ -811,7 +817,7 @@ func AnalyzeAPKStructure(client *ssh.Client, remotePath string) error {
 func CheckMelangeOutput(client *ssh.Client, arch string) error {
 	sess, err := client.NewSession()
 	if err != nil {
-		return fmt.Errorf("failed to create ssh session: %w", err)
+		return fmt.Errorf("failed to create ssh session: %w: %w", ErrSSH, err)
 	}
 	defer sess.Close()
 

--- a/pkg/listener/external-image-scan-builder.go
+++ b/pkg/listener/external-image-scan-builder.go
@@ -173,7 +173,6 @@ func HandleExternalImageScanOnBuilder(ctx context.Context, payloadJSON string) e
 func dispatchScanToBuilder(ctx context.Context, cache *scan.ScanCapacityCache, digest string, sbomByArch map[string]string, archsToScan []string) error {
 	span, ctx := telemetry.StartSpan(ctx, "listener.dispatch_scan_to_builder")
 	defer span.Finish()
-	span.SetTag("digest", digest)
 
 	builderVM, err := scan.SelectBuilderForScan(ctx, cache)
 	if err != nil {

--- a/pkg/listener/external-image-scan-builder.go
+++ b/pkg/listener/external-image-scan-builder.go
@@ -15,6 +15,7 @@ import (
 	"github.com/securebuildhq/securebuild/pkg/logger"
 	"github.com/securebuildhq/securebuild/pkg/persistence"
 	"github.com/securebuildhq/securebuild/pkg/scan"
+	"github.com/securebuildhq/securebuild/pkg/telemetry"
 	"go.uber.org/zap"
 )
 
@@ -170,6 +171,10 @@ func HandleExternalImageScanOnBuilder(ctx context.Context, payloadJSON string) e
 //     grype processes are killed before returning, preventing orphaned
 //     processes that would race with a retry on a different builder.
 func dispatchScanToBuilder(ctx context.Context, cache *scan.ScanCapacityCache, digest string, sbomByArch map[string]string, archsToScan []string) error {
+	span, ctx := telemetry.StartSpan(ctx, "listener.dispatch_scan_to_builder")
+	defer span.Finish()
+	span.SetTag("digest", digest)
+
 	builderVM, err := scan.SelectBuilderForScan(ctx, cache)
 	if err != nil {
 		return fmt.Errorf("failed to select builder for scan: %w", err)

--- a/pkg/listener/update-external-image-scan-status.go
+++ b/pkg/listener/update-external-image-scan-status.go
@@ -1,10 +1,13 @@
 package listener
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -12,6 +15,7 @@ import (
 	"time"
 
 	"github.com/securebuildhq/securebuild/pkg/buildbackend"
+	"github.com/securebuildhq/securebuild/pkg/builder"
 	buildertypes "github.com/securebuildhq/securebuild/pkg/builder/types"
 	"github.com/securebuildhq/securebuild/pkg/externalimage"
 	"github.com/securebuildhq/securebuild/pkg/listener/types"
@@ -82,10 +86,16 @@ func pollScanStatus(ctx context.Context, cache *scan.ScanCapacityCache) error {
 
 // processBuilderScans checks all scan directories on a single builder,
 // collects results for completed scans, and cleans up finished scan dirs.
+//
+// Completed scans are batched: a single tar is created on the VM containing
+// all grype-scan.json and grype.stderr files, transferred in one SSH session,
+// and processed locally. This avoids opening dozens of individual SSH
+// sessions (one per file) that exhaust the SSH server's MaxSessions limit.
+// Scan dirs that are still in-progress or have timed-out archs are handled
+// individually since they require interactive SSH commands (kill, write).
 func processBuilderScans(ctx context.Context, cache *scan.ScanCapacityCache, vm buildertypes.BuilderVM) {
 	span, ctx := telemetry.StartSpan(ctx, "listener.process_builder_scans")
 	defer span.Finish()
-	span.SetTag("machine_id", vm.ID)
 
 	baseDir, err := scan.ResolveScanBaseDir(ctx, vm)
 	if err != nil {
@@ -129,26 +139,265 @@ func processBuilderScans(ctx context.Context, cache *scan.ScanCapacityCache, vm 
 	}
 	cache.SetBuilderScans(vm.ID, activeScans)
 
-	// Process scan dirs concurrently with a bounded worker pool. The
-	// SSHRunner shares a single SSH connection, and each processScanDir
-	// call creates multiple SSH sessions (ReadFile, cleanup, etc.). Too
-	// many concurrent goroutines exceed the SSH server's MaxSessions
-	// limit (default 10 on Ubuntu), causing "ssh: rejected: connect
-	// failed (open failed)" errors that mark completed scans as failed
-	// and prevent scan dir cleanup.
-	const maxConcurrentScanDirs = 5
-	sem := make(chan struct{}, maxConcurrentScanDirs)
-	var scanWG sync.WaitGroup
+	// Partition scan dirs into completed (batch via tar) and in-progress
+	// (handle individually for timeout/kill).
+	var completedDirs []scan.ScanDirStatus
+	var inProgressDirs []scan.ScanDirStatus
 	for _, sd := range scanDirs {
-		scanWG.Add(1)
-		go func(sd scan.ScanDirStatus) {
-			defer scanWG.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-			processScanDir(ctx, cache, vm, runner, sd)
-		}(sd)
+		if sd.AllArchsDone && len(sd.ArchStatuses) > 0 {
+			completedDirs = append(completedDirs, sd)
+		} else {
+			inProgressDirs = append(inProgressDirs, sd)
+		}
 	}
-	scanWG.Wait()
+
+	// Handle in-progress scans individually (timeout detection, kill).
+	for _, sd := range inProgressDirs {
+		processScanDir(ctx, cache, vm, runner, sd)
+	}
+
+	// Batch-collect completed scans via a single tar transfer.
+	if len(completedDirs) > 0 {
+		processCompletedScansBatch(ctx, cache, vm, runner, baseDir, completedDirs)
+	}
+}
+
+// processCompletedScansBatch transfers all completed scan results from the
+// builder in a single tar archive, processes them locally, and cleans up
+// all completed scan dirs with a single rm -rf command. This replaces the
+// per-scan-dir SSH ReadFile + cleanup approach that opened dozens of SSH
+// sessions.
+func processCompletedScansBatch(ctx context.Context, cache *scan.ScanCapacityCache, vm buildertypes.BuilderVM, runner buildbackend.Runner, baseDir string, completedDirs []scan.ScanDirStatus) {
+	span, ctx := telemetry.StartSpan(ctx, "listener.process_completed_scans_batch")
+	defer span.Finish()
+
+	// Build a list of relative paths to include in the tar. For each
+	// completed scan dir, include grype-scan.json and grype.stderr for
+	// every arch that has an exit_code file (i.e., grype finished).
+	type archResult struct {
+		digest    string
+		arch      string
+		exitCode  int
+		grypePath string
+		stderrRel string
+	}
+	var results []archResult
+	var tarRelPaths []string
+
+	for _, sd := range completedDirs {
+		if sd.Metadata.Digest == "" {
+			continue
+		}
+		relDir, err := filepath.Rel(baseDir, sd.WorkDir)
+		if err != nil {
+			continue
+		}
+		for arch, status := range sd.ArchStatuses {
+			if !status.Done {
+				continue
+			}
+			exitCode, parseErr := strconv.Atoi(strings.TrimSpace(status.ExitCode))
+			if parseErr != nil {
+				exitCode = 1
+			}
+			grypeRel := filepath.Join(relDir, arch, "grype-scan.json")
+			stderrRel := filepath.Join(relDir, arch, "output", "grype.stderr")
+			tarRelPaths = append(tarRelPaths, grypeRel, stderrRel)
+			results = append(results, archResult{
+				digest:    sd.Metadata.Digest,
+				arch:      arch,
+				exitCode:  exitCode,
+				grypePath: grypeRel,
+				stderrRel: stderrRel,
+			})
+		}
+	}
+
+	if len(tarRelPaths) == 0 {
+		return
+	}
+
+	// Create tar on the VM containing all result files. Use --null -T -
+	// with a null-delimited file list to handle paths with colons (digests).
+	localDir, err := os.MkdirTemp("", "scan-results-*")
+	if err != nil {
+		logger.Warn("failed to create temp dir for scan results, falling back to per-dir processing",
+			zap.String("machineID", vm.ID),
+			zap.Error(err))
+		for _, sd := range completedDirs {
+			processScanDir(ctx, cache, vm, runner, sd)
+		}
+		return
+	}
+	defer os.RemoveAll(localDir)
+
+	if err := tarScanResultsFromBuilder(ctx, runner, baseDir, localDir, tarRelPaths); err != nil {
+		if errors.Is(err, builder.ErrSSH) {
+			logger.Warn("transient SSH error during batch tar transfer, will retry next cycle",
+				zap.String("machineID", vm.ID),
+				zap.Error(err))
+			return
+		}
+		logger.Warn("failed to batch transfer scan results, falling back to per-dir processing",
+			zap.String("machineID", vm.ID),
+			zap.Error(err))
+		for _, sd := range completedDirs {
+			processScanDir(ctx, cache, vm, runner, sd)
+		}
+		return
+	}
+
+	// Process results locally from the extracted tar.
+	now := time.Now().UTC()
+	var dirsToCleanup []string
+	successByDigest := make(map[string][]string)
+
+	for _, r := range results {
+		grypeJSON := ""
+		grypeLocalPath := filepath.Join(localDir, r.grypePath)
+		if data, err := os.ReadFile(grypeLocalPath); err == nil {
+			grypeJSON = string(data)
+		}
+
+		if r.exitCode == 0 {
+			if strings.TrimSpace(grypeJSON) == "" {
+				recordScanFailure(ctx, r.digest, r.arch,
+					externalimage.NewScanFailureError(externalimage.ErrParseScanResult,
+						"grype JSON result is empty"),
+					false, 0, 0)
+				logger.Warn("grype JSON result is empty",
+					zap.String("digest", r.digest),
+					zap.String("arch", r.arch))
+			} else if err := storeBuilderScanResult(ctx, r.digest, r.arch, grypeJSON); err != nil {
+				logger.Warn("failed to store scan result",
+					zap.String("digest", r.digest),
+					zap.String("arch", r.arch),
+					zap.Error(err))
+				recordScanFailure(ctx, r.digest, r.arch, err, false, 0, 0)
+			} else {
+				logger.Info("stored scan result",
+					zap.String("digest", r.digest),
+					zap.String("arch", r.arch))
+				successByDigest[r.digest] = append(successByDigest[r.digest], r.arch)
+			}
+		} else {
+			stderr := ""
+			stderrLocalPath := filepath.Join(localDir, r.stderrRel)
+			if data, err := os.ReadFile(stderrLocalPath); err == nil {
+				stderr = strings.TrimRight(string(data), "\n\r")
+			}
+			msg := fmt.Sprintf("grype exited with code %d", r.exitCode)
+			if stderr != "" {
+				msg = fmt.Sprintf("grype exited with code %d: %s", r.exitCode, stderr)
+			}
+			recordScanFailure(ctx, r.digest, r.arch,
+				externalimage.NewScanFailureError(externalimage.ErrScanExecutionFailed, msg),
+				false, 0, 0)
+			logger.Warn("scan failed",
+				zap.String("digest", r.digest),
+				zap.String("arch", r.arch),
+				zap.Int("exitCode", r.exitCode))
+		}
+	}
+
+	// Update last_security_scanned and collect dirs for batch cleanup.
+	for _, sd := range completedDirs {
+		if sd.Metadata.Digest == "" {
+			continue
+		}
+		scannedArchs := make([]string, 0, len(sd.ArchStatuses))
+		for arch := range sd.ArchStatuses {
+			scannedArchs = append(scannedArchs, arch)
+		}
+		if err := scan.UpdateLastSecurityScanned(ctx, sd.Metadata.Digest, scannedArchs, now); err != nil {
+			logger.Warn("failed to update last_security_scanned_at",
+				zap.String("digest", sd.Metadata.Digest),
+				zap.Error(err))
+		}
+		cache.RemoveScan(vm.ID, sd.Metadata.Digest)
+		dirsToCleanup = append(dirsToCleanup, sd.WorkDir)
+
+		logger.Info("completed scan collection for digest",
+			zap.String("digest", sd.Metadata.Digest),
+			zap.Int("archs", len(sd.ArchStatuses)),
+			zap.Int("succeeded", len(successByDigest[sd.Metadata.Digest])),
+			zap.String("machineID", vm.ID))
+	}
+
+	// Batch cleanup: single rm -rf for all completed scan dirs.
+	if len(dirsToCleanup) > 0 {
+		cleanupScanDirsBatch(ctx, runner, dirsToCleanup)
+	}
+}
+
+// tarScanResultsFromBuilder creates a tar.gz on the VM containing the given
+// relative paths (relative to baseDir), transfers it locally, and extracts
+// it into localDir.
+func tarScanResultsFromBuilder(ctx context.Context, runner buildbackend.Runner, baseDir, localDir string, relPaths []string) error {
+	// Write the file list to a temp file on the VM, then tar from it.
+	// Using --null -T - with null-delimited input handles paths with
+	// colons (digests like sha256:abc...) safely.
+	listContent := strings.Join(relPaths, "\x00") + "\x00"
+
+	remoteListPath := fmt.Sprintf("/tmp/scan-tar-list-%d.txt", time.Now().UnixNano())
+	remoteTarPath := fmt.Sprintf("/tmp/scan-tar-%d.tar.gz", time.Now().UnixNano())
+
+	if err := runner.WriteFile(remoteListPath, listContent); err != nil {
+		return fmt.Errorf("failed to write file list to VM: %w", err)
+	}
+
+	tarCmd := fmt.Sprintf("cd %q && tar -czf %q --null -T %q && rm -f %q",
+		baseDir, remoteTarPath, remoteListPath, remoteListPath)
+	if _, err := runner.RunCommand(ctx, tarCmd); err != nil {
+		_, _ = runner.RunCommand(ctx, fmt.Sprintf("rm -f %q %q", remoteListPath, remoteTarPath))
+		return fmt.Errorf("failed to create tar on VM: %w", err)
+	}
+
+	// Copy tar to local temp file and extract.
+	tmpFile, err := os.CreateTemp("", "scan-tar-*.tar.gz")
+	if err != nil {
+		_, _ = runner.RunCommand(ctx, fmt.Sprintf("rm -f %q", remoteTarPath))
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+
+	if err := runner.CopyToLocal(remoteTarPath, tmpPath); err != nil {
+		_, _ = runner.RunCommand(ctx, fmt.Sprintf("rm -f %q", remoteTarPath))
+		return fmt.Errorf("failed to copy tar from VM: %w", err)
+	}
+
+	// Clean up remote tar.
+	_, _ = runner.RunCommand(ctx, fmt.Sprintf("rm -f %q", remoteTarPath))
+
+	// Extract locally.
+	extractCmd := exec.CommandContext(ctx, "tar", "-xzf", tmpPath, "-C", localDir)
+	var stderr bytes.Buffer
+	extractCmd.Stderr = &stderr
+	if err := extractCmd.Run(); err != nil {
+		return fmt.Errorf("failed to extract tar: %w (stderr: %s)", err, stderr.String())
+	}
+
+	return nil
+}
+
+// cleanupScanDirsBatch removes multiple scan directories in a single SSH
+// command.
+func cleanupScanDirsBatch(ctx context.Context, runner buildbackend.Runner, workDirs []string) {
+	span, _ := telemetry.StartSpan(ctx, "listener.cleanup_scan_dirs_batch")
+	defer span.Finish()
+
+	quoted := make([]string, len(workDirs))
+	for i, d := range workDirs {
+		quoted[i] = fmt.Sprintf("%q", d)
+	}
+	cmd := "rm -rf " + strings.Join(quoted, " ")
+	if _, err := runner.RunCommand(ctx, cmd); err != nil {
+		logger.Warn("failed to batch clean up scan dirs on builder",
+			zap.Strings("workDirs", workDirs),
+			zap.Error(err))
+	}
 }
 
 // processScanDir processes a single scan directory on a builder.
@@ -180,22 +429,22 @@ func processScanDir(ctx context.Context, cache *scan.ScanCapacityCache, vm build
 				exitCode = 1
 			}
 
-		if exitCode == 0 {
-			err := handleSuccessfulScan(ctx, runner, sd.WorkDir, digest, arch)
-			if err != nil {
-				if errors.Is(err, buildbackend.ErrSSH) {
-					logger.Warn("transient SSH error reading grype result, will retry next cycle",
-						zap.String("digest", digest),
-						zap.String("arch", arch),
-						zap.Error(err))
-					allDone = false
-				} else {
-					logger.Warn("failed to handle successful scan",
-						zap.String("digest", digest),
-						zap.String("arch", arch),
-						zap.Error(err))
-					recordScanFailure(ctx, digest, arch, err, false, 0, 0)
-				}
+			if exitCode == 0 {
+				err := handleSuccessfulScan(ctx, runner, sd.WorkDir, digest, arch)
+				if err != nil {
+					if errors.Is(err, builder.ErrSSH) {
+						logger.Warn("transient SSH error reading grype result, will retry next cycle",
+							zap.String("digest", digest),
+							zap.String("arch", arch),
+							zap.Error(err))
+						allDone = false
+					} else {
+						logger.Warn("failed to handle successful scan",
+							zap.String("digest", digest),
+							zap.String("arch", arch),
+							zap.Error(err))
+						recordScanFailure(ctx, digest, arch, err, false, 0, 0)
+					}
 				} else {
 					successArchs = append(successArchs, arch)
 				}
@@ -252,8 +501,6 @@ func processScanDir(ctx context.Context, cache *scan.ScanCapacityCache, vm build
 func handleSuccessfulScan(ctx context.Context, runner buildbackend.Runner, workDir, digest, arch string) error {
 	span, ctx := telemetry.StartSpan(ctx, "listener.handle_successful_scan")
 	defer span.Finish()
-	span.SetTag("digest", digest)
-	span.SetTag("arch", arch)
 
 	grypeJSONPath := filepath.Join(workDir, arch, "grype-scan.json")
 	grypeJSON, err := runner.ReadFile(grypeJSONPath)
@@ -281,9 +528,6 @@ func handleSuccessfulScan(ctx context.Context, runner buildbackend.Runner, workD
 func handleFailedScan(ctx context.Context, runner buildbackend.Runner, workDir, digest, arch string, exitCode int) {
 	span, ctx := telemetry.StartSpan(ctx, "listener.handle_failed_scan")
 	defer span.Finish()
-	span.SetTag("digest", digest)
-	span.SetTag("arch", arch)
-	span.SetTag("exit_code", exitCode)
 
 	stderrPath := filepath.Join(workDir, arch, "output", "grype.stderr")
 	stderr := ""
@@ -373,7 +617,6 @@ func writeExitCode(ctx context.Context, runner buildbackend.Runner, workDir, arc
 func cleanupScanDir(ctx context.Context, runner buildbackend.Runner, workDir string) {
 	span, _ := telemetry.StartSpan(ctx, "listener.cleanup_scan_dir")
 	defer span.Finish()
-	span.SetTag("work_dir", workDir)
 
 	cmd := fmt.Sprintf("rm -rf %q", workDir)
 	if _, err := runner.RunCommand(ctx, cmd); err != nil {

--- a/pkg/listener/update-external-image-scan-status.go
+++ b/pkg/listener/update-external-image-scan-status.go
@@ -83,6 +83,10 @@ func pollScanStatus(ctx context.Context, cache *scan.ScanCapacityCache) error {
 // processBuilderScans checks all scan directories on a single builder,
 // collects results for completed scans, and cleans up finished scan dirs.
 func processBuilderScans(ctx context.Context, cache *scan.ScanCapacityCache, vm buildertypes.BuilderVM) {
+	span, ctx := telemetry.StartSpan(ctx, "listener.process_builder_scans")
+	defer span.Finish()
+	span.SetTag("machine_id", vm.ID)
+
 	baseDir, err := scan.ResolveScanBaseDir(ctx, vm)
 	if err != nil {
 		logger.Warn("failed to resolve scan base dir for builder, skipping",
@@ -246,6 +250,11 @@ func processScanDir(ctx context.Context, cache *scan.ScanCapacityCache, vm build
 //   - All other errors (permanent): the caller should call recordScanFailure
 //     and clean up the scan dir.
 func handleSuccessfulScan(ctx context.Context, runner buildbackend.Runner, workDir, digest, arch string) error {
+	span, ctx := telemetry.StartSpan(ctx, "listener.handle_successful_scan")
+	defer span.Finish()
+	span.SetTag("digest", digest)
+	span.SetTag("arch", arch)
+
 	grypeJSONPath := filepath.Join(workDir, arch, "grype-scan.json")
 	grypeJSON, err := runner.ReadFile(grypeJSONPath)
 	if err != nil {
@@ -270,6 +279,12 @@ func handleSuccessfulScan(ctx context.Context, runner buildbackend.Runner, workD
 // handleFailedScan reads the grype stderr and records the scan failure.
 // Grype failures are non-retryable (same SBOM gives same result).
 func handleFailedScan(ctx context.Context, runner buildbackend.Runner, workDir, digest, arch string, exitCode int) {
+	span, ctx := telemetry.StartSpan(ctx, "listener.handle_failed_scan")
+	defer span.Finish()
+	span.SetTag("digest", digest)
+	span.SetTag("arch", arch)
+	span.SetTag("exit_code", exitCode)
+
 	stderrPath := filepath.Join(workDir, arch, "output", "grype.stderr")
 	stderr := ""
 	if content, err := runner.ReadFileTail(stderrPath, 10240); err == nil {
@@ -356,6 +371,10 @@ func writeExitCode(ctx context.Context, runner buildbackend.Runner, workDir, arc
 
 // cleanupScanDir removes the scan work directory from the builder.
 func cleanupScanDir(ctx context.Context, runner buildbackend.Runner, workDir string) {
+	span, _ := telemetry.StartSpan(ctx, "listener.cleanup_scan_dir")
+	defer span.Finish()
+	span.SetTag("work_dir", workDir)
+
 	cmd := fmt.Sprintf("rm -rf %q", workDir)
 	if _, err := runner.RunCommand(ctx, cmd); err != nil {
 		logger.Warn("failed to clean up scan dir on builder",


### PR DESCRIPTION
- Use tar/gzip to read scan results from VM. Image scans happen within minutes, but it may take several minutes to read scan results from remote VMs. Instead of copying individual files, we can use tar archive to copy all files in one go.
- Increase default number of allowed ssh connections from 10 to 500
- Add traces to collect performance metrics.