### PR TITLE
Handle v prefix in git tags for linked packages and images

### DIFF
--- a/hack/securebuild-dev/docker-compose.yml
+++ b/hack/securebuild-dev/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: cve0.io/postgres:17

--- a/integration/worker/package-family-update-check/git_linked_test.go
+++ b/integration/worker/package-family-update-check/git_linked_test.go
@@ -44,6 +44,12 @@ pipeline:
   - runs: echo "Building test package"
 `
 
+const gitLinkedApkoYAML = `contents:
+  packages:
+    - test-git-linked-1.0
+    - busybox
+`
+
 func setupGitLinkedTestEnv(t *testing.T, ctx context.Context) (context.Context, *testutil.TestDatabase, *listener.Listener) {
 	t.Helper()
 
@@ -76,6 +82,7 @@ func startGitLinkedGitHubMock(t *testing.T, tag, commitSHA string) *httptest.Ser
 	t.Helper()
 
 	melangeBase64 := base64.StdEncoding.EncodeToString([]byte(gitLinkedMelangeYAML))
+	apkoBase64 := base64.StdEncoding.EncodeToString([]byte(gitLinkedApkoYAML))
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
@@ -92,12 +99,26 @@ func startGitLinkedGitHubMock(t *testing.T, tag, commitSHA string) *httptest.Ser
 			json.NewEncoder(w).Encode(ref)
 
 		case strings.Contains(path, "/contents/"):
-			content := &github.RepositoryContent{
-				Type:     github.String("file"),
-				Name:     github.String("melange.yaml"),
-				Path:     github.String("securebuild/package/melange.yaml"),
-				Content:  github.String(melangeBase64),
-				Encoding: github.String("base64"),
+			var content *github.RepositoryContent
+			if strings.Contains(path, "melange.yaml") {
+				content = &github.RepositoryContent{
+					Type:     github.String("file"),
+					Name:     github.String("melange.yaml"),
+					Path:     github.String("securebuild/package/melange.yaml"),
+					Content:  github.String(melangeBase64),
+					Encoding: github.String("base64"),
+				}
+			} else if strings.Contains(path, "apko-test.yaml") {
+				content = &github.RepositoryContent{
+					Type:     github.String("file"),
+					Name:     github.String("apko-test.yaml"),
+					Path:     github.String("securebuild/image/apko-test.yaml"),
+					Content:  github.String(apkoBase64),
+					Encoding: github.String("base64"),
+				}
+			} else {
+				w.WriteHeader(http.StatusNotFound)
+				return
 			}
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(content)
@@ -108,6 +129,11 @@ func startGitLinkedGitHubMock(t *testing.T, tag, commitSHA string) *httptest.Ser
 				Entries: []*github.TreeEntry{
 					{
 						Path: github.String("securebuild/package/melange.yaml"),
+						Type: github.String("blob"),
+						SHA:  github.String(commitSHA),
+					},
+					{
+						Path: github.String("securebuild/image/apko-test.yaml"),
 						Type: github.String("blob"),
 						SHA:  github.String(commitSHA),
 					},
@@ -314,4 +340,95 @@ func TestGitLinkedUpdateCheckExistingPackagePatchRelease(t *testing.T) {
 	err = testDB.Pool.QueryRow(ctx, "SELECT last_error FROM package_family WHERE id = $1", gitLinkedFamilyID).Scan(&lastError)
 	require.NoError(t, err)
 	assert.Nil(t, lastError, "package_family last_error should be cleared on success")
+}
+
+func TestGitLinkedImageUpdateCheckWithVPrefix(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	ctx, testDB, l := setupGitLinkedTestEnv(t, ctx)
+	defer testutil.TeardownTestDatabase(ctx, t, testDB)
+	defer persistence.ClosePool(ctx)
+
+	// Seed the image data
+	projectRoot, err := testutil.FindProjectRoot()
+	require.NoError(t, err)
+
+	imageSeedDir := filepath.Join(projectRoot, "integration", "worker", "package-family-update-check", "testdata", "git-linked-seed-data")
+	err = testutil.ApplySchemaHero(ctx, testDB.ConnStr, imageSeedDir, true)
+	require.NoError(t, err)
+
+	tag := "v1.0.0"
+	commitSHA := "abc123initialcommit00000000000000000abc"
+
+	githubServer := startGitLinkedGitHubMock(t, tag, commitSHA)
+	githubClient := newMockGitHubClient(githubServer)
+
+	listenerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	listenerCtx = listener.WithGithubClientOverride(listenerCtx, githubClient)
+
+	// Start the image update check listener
+	listener.StartImageUpdateCheckListener(listenerCtx, l)
+
+	go l.Start(listenerCtx)
+	defer l.Stop(listenerCtx)
+
+	time.Sleep(1 * time.Second)
+
+	// Trigger image update check with v-prefixed tag
+	payload := listener.ImageUpdateCheckPayload{
+		ImageID: "img-git-linked-test",
+		Tag:     tag,
+	}
+	payloadBytes, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	err = persistence.EnqueueWork(ctx, "image_update_check", payloadBytes)
+	require.NoError(t, err)
+
+	// Wait for the handler to process (may retry once if VM assignment fails,
+	// but the image_apko records are created on the first attempt)
+	time.Sleep(5 * time.Second)
+
+	// Verify image_apko was created with the correct git_tag
+	var apkoID, apkoGitTag string
+	err = testDB.Pool.QueryRow(ctx, `
+		SELECT id, git_tag
+		FROM image_apko
+		WHERE image_id = $1
+	`, "img-git-linked-test").Scan(&apkoID, &apkoGitTag)
+	require.NoError(t, err, "image_apko should have been created")
+	assert.Equal(t, tag, apkoGitTag, "git_tag should preserve the v prefix")
+
+	// Verify image_apko_version has the package pinned correctly
+	var apkoYAML string
+	err = testDB.Pool.QueryRow(ctx, `
+		SELECT apko_yaml
+		FROM image_apko_version
+		WHERE image_apko_id = $1
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, apkoID).Scan(&apkoYAML)
+	require.NoError(t, err, "image_apko_version should have been created")
+
+	// The core bug: without the fix, the package would remain unpinned
+	// because pinCorePackageForImage queries pv.version = 'v1.0.0' which
+	// does not match the normalized '1.0.0' stored in the DB.
+	assert.Contains(t, apkoYAML, "test-git-linked-1.0~1.0.0",
+		"APKO YAML should have the core package pinned to the normalized version")
+
+	// Verify the image_package link was created
+	var pinnedVersion string
+	err = testDB.Pool.QueryRow(ctx, `
+		SELECT pinned_version
+		FROM image_package
+		WHERE apko_id = $1
+	`, apkoID).Scan(&pinnedVersion)
+	require.NoError(t, err, "image_package link should have been created")
+	assert.Equal(t, "1.0.0", pinnedVersion, "pinned_version should be the normalized version")
 }

--- a/integration/worker/package-family-update-check/testdata/git-linked-seed-data/image-git-linked.yaml
+++ b/integration/worker/package-family-update-check/testdata/git-linked-seed-data/image-git-linked.yaml
@@ -1,0 +1,30 @@
+database: securebuild
+name: image
+requires: []
+seedData:
+  rows:
+    - columns:
+        - column: id
+          value:
+            str: "img-git-linked-test"
+        - column: name
+          value:
+            str: "test-git-linked-image"
+        - column: created_at
+          value:
+            str: "2025-01-01T00:00:00Z"
+        - column: updated_at
+          value:
+            str: "2025-01-01T00:00:00Z"
+        - column: is_public
+          value:
+            str: "false"
+        - column: git_remote
+          value:
+            str: "https://github.com/test-org/test-repo.git"
+        - column: apko_file_path
+          value:
+            str: "securebuild/image/apko-test.yaml"
+        - column: image_tag_template
+          value:
+            str: "v{major}.{minor}.{patch}"

--- a/pkg/listener/image-update-check.go
+++ b/pkg/listener/image-update-check.go
@@ -53,7 +53,9 @@ func handleImageUpdateCheck(ctx context.Context, payload string) error {
 	}
 
 	var githubClient *github.Client
-	if githubToken := param.GetParam(ctx).UpdaterGithubAPIToken; githubToken != "" {
+	if override := getGithubClientOverride(ctx); override != nil {
+		githubClient = override
+	} else if githubToken := param.GetParam(ctx).UpdaterGithubAPIToken; githubToken != "" {
 		ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: githubToken})
 		tc := oauth2.NewClient(ctx, ts)
 		githubClient = github.NewClient(tc)
@@ -317,7 +319,7 @@ func pinCorePackageForImage(ctx context.Context, conn *pgxpool.Conn, gitRemote, 
 			  AND p.parent_id IS NULL
 			ORDER BY pv.apk_release DESC
 			LIMIT 1
-		`, packageName, tag).Scan(&pkgID, &pkgName, &pkgVersion)
+		`, packageName, v.String()).Scan(&pkgID, &pkgName, &pkgVersion)
 
 		if err != nil {
 			if err == pgx.ErrNoRows {
@@ -361,7 +363,7 @@ func pinCorePackageForImage(ctx context.Context, conn *pgxpool.Conn, gitRemote, 
 		return apkoYAML, "", "", fmt.Errorf("no matching package found for tag %s in families with git_remote %s", tag, gitRemote)
 	}
 
-	pinnedYAML, err := pinCorePackageInApkoYAML(apkoYAML, possibleNames, pinnedVersion)
+	pinnedYAML, err := pinCorePackageInApkoYAML(apkoYAML, possibleNames, pinnedVersion, true)
 	if err != nil {
 		return apkoYAML, packageID, pinnedVersion, fmt.Errorf("failed to pin core package: %w", err)
 	}

--- a/pkg/listener/package-family-update-check.go
+++ b/pkg/listener/package-family-update-check.go
@@ -469,8 +469,8 @@ func performGitLinkedUpdateCheck(ctx context.Context, githubClient *github.Clien
 	// Determine which tags are new or re-tagged
 	var updateResults []*UpdateResult
 	for _, v := range filteredTags {
-		versionStr := v.Original()
-		tagStr := versionStr
+		versionStr := v.String()
+		tagStr := v.Original()
 
 		// Skip if version already exists and tag hasn't been re-assigned
 		if existingVersionSet[versionStr] {
@@ -1190,7 +1190,7 @@ func generateImageAPKOsForGitLinkedVersion(ctx context.Context, githubClient *gi
 		}
 
 		// Pin the core package to the correct version in the APKO YAML
-		pinnedApkoYAML, err := pinCorePackageInApkoYAML(apkoSpec.Content, possibleNames, versionStr)
+		pinnedApkoYAML, err := pinCorePackageInApkoYAML(apkoSpec.Content, possibleNames, versionStr, true)
 		if err != nil {
 			logger.Warn("failed to pin core package in APKO YAML, using as-is",
 				zap.String("image_id", img.ImageID),
@@ -1282,35 +1282,121 @@ func createLinkedImageAPKO(ctx context.Context, imageID, gitRemote, apkoFilePath
 // pinCorePackageInApkoYAML finds the core package in the APKO YAML and pins it to the
 // specified version using the ~version syntax. Uses the same package detection logic
 // as IsPackageCoreForAPKO (matching by family name, package name, and provides).
-func pinCorePackageInApkoYAML(apkoYAML string, possibleNames map[string]struct{}, version string) (string, error) {
+//
+// For linked images/packages (linked=true), the YAML is parsed into yaml.Node, the
+// packages are found using the proper ImageConfiguration type, and replaced directly
+// in the yaml.Node tree. This preserves formatting and comments while avoiding any
+// risk of replacing package names that appear in non-package sections.
+//
+// For non-linked images/packages (linked=false), the original string replacement
+// approach is used as a fallback.
+func pinCorePackageInApkoYAML(apkoYAML string, possibleNames map[string]struct{}, version string, linked bool) (string, error) {
 	var imageConfig apkotypes.ImageConfiguration
 	if err := yaml.Unmarshal([]byte(apkoYAML), &imageConfig); err != nil {
 		return "", fmt.Errorf("failed to parse APKO YAML: %w", err)
 	}
 
-	// Build a map of replacements
+	// Build a map of replacements keyed by the exact original package string
 	replacements := make(map[string]string)
-
 	for _, pkg := range imageConfig.Contents.Packages {
 		parsed := apkopackage.ResolvePackageNameVersionPin(pkg)
 		if parsed.Name == "" {
 			continue
 		}
-
 		if _, exists := possibleNames[parsed.Name]; exists {
-			// Pin this package to the correct version
 			newPkg := fmt.Sprintf("%s~%s", parsed.Name, version)
 			replacements[pkg] = newPkg
 		}
 	}
 
-	// Apply replacements to the YAML string, preserving formatting
+	if len(replacements) == 0 {
+		return apkoYAML, nil
+	}
+
+	if linked {
+		return pinCorePackageInApkoYAMLLinked(apkoYAML, replacements)
+	}
+
+	// Fallback for non-linked images: use string replacement on the original YAML text
 	result := apkoYAML
 	for oldPkg, newPkg := range replacements {
 		result = strings.ReplaceAll(result, oldPkg, newPkg)
 	}
-
 	return result, nil
+}
+
+// pinCorePackageInApkoYAMLLinked uses yaml.Node to preserve formatting while replacing
+// only packages in the contents.packages section. This avoids any risk of replacing
+// package names that appear in other sections (accounts, paths, entrypoint, etc.).
+//
+// NOTE: We intentionally do NOT modify an apkotypes.ImageConfiguration struct and
+// marshal it back to YAML. The apko ImageConfiguration types lack `omitempty` yaml tags
+// on many nested fields (e.g., entrypoint.services, paths[].uid, paths[].permissions).
+// yaml.Marshal on the struct would produce phantom zero-value fields like `permissions: 0`
+// and `services: {}` that are not present in the original YAML and could be semantically
+// different for APKO. yaml.Node round-trips the exact original structure while only
+// mutating the specific package scalars we need to change.
+func pinCorePackageInApkoYAMLLinked(apkoYAML string, replacements map[string]string) (string, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(apkoYAML), &root); err != nil {
+		return "", fmt.Errorf("failed to parse YAML nodes: %w", err)
+	}
+
+	if err := modifyPackagesInYAMLNode(&root, replacements); err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&root); err != nil {
+		return "", fmt.Errorf("failed to encode YAML: %w", err)
+	}
+	enc.Close()
+
+	return buf.String(), nil
+}
+
+func modifyPackagesInYAMLNode(node *yaml.Node, replacements map[string]string) error {
+	switch node.Kind {
+	case yaml.DocumentNode:
+		for _, child := range node.Content {
+			if err := modifyPackagesInYAMLNode(child, replacements); err != nil {
+				return err
+			}
+		}
+	case yaml.MappingNode:
+		for i := 0; i < len(node.Content); i += 2 {
+			key := node.Content[i]
+			val := node.Content[i+1]
+			if key.Value == "contents" && val.Kind == yaml.MappingNode {
+				for j := 0; j < len(val.Content); j += 2 {
+					contentsKey := val.Content[j]
+					contentsVal := val.Content[j+1]
+					if contentsKey.Value == "packages" && contentsVal.Kind == yaml.SequenceNode {
+						for _, pkgNode := range contentsVal.Content {
+							if pkgNode.Kind == yaml.ScalarNode {
+								if newPkg, ok := replacements[pkgNode.Value]; ok {
+									pkgNode.Value = newPkg
+								}
+							}
+						}
+						return nil
+					}
+				}
+			}
+			if err := modifyPackagesInYAMLNode(val, replacements); err != nil {
+				return err
+			}
+		}
+	case yaml.SequenceNode:
+		for _, child := range node.Content {
+			if err := modifyPackagesInYAMLNode(child, replacements); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // Routes to either processMinorVersionUpdate or processPatchVersionUpdate based on version change type

--- a/pkg/listener/package-family-update-check_test.go
+++ b/pkg/listener/package-family-update-check_test.go
@@ -377,3 +377,210 @@ test:
 		})
 	}
 }
+
+func TestPinCorePackageInApkoYAML(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputYAML     string
+		possibleNames map[string]struct{}
+		version       string
+		expectedYAML  string
+		expectError   bool
+	}{
+		{
+			name: "pins only in packages section",
+			inputYAML: `contents:
+  packages:
+    - kotsadm
+    - kubectl
+    - busybox
+
+accounts:
+  groups:
+    - groupname: kotsadm
+      gid: 1001
+  users:
+    - username: kotsadm
+      uid: 1001
+      gid: 1001
+  run-as: kotsadm
+
+paths:
+  - path: /kotsadm
+    type: symlink
+    source: /usr/local/bin/kotsadm
+
+entrypoint:
+  command: /kotsadm
+`,
+			possibleNames: map[string]struct{}{"kotsadm": {}},
+			version:     "1.131.1",
+			expectedYAML: `contents:
+  packages:
+    - kotsadm~1.131.1
+    - kubectl
+    - busybox
+accounts:
+  groups:
+    - groupname: kotsadm
+      gid: 1001
+  users:
+    - username: kotsadm
+      uid: 1001
+      gid: 1001
+  run-as: kotsadm
+paths:
+  - path: /kotsadm
+    type: symlink
+    source: /usr/local/bin/kotsadm
+entrypoint:
+  command: /kotsadm
+`,
+		},
+		{
+			name: "does not pin substring package names",
+			inputYAML: `contents:
+  packages:
+    - kotsadm
+    - kotsadm-migrations
+    - kotsadm-cli
+`,
+			possibleNames: map[string]struct{}{"kotsadm": {}},
+			version:       "1.131.1",
+			expectedYAML: `contents:
+  packages:
+    - kotsadm~1.131.1
+    - kotsadm-migrations
+    - kotsadm-cli
+`,
+		},
+		{
+			name: "preserves comments and formatting in packages section",
+			inputYAML: `contents:
+  packages:
+    - kotsadm  # core package
+    - kubectl
+`,
+			possibleNames: map[string]struct{}{"kotsadm": {}},
+			version:       "1.131.1",
+			expectedYAML: `contents:
+  packages:
+    - kotsadm~1.131.1 # core package
+    - kubectl
+`,
+		},
+		{
+			name: "does not replace in comment before packages section",
+			inputYAML: `# packages: kotsadm
+contents:
+  packages:
+    - kotsadm
+`,
+			possibleNames: map[string]struct{}{"kotsadm": {}},
+			version:       "1.131.1",
+			expectedYAML: `# packages: kotsadm
+contents:
+  packages:
+    - kotsadm~1.131.1
+`,
+		},
+		{
+			name: "no matching packages",
+			inputYAML: `contents:
+  packages:
+    - kubectl
+    - busybox
+`,
+			possibleNames: map[string]struct{}{"kotsadm": {}},
+			version:       "1.131.1",
+			expectedYAML: `contents:
+  packages:
+    - kubectl
+    - busybox
+`,
+		},
+		{
+			name: "pins already-pinned package to new version",
+			inputYAML: `contents:
+  packages:
+    - kotsadm~1.130.9
+    - kubectl
+`,
+			possibleNames: map[string]struct{}{"kotsadm": {}},
+			version:       "1.131.1",
+			expectedYAML: `contents:
+  packages:
+    - kotsadm~1.131.1
+    - kubectl
+`,
+		},
+		{
+			name: "pins package with equals version",
+			inputYAML: `contents:
+  packages:
+    - kotsadm=1.130.9
+    - kubectl
+`,
+			possibleNames: map[string]struct{}{"kotsadm": {}},
+			version:       "1.131.1",
+			expectedYAML: `contents:
+  packages:
+    - kotsadm~1.131.1
+    - kubectl
+`,
+		},
+		{
+			name: "empty packages section",
+			inputYAML: `contents:
+  packages:
+
+accounts:
+  run-as: kotsadm
+`,
+			possibleNames: map[string]struct{}{"kotsadm": {}},
+			version:       "1.131.1",
+			expectedYAML: `contents:
+  packages:
+
+accounts:
+  run-as: kotsadm
+`,
+		},
+		{
+			name: "multiple packages pinned",
+			inputYAML: `contents:
+  packages:
+    - bash
+    - bash-entrypoint
+    - git
+`,
+			possibleNames: map[string]struct{}{"bash": {}, "bash-entrypoint": {}},
+			version:       "5.3",
+			expectedYAML: `contents:
+  packages:
+    - bash~5.3
+    - bash-entrypoint~5.3
+    - git
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := pinCorePackageInApkoYAML(tt.inputYAML, tt.possibleNames, tt.version, true)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+			if result != tt.expectedYAML {
+				t.Errorf("Result mismatch.\nExpected:\n%s\n\nGot:\n%s", tt.expectedYAML, result)
+			}
+		})
+	}
+}

--- a/securebuild-api/.dockerignore
+++ b/securebuild-api/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env*.local
+.git


### PR DESCRIPTION
1. When pulling APKO specs from git, the git tag may have the "v" prefix. This results in un-pinned packages:
   ```
   contents:
     packages:
       - local-artifact-mirror-k8s1.33
   ```
   instead of:
   ```
   contents:
     packages:
       - local-artifact-mirror-k8s1.33~2.18.1
   ```
   
2. Instead of replacing string on the APKO yaml data, use proper yaml parsing when pinning package dependencies for linked specs.  This reformats the yaml, but precisely targets package names.