### PR TITLE
Fix registry auth when downloading external image sbom

### DIFF
--- a/autoimg-cmd/cli/sbom.go
+++ b/autoimg-cmd/cli/sbom.go
@@ -16,7 +16,9 @@ func generateSBOM(ctx context.Context, imageInfo *ImageInfo, outputDir string) (
 	fmt.Printf("  Generating SBOM for %s/%s@%s\n", imageInfo.Registry, imageInfo.Repository, imageInfo.Digest)
 
 	// Use the existing SBOM functionality from pkg/sbom
-	sboms, err := sbom.FetchSBOM(ctx, imageInfo.Registry, imageInfo.Repository, imageInfo.Digest)
+	// autoimg does not operate on behalf of a SecureBuild team, so it only uses
+	// anonymous registry access here.
+	sboms, err := sbom.FetchSBOM(ctx, "", imageInfo.Registry, imageInfo.Repository, imageInfo.Digest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch SBOM: %w", err)
 	}

--- a/pkg/externalimage/externalimage.go
+++ b/pkg/externalimage/externalimage.go
@@ -563,10 +563,14 @@ func ListExternalImagesNeedDigestCheck(ctx context.Context) ([]*types.ExternalIm
 
 	now := time.Now()
 	query := `
-		select digest, registry, image_name, array_agg(image_tag), max(created_at) as max_created_at
-		from external_image_tag
-		where next_check_digest_at < $1
-		group by digest, registry, image_name
+		select eit.team_id, et.digest, et.registry, et.image_name, array_agg(et.image_tag), max(et.created_at) as max_created_at
+		from external_image_tag et
+		join external_image_team eit
+		  on eit.registry = et.registry
+		 and eit.image_name = et.image_name
+		 and eit.image_tag = et.image_tag
+		where et.next_check_digest_at < $1
+		group by eit.team_id, et.digest, et.registry, et.image_name
 		order by max_created_at desc
 	`
 
@@ -579,16 +583,17 @@ func ListExternalImagesNeedDigestCheck(ctx context.Context) ([]*types.ExternalIm
 	var externalImages []*types.ExternalImage
 
 	for rows.Next() {
-		var digest, registry, imageName string
+		var teamID, digest, registry, imageName string
 		var tags []string
 		var createdAt time.Time
 
-		err := rows.Scan(&digest, &registry, &imageName, &tags, &createdAt)
+		err := rows.Scan(&teamID, &digest, &registry, &imageName, &tags, &createdAt)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan external image row for digest check: %w", err)
 		}
 
 		externalImages = append(externalImages, &types.ExternalImage{
+			TeamID:    teamID,
 			Digest:    digest,
 			Registry:  registry,
 			ImageName: imageName,
@@ -658,15 +663,17 @@ func UpdateExternalImageTagNextCheckDigestAt(ctx context.Context, registry strin
 	return nil
 }
 
-func GetExternalImageCredentials(ctx context.Context, registry string, imageName string) (string, string, error) {
+func GetExternalImageCredentials(ctx context.Context, teamID string, registry string, imageName string) (string, string, error) {
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
 	query := `
-		select username, password from external_image_credential where registry = $1 and image_name = $2
+		select username, password
+		from external_image_credential
+		where registry = $1 and image_name = $2 and team_id = $3
 	`
 
-	row := conn.QueryRow(ctx, query, registry, imageName)
+	row := conn.QueryRow(ctx, query, registry, imageName, teamID)
 
 	var username sql.NullString
 	var password sql.NullString
@@ -675,7 +682,7 @@ func GetExternalImageCredentials(ctx context.Context, registry string, imageName
 		if err == pgx.ErrNoRows {
 			return "", "", nil
 		}
-		return "", "", fmt.Errorf("failed to scan external image credentials for %s/%s: %w", registry, imageName, err)
+		return "", "", fmt.Errorf("failed to scan external image credentials for team %s and image %s/%s: %w", teamID, registry, imageName, err)
 	}
 
 	if !username.Valid || !password.Valid {

--- a/pkg/externalimage/monitor.go
+++ b/pkg/externalimage/monitor.go
@@ -43,7 +43,7 @@ func checkTagsForUpdatedDigests(ctx context.Context) error {
 	}
 
 	for _, externalImage := range externalImages {
-		username, password, err := GetExternalImageCredentials(ctx, externalImage.Registry, externalImage.ImageName)
+		username, password, err := GetExternalImageCredentials(ctx, externalImage.TeamID, externalImage.Registry, externalImage.ImageName)
 		if err != nil {
 			logger.Info("failed to get credentials", zap.String("registry", externalImage.Registry), zap.String("image_name", externalImage.ImageName), zap.Error(err))
 			// Update next_check_digest_at for all tags of this image to delay retry by 24 hours
@@ -81,6 +81,7 @@ func checkTagsForUpdatedDigests(ctx context.Context) error {
 				// queue the initial work for SBOM
 				p := listenertypes.ExternalImageSbomPayload{
 					Digest: currentDigest,
+					TeamID: externalImage.TeamID,
 				}
 
 				payload, err := json.Marshal(p)

--- a/pkg/externalimage/types/types.go
+++ b/pkg/externalimage/types/types.go
@@ -3,6 +3,7 @@ package types
 import "time"
 
 type ExternalImage struct {
+	TeamID    string
 	Digest    string
 	Registry  string
 	ImageName string

--- a/pkg/image/external.go
+++ b/pkg/image/external.go
@@ -72,12 +72,6 @@ func DecryptExternalRegistryPassword(ctx context.Context, password string) (stri
 		return "", fmt.Errorf("external registry encryption secret is not set")
 	}
 
-	// base64 decode the secret if it is base64 encoded
-	decodedSecret, err := base64.StdEncoding.DecodeString(secret)
-	if err == nil {
-		secret = string(decodedSecret)
-	}
-
 	// Base64 decode the input
 	combined, err := base64.StdEncoding.DecodeString(password)
 	if err != nil {

--- a/pkg/listener/external-image-sbom-builder.go
+++ b/pkg/listener/external-image-sbom-builder.go
@@ -2,6 +2,7 @@ package listener
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,6 +15,7 @@ import (
 	extimgtypes "github.com/securebuildhq/securebuild/pkg/externalimage/types"
 	"github.com/securebuildhq/securebuild/pkg/listener/types"
 	"github.com/securebuildhq/securebuild/pkg/logger"
+	registrypkg "github.com/securebuildhq/securebuild/pkg/registry"
 	"github.com/securebuildhq/securebuild/pkg/sbom"
 	"github.com/securebuildhq/securebuild/pkg/telemetry"
 	"go.uber.org/zap"
@@ -51,7 +53,7 @@ func handleExternalImageSbomOnBuilder(ctx context.Context, p types.ExternalImage
 		return fmt.Errorf("SBOM download capacity cache is not ready")
 	}
 
-	dispatchErr := dispatchSbomDownloadToBuilder(ctx, cache, p.Digest, externalImage.Registry, externalImage.ImageName)
+	dispatchErr := dispatchSbomDownloadToBuilder(ctx, cache, p.TeamID, p.Digest, externalImage.Registry, externalImage.ImageName)
 	if dispatchErr != nil {
 		if errors.Is(dispatchErr, sbom.ErrNoBuilderAvailableForSbomDownload) {
 			// Revert status so the scheduler can re-enqueue on the next cycle.
@@ -77,7 +79,7 @@ func handleExternalImageSbomOnBuilder(ctx context.Context, p types.ExternalImage
 // dispatchSbomDownloadToBuilder handles builder selection, file copy, and syft
 // launch. It reserves a capacity slot atomically and releases it if any step
 // fails before the download is fully launched.
-func dispatchSbomDownloadToBuilder(ctx context.Context, cache *sbom.SbomDownloadCapacityCache, digest, registry, imageName string) error {
+func dispatchSbomDownloadToBuilder(ctx context.Context, cache *sbom.SbomDownloadCapacityCache, teamID, digest, registry, imageName string) error {
 	span, ctx := telemetry.StartSpan(ctx, "listener.dispatch_sbom_download_to_builder")
 	defer span.Finish()
 
@@ -104,7 +106,13 @@ func dispatchSbomDownloadToBuilder(ctx context.Context, cache *sbom.SbomDownload
 	}
 	defer runner.Close()
 
+	dockerConfig, err := buildSbomDockerConfig(ctx, teamID, registry, imageName)
+	if err != nil {
+		return fmt.Errorf("failed to configure registry authentication: %w", err)
+	}
+
 	metadata := sbom.SbomDownloadMetadata{
+		TeamID:    teamID,
 		Digest:    digest,
 		Registry:  registry,
 		ImageName: imageName,
@@ -112,7 +120,7 @@ func dispatchSbomDownloadToBuilder(ctx context.Context, cache *sbom.SbomDownload
 	}
 
 	// Phase 1: Prepare all files (dirs, download.json, per-arch dirs).
-	if err := prepareSbomDownloadFiles(ctx, runner, workDir, metadata); err != nil {
+	if err := prepareSbomDownloadFiles(ctx, runner, workDir, metadata, dockerConfig); err != nil {
 		cleanupSbomDownloadDir(ctx, runner, workDir)
 		return fmt.Errorf("failed to prepare SBOM download files on builder %s: %w", builderVM.ID, err)
 	}
@@ -121,7 +129,7 @@ func dispatchSbomDownloadToBuilder(ctx context.Context, cache *sbom.SbomDownload
 	// have already been launched, kill those processes and clean up.
 	launchedPlatforms := make([]string, 0, len(sbomDownloadPlatforms))
 	for _, platform := range sbomDownloadPlatforms {
-		syftCmd := buildSyftLaunchCommand(workDir, platform, registry, imageName, digest)
+		syftCmd := buildSyftLaunchCommand(workDir, platform, registry, imageName, digest, dockerConfig != "")
 		if _, err := runner.RunCommand(ctx, syftCmd); err != nil {
 			logger.Warn("failed to launch syft, cleaning up already-launched processes",
 				zap.String("digest", digest),
@@ -146,6 +154,7 @@ func dispatchSbomDownloadToBuilder(ctx context.Context, cache *sbom.SbomDownload
 	// reflects it immediately.
 	slotReserved = false
 	cache.AddDownload(builderVM.ID, sbom.SbomDownloadDirInfo{
+		TeamID:    teamID,
 		Digest:    digest,
 		WorkDir:   workDir,
 		CreatedAt: metadata.CreatedAt,
@@ -162,7 +171,7 @@ func dispatchSbomDownloadToBuilder(ctx context.Context, cache *sbom.SbomDownload
 // prepareSbomDownloadFiles creates the download work directory, writes
 // download.json, and creates per-arch output directories. If this function
 // returns an error, no syft processes have been started.
-func prepareSbomDownloadFiles(ctx context.Context, runner buildbackend.Runner, workDir string, metadata sbom.SbomDownloadMetadata) error {
+func prepareSbomDownloadFiles(ctx context.Context, runner buildbackend.Runner, workDir string, metadata sbom.SbomDownloadMetadata, dockerConfig string) error {
 	if err := runner.MkdirAll(workDir); err != nil {
 		return fmt.Errorf("failed to create SBOM download work dir %s: %w", workDir, err)
 	}
@@ -175,6 +184,23 @@ func prepareSbomDownloadFiles(ctx context.Context, runner buildbackend.Runner, w
 	downloadJSONPath := filepath.Join(workDir, "download.json")
 	if err := runner.WriteFile(downloadJSONPath, string(metadataJSON)); err != nil {
 		return fmt.Errorf("failed to write download.json: %w", err)
+	}
+
+	if dockerConfig != "" {
+		dockerConfigDir := filepath.Join(workDir, "docker-config")
+		if err := runner.MkdirAll(dockerConfigDir); err != nil {
+			return fmt.Errorf("failed to create Docker config dir: %w", err)
+		}
+		if _, err := runner.RunCommand(ctx, fmt.Sprintf("chmod 700 %q", dockerConfigDir)); err != nil {
+			return fmt.Errorf("failed to secure Docker config dir: %w", err)
+		}
+		dockerConfigPath := filepath.Join(dockerConfigDir, "config.json")
+		if err := runner.WriteFile(dockerConfigPath, dockerConfig); err != nil {
+			return fmt.Errorf("failed to write Docker config: %w", err)
+		}
+		if _, err := runner.RunCommand(ctx, fmt.Sprintf("chmod 600 %q", dockerConfigPath)); err != nil {
+			return fmt.Errorf("failed to secure Docker config: %w", err)
+		}
 	}
 
 	for _, platform := range sbomDownloadPlatforms {
@@ -196,17 +222,77 @@ func prepareSbomDownloadFiles(ctx context.Context, runner buildbackend.Runner, w
 //   - output/exit_code (syft exit code: 0=success)
 //   - output/syft.stderr (syft stderr)
 //   - output/syft.pid (actual syft process PID)
-func buildSyftLaunchCommand(workDir, platform, registry, imageName, digest string) string {
+func buildSyftLaunchCommand(workDir, platform, registry, imageName, digest string, authenticated bool) string {
 	archDir := filepath.Join(workDir, platformToArchDir(platform))
 	imageRef := registry + "/" + imageName + "@" + digest
+	dockerConfigEnv := ""
+	if authenticated {
+		dockerConfigEnv = fmt.Sprintf("  export DOCKER_CONFIG=%q\n", filepath.Join(workDir, "docker-config"))
+	}
 	return fmt.Sprintf(`nohup bash -c '
   cd %q
-  syft --platform %s -o spdx-json=./sbom.spdx.json -o syft-json=./sbom.syft.json registry:%s > output/syft.stderr 2>&1 &
+%s  syft --platform %s -o spdx-json=./sbom.spdx.json -o syft-json=./sbom.syft.json registry:%s > output/syft.stderr 2>&1 &
   syft_pid=$!
   echo $syft_pid > output/syft.pid
   wait $syft_pid
   echo $? > output/exit_code
-' > %q 2>&1 < /dev/null &`, archDir, platform, imageRef, filepath.Join(archDir, "download.log"))
+' > %q 2>&1 < /dev/null &`, archDir, dockerConfigEnv, platform, imageRef, filepath.Join(archDir, "download.log"))
+}
+
+// buildSbomDockerConfig resolves stored registry credentials and returns a
+// Docker config suitable for Syft. An empty string means anonymous access.
+func buildSbomDockerConfig(ctx context.Context, teamID, registry, imageName string) (string, error) {
+	username, password, err := externalimage.GetExternalImageCredentials(ctx, teamID, registry, imageName)
+	if err != nil {
+		return "", err
+	}
+	if username == "" || password == "" {
+		return "", nil
+	}
+
+	authenticator, err := registrypkg.GetCredentialsForEndpoint(ctx, registry, username, password)
+	if err != nil {
+		return "", fmt.Errorf("failed to get credentials for registry %s: %w", registry, err)
+	}
+	authConfig, err := authenticator.Authorization()
+	if err != nil {
+		return "", fmt.Errorf("failed to authorize registry %s: %w", registry, err)
+	}
+
+	return marshalSbomDockerConfig(registry, authConfig.Username, authConfig.Password, authConfig.RegistryToken)
+}
+
+func marshalSbomDockerConfig(registry, username, password, registryToken string) (string, error) {
+	registryAuth := map[string]string{}
+	if username != "" || password != "" {
+		registryAuth["username"] = username
+		registryAuth["password"] = password
+	} else if registryToken != "" {
+		registryAuth["auth"] = base64.StdEncoding.EncodeToString([]byte(":" + registryToken))
+	} else {
+		return "", nil
+	}
+
+	dockerConfig := map[string]any{
+		"auths": map[string]any{
+			normalizeRegistryForDockerConfig(registry): registryAuth,
+		},
+	}
+	configJSON, err := json.Marshal(dockerConfig)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal Docker config: %w", err)
+	}
+	return string(configJSON), nil
+}
+
+func normalizeRegistryForDockerConfig(registry string) string {
+	if registry == "index.docker.io" {
+		return "https://index.docker.io/v1/"
+	}
+	if strings.HasPrefix(registry, "http://") || strings.HasPrefix(registry, "https://") {
+		return registry
+	}
+	return "https://" + registry
 }
 
 // platformToArchDir converts a platform string (linux/amd64) to a directory-safe

--- a/pkg/listener/external-image-sbom.go
+++ b/pkg/listener/external-image-sbom.go
@@ -42,11 +42,13 @@ func WithMockScanExternalImage(ctx context.Context, mock func(context.Context, s
 
 // getFetchSBOMFunc returns the SBOM fetch function from the context if injected,
 // otherwise falls back to the real implementation.
-func getFetchSBOMFunc(ctx context.Context) func(context.Context, string, string, string) ([]sbom.SBOMResult, error) {
+func getFetchSBOMFunc(ctx context.Context, teamID string) func(context.Context, string, string, string) ([]sbom.SBOMResult, error) {
 	if f, ok := ctx.Value(fetchSBOMFuncKey).(func(context.Context, string, string, string) ([]sbom.SBOMResult, error)); ok {
 		return f
 	}
-	return sbom.FetchSBOM
+	return func(ctx context.Context, registry, imageName, digest string) ([]sbom.SBOMResult, error) {
+		return sbom.FetchSBOM(ctx, teamID, registry, imageName, digest)
+	}
 }
 
 // getScanExternalImageFunc returns the scan function from the context if injected,
@@ -159,7 +161,7 @@ func handleExternalImageSbomInProcess(ctx context.Context, p types.ExternalImage
 		logger.Warnf("failed to set SBOM status to generating for digest %s: %s", p.Digest, err.Error())
 	}
 
-	sbomResults, err := getFetchSBOMFunc(ctx)(ctx, externalImage.Registry, externalImage.ImageName, p.Digest)
+	sbomResults, err := getFetchSBOMFunc(ctx, p.TeamID)(ctx, externalImage.Registry, externalImage.ImageName, p.Digest)
 	if err != nil {
 		recordSBOMFailure(ctx, p.Digest, externalimage.NewScanFailureError(externalimage.ErrFetchSBOM, fmt.Sprintf("failed to fetch SBOM: %s", err.Error())), true, attempt, maxAttempts)
 		return fmt.Errorf("failed to fetch sbom: %w", err)

--- a/pkg/listener/types/types.go
+++ b/pkg/listener/types/types.go
@@ -6,6 +6,7 @@ type ExternalImageScanPayload struct {
 
 type ExternalImageSbomPayload struct {
 	Digest             string `json:"digest"`
+	TeamID             string `json:"team_id,omitempty"`
 	EnqueueRescanAfter bool   `json:"enqueue_rescan_after,omitempty"`
 }
 

--- a/pkg/listener/update-external-image-sbom-status.go
+++ b/pkg/listener/update-external-image-sbom-status.go
@@ -121,6 +121,7 @@ func processBuilderSbomDownloads(ctx context.Context, cache *sbom.SbomDownloadCa
 	for _, dd := range downloadDirs {
 		if dd.Metadata.Digest != "" && !dd.AllArchsDone {
 			activeDownloads = append(activeDownloads, sbom.SbomDownloadDirInfo{
+				TeamID:    dd.Metadata.TeamID,
 				Digest:    dd.Metadata.Digest,
 				WorkDir:   dd.WorkDir,
 				CreatedAt: dd.Metadata.CreatedAt,
@@ -159,12 +160,12 @@ func processCompletedSbomDownloadsBatch(ctx context.Context, cache *sbom.SbomDow
 	defer span.Finish()
 
 	type archResult struct {
-		digest     string
-		platform   string
-		exitCode   int
-		spdxRel    string
-		syftRel    string
-		stderrRel  string
+		digest    string
+		platform  string
+		exitCode  int
+		spdxRel   string
+		syftRel   string
+		stderrRel string
 	}
 	var results []archResult
 	var tarRelPaths []string
@@ -625,15 +626,15 @@ func handleMissingBuilderForSbomDownload(ctx context.Context, cache *sbom.SbomDo
 				zap.String("digest", d.Digest),
 				zap.Error(err))
 		}
-		reenqueueSbomDownload(ctx, d.Digest)
+		reenqueueSbomDownload(ctx, d.TeamID, d.Digest)
 	}
 
 	cache.RemoveBuilder(machineID)
 }
 
 // reenqueueSbomDownload enqueues a new external_image_sbom work item for a digest.
-func reenqueueSbomDownload(ctx context.Context, digest string) {
-	payloadBytes, err := json.Marshal(listenertypes.ExternalImageSbomPayload{Digest: digest})
+func reenqueueSbomDownload(ctx context.Context, teamID, digest string) {
+	payloadBytes, err := json.Marshal(listenertypes.ExternalImageSbomPayload{Digest: digest, TeamID: teamID})
 	if err != nil {
 		logger.Error(fmt.Errorf("failed to marshal re-enqueue SBOM payload: %w", err))
 		return

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -39,7 +39,7 @@ type SBOMResult struct {
 	ImageDigest    string `json:"image_digest"` // per-architecture manifest digest
 }
 
-func FetchSBOM(ctx context.Context, registry string, imageName string, digest string) (results []SBOMResult, err error) {
+func FetchSBOM(ctx context.Context, teamID string, registry string, imageName string, digest string) (results []SBOMResult, err error) {
 	span, ctx := telemetry.StartSpan(ctx, "sbom.FetchSBOM")
 	defer func() {
 		if err != nil {
@@ -54,7 +54,7 @@ func FetchSBOM(ctx context.Context, registry string, imageName string, digest st
 	auth := authn.Anonymous
 	isAnonDockerHub := false
 
-	username, password, err := externalimage.GetExternalImageCredentials(ctx, registry, imageName)
+	username, password, err := externalimage.GetExternalImageCredentials(ctx, teamID, registry, imageName)
 	if err != nil {
 		logger.Warn("failed to get external image credentials, continuing with anonymous auth", zap.Error(err))
 	} else if username != "" && password != "" {

--- a/pkg/sbom/sbom_download_capacity.go
+++ b/pkg/sbom/sbom_download_capacity.go
@@ -44,6 +44,7 @@ var ErrNoBuilderAvailableForSbomDownload = fmt.Errorf("no builder available for 
 // directory on the builder. It allows the poller to discover downloads and know
 // which DB rows to update.
 type SbomDownloadMetadata struct {
+	TeamID     string    `json:"team_id,omitempty"`
 	Digest     string    `json:"digest"`
 	Registry   string    `json:"registry"`
 	ImageName  string    `json:"image_name"`
@@ -53,6 +54,7 @@ type SbomDownloadMetadata struct {
 
 // SbomDownloadDirInfo tracks a single active SBOM download directory on a builder.
 type SbomDownloadDirInfo struct {
+	TeamID    string
 	Digest    string
 	WorkDir   string
 	CreatedAt time.Time
@@ -64,7 +66,7 @@ type SbomDownloadDirInfo struct {
 // capacity limits (MaxSbomDownloadsPerBuilder) since image pulls are heavier.
 type SbomDownloadCapacityCache struct {
 	mu     sync.RWMutex
-	counts map[string]int                  // machineID → count of active download directories
+	counts map[string]int                   // machineID → count of active download directories
 	scans  map[string][]SbomDownloadDirInfo // machineID → list of active download dirs
 	ready  bool
 }
@@ -264,9 +266,9 @@ func (c *SbomDownloadCapacityCache) ReportDownloadCapacityMetrics(ctx context.Co
 func (c *SbomDownloadCapacityCache) DumpToFile() error {
 	c.mu.RLock()
 	snapshot := struct {
-		Timestamp time.Time                     `json:"timestamp"`
-		Ready     bool                          `json:"ready"`
-		Counts    map[string]int                `json:"counts"`
+		Timestamp time.Time                        `json:"timestamp"`
+		Ready     bool                             `json:"ready"`
+		Counts    map[string]int                   `json:"counts"`
 		Downloads map[string][]SbomDownloadDirInfo `json:"downloads"`
 	}{
 		Timestamp: time.Now().UTC(),
@@ -328,6 +330,7 @@ func InitSbomDownloadCapacityCache(ctx context.Context) (*SbomDownloadCapacityCa
 					continue
 				}
 				activeDownloads = append(activeDownloads, SbomDownloadDirInfo{
+					TeamID:    d.Metadata.TeamID,
 					Digest:    d.Metadata.Digest,
 					WorkDir:   d.WorkDir,
 					CreatedAt: d.Metadata.CreatedAt,
@@ -407,10 +410,10 @@ type SbomDownloadDirStatus struct {
 
 // ArchSbomDownloadStatus represents the status of a single architecture's SBOM download.
 type ArchSbomDownloadStatus struct {
-	Done      bool
-	ExitCode  string
-	SbomJSON  string
-	Stderr    string
+	Done     bool
+	ExitCode string
+	SbomJSON string
+	Stderr   string
 }
 
 // ListSbomDownloadDirsOnBuilder connects to a builder and discovers all SBOM

--- a/securebuild-api/app/api/v1/external-image/route.ts
+++ b/securebuild-api/app/api/v1/external-image/route.ts
@@ -56,6 +56,7 @@ export async function POST(request: NextRequest) {
     if (!shouldSkipSBOM) {
       await enqueueWork('external_image_sbom', {
         digest: digest,
+        team_id: teamId,
       })
     }
 

--- a/securebuild-api/lib/externalimage/externalimage.ts
+++ b/securebuild-api/lib/externalimage/externalimage.ts
@@ -159,12 +159,10 @@ export async function listExternalImages(teamId: string): Promise<TrackedExterna
 
 
 export async function encryptPassword(password: string): Promise<string> {
-  const secretEncoded = process.env.EXTERNAL_REGISTRY_ENCRYPTION_SECRET;
-  if (!secretEncoded) {
+  const secret = process.env.EXTERNAL_REGISTRY_ENCRYPTION_SECRET;
+  if (!secret) {
     throw new Error("EXTERNAL_REGISTRY_ENCRYPTION_SECRET environment variable is required");
   }
-
-  const secret = Buffer.from(secretEncoded, 'base64').toString('utf-8');
 
   // Generate a random IV for each encryption
   const iv = crypto.getRandomValues(new Uint8Array(12));
@@ -200,12 +198,10 @@ export async function encryptPassword(password: string): Promise<string> {
 }
 
 export async function decryptPassword(encryptedPassword: string): Promise<string> {
-  const secretEncoded = process.env.EXTERNAL_REGISTRY_ENCRYPTION_SECRET;
-  if (!secretEncoded) {
+  const secret = process.env.EXTERNAL_REGISTRY_ENCRYPTION_SECRET;
+  if (!secret) {
     throw new Error("EXTERNAL_REGISTRY_ENCRYPTION_SECRET environment variable is required");
   }
-
-  const secret = Buffer.from(secretEncoded, 'base64').toString('utf-8');
 
   // Decode the base64 combined data
   const combined = Buffer.from(encryptedPassword, 'base64');

--- a/securebuild-app/lib/image/image.ts
+++ b/securebuild-app/lib/image/image.ts
@@ -115,12 +115,10 @@ export async function deleteImage(id: string): Promise<void> {
 }
 
 async function encryptExternalRegistryPassword(password: string): Promise<string> {
-  const secretEncoded = process.env.EXTERNAL_REGISTRY_ENCRYPTION_SECRET;
-  if (!secretEncoded) {
+  const secret = process.env.EXTERNAL_REGISTRY_ENCRYPTION_SECRET;
+  if (!secret) {
     throw new Error("EXTERNAL_REGISTRY_ENCRYPTION_SECRET environment variable is required");
   }
-
-  const secret = Buffer.from(secretEncoded, 'base64').toString('utf-8');
 
   // Generate a random IV for each encryption
   const iv = crypto.getRandomValues(new Uint8Array(12));


### PR DESCRIPTION
1. Remove base64 decryption. The values are not base64 encrypted and there is no valid way to check if they are.
2. Created docker config on the host for generating SBOM files.