### PR TITLE
Don't write scan and sbom data to db

### DIFF
--- a/docs/proposals/migrate-blobs-to-object-store.md
+++ b/docs/proposals/migrate-blobs-to-object-store.md
@@ -440,38 +440,7 @@ The write path from Phase 1 is unchanged. New writes still go to both S3 and DB.
 
 ### Read path changes (Go)
 
-Replace the Phase 1 fallback readers with S3-only getters. No DB fallback:
-
-```go
-// GetExternalImageScanRawResult returns the raw scan result from object storage.
-func GetExternalImageScanRawResult(ctx context.Context, digest, arch string) (string, error) {
-    store, err := newBlobStore(ctx)
-    if err != nil {
-        return "", fmt.Errorf("failed to create blob store: %w", err)
-    }
-    return store.getRawResult(ctx, digest, arch)
-}
-
-// GetExternalImageScanParsedResultsDetails returns parsed vulnerability details from object storage.
-func GetExternalImageScanParsedResultsDetails(ctx context.Context, digest, arch string) (string, error) {
-    store, err := newBlobStore(ctx)
-    if err != nil {
-        return "", fmt.Errorf("failed to create blob store: %w", err)
-    }
-    return store.getParsedResultsDetails(ctx, digest, arch)
-}
-
-// GetExternalImageSBOMContent returns the SBOM JSON from object storage.
-func GetExternalImageSBOMContent(ctx context.Context, digest, arch string) (string, error) {
-    store, err := newBlobStore(ctx)
-    if err != nil {
-        return "", fmt.Errorf("failed to create blob store: %w", err)
-    }
-    return store.getSBOM(ctx, digest, arch)
-}
-```
-
-No fallback, no DB column reads. If S3 is unavailable, the read fails — same as any other infrastructure dependency.
+`GetExternalImageSBOM` and `GetExternalImageSBOMs` fetch SBOM content from object storage. Standalone raw-result, parsed-details, and SBOM-content getters were removed because they had no callers; the TypeScript API reads those objects through its own blob-store module.
 
 ### API (TypeScript) read path changes
 
@@ -626,26 +595,20 @@ func SetExternalImageSBOM(ctx context.Context, digest string, sbom string, sourc
 
 ### Schema changes
 
-Remove the old columns and the `is_in_object_store` tracking column from SchemaHero YAML:
+Remove the old blob columns from SchemaHero YAML. Keep `is_in_object_store` for now so rows with missing objects can be identified and rescanned:
 
 **`db/schema/tables/external-image-scan.yaml`** — remove:
 ```yaml
-    - name: parsed_results
-      type: text
     - name: parsed_results_details
       type: text
     - name: raw_result
       type: text
-    - name: is_in_object_store
-      type: boolean
 ```
 
 **`db/schema/tables/external-image-sbom.yaml`** — remove:
 ```yaml
     - name: sbom
       type: text
-    - name: is_in_object_store
-      type: boolean
 ```
 
 SchemaHero generates `ALTER TABLE ... DROP COLUMN` DDL. This reclaims TOAST space immediately.
@@ -673,7 +636,7 @@ The ~1.25 TB of blobs now lives in R2/S3 at a fraction of the cost.
 
 ## Write Path: Dual-Write Stop Condition
 
-Phase 4 is where dual-write stops. The DB INSERT/UPDATE no longer includes `raw_result`, `parsed_results_details`, or `sbom` columns. Only `parsed_results` (the 66-byte counts JSON) remains in the DB for efficient count queries.
+Phase 4 is where dual-write stops. The DB INSERT/UPDATE no longer includes `raw_result`, `parsed_results_details`, or `sbom` columns. `parsed_results` (the 66-byte counts JSON) remains for efficient count queries, and `is_in_object_store` remains so missing objects can be identified and rescanned.
 
 ---
 
@@ -721,7 +684,7 @@ After Phase 4 (stop writing + columns dropped), rollback is not possible without
   - [ ] Verify object count in S3 matches row count in DB
 
 - [x] **Phase 3** (S3-only reads, still dual-write)
-  - [x] Add public Go getter functions (`GetExternalImageScanRawResult`, `GetExternalImageScanParsedResultsDetails`, `GetExternalImageSBOMContent`)
+  - [x] Remove unused standalone Go blob getter functions
   - [x] Update Go `GetExternalImageSBOM` / `GetExternalImageSBOMs` to read SBOM from object store
   - [x] Create TypeScript R2 blob reader (`securebuild-api/lib/externalimage/blobstore.ts`)
   - [x] Add R2 params to TypeScript param module (`securebuild-api/lib/data/param.ts`)
@@ -731,10 +694,13 @@ After Phase 4 (stop writing + columns dropped), rollback is not possible without
   - [x] Modify `getBatchExternalSboms` to fetch SBOMs from object store
   - [ ] Deploy and monitor for 2 weeks — DB columns still written as safety net
 
-- [ ] **Phase 4** (not started) (stop writing to DB + drop columns)
-  - [ ] Modify `SetExternalImageScanStatus` — remove `raw_result` and `parsed_results_details` from DB write (keep `parsed_results` counts)
-  - [ ] Modify `SetExternalImageSBOM` — remove `sbom` from DB write
-  - [ ] Remove old columns from SchemaHero YAML
+- [ ] **Phase 4** (in progress) (stop writing to DB + drop columns)
+  - [x] Add compressed SQL backup and streaming restore scripts for `sbom`, `parsed_results_details`, and `raw_result`
+  - [x] Review rows where `is_in_object_store` is `false`; retain the flag so they can be rescanned
+  - [ ] Run the backup script
+  - [x] Modify `SetExternalImageScanStatus` — remove `raw_result` and `parsed_results_details` from DB write (keep `parsed_results` counts)
+  - [x] Modify `SetExternalImageSBOM` — remove `sbom` from DB write
+  - [ ] Remove old blob columns from SchemaHero YAML; retain `is_in_object_store`
   - [ ] Apply schema change
   - [ ] Run `VACUUM FULL` on both tables
   - [ ] Deploy final code

--- a/pkg/externalimage/externalimage.go
+++ b/pkg/externalimage/externalimage.go
@@ -351,7 +351,7 @@ func SetExternalImageScanStatus(ctx context.Context, params SetExternalImageScan
 		    updated_at = $4,
 		    scan_completed_at = $4,
 		    scan_status_updated_at = $4,
-		    is_in_object_store = $7
+		    is_in_object_store = external_image_scan.is_in_object_store OR EXCLUDED.is_in_object_store
 	`
 
 	_, err := conn.Exec(ctx, query,

--- a/pkg/externalimage/externalimage.go
+++ b/pkg/externalimage/externalimage.go
@@ -340,28 +340,24 @@ func SetExternalImageScanStatus(ctx context.Context, params SetExternalImageScan
 		blobsUploaded = true
 	}
 
-	// Step 2: DB write — fail on error (S3 object stays, will be overwritten on retry)
+	// Step 2: Write metadata to DB. Blob content lives only in object storage.
 	query := `
-		INSERT INTO external_image_scan (digest, arch, parsed_results, parsed_results_details, raw_result, created_at, status, scan_status_message, updated_at, scan_completed_at, scan_attempted_at, scan_status_updated_at, is_in_object_store)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $6, $6, $6, $6, $9)
+		INSERT INTO external_image_scan (digest, arch, parsed_results, created_at, status, scan_status_message, updated_at, scan_completed_at, scan_attempted_at, scan_status_updated_at, is_in_object_store)
+		VALUES ($1, $2, $3, $4, $5, $6, $4, $4, $4, $4, $7)
 		ON CONFLICT (digest, arch) DO UPDATE
 		SET parsed_results = $3,
-		    parsed_results_details = $4,
-		    raw_result = $5,
-		    status = $7,
-		    scan_status_message = $8,
-		    updated_at = $6,
-		    scan_completed_at = $6,
-		    scan_status_updated_at = $6,
-		    is_in_object_store = $9
+		    status = $5,
+		    scan_status_message = $6,
+		    updated_at = $4,
+		    scan_completed_at = $4,
+		    scan_status_updated_at = $4,
+		    is_in_object_store = $7
 	`
 
 	_, err := conn.Exec(ctx, query,
 		params.Digest,
 		params.Arch,
 		params.ParsedResults,
-		params.ParsedResultsDetails,
-		params.RawResult,
 		now,
 		string(params.Status),
 		scanStatusMessage,
@@ -374,46 +370,22 @@ func SetExternalImageScanStatus(ctx context.Context, params SetExternalImageScan
 	return nil
 }
 
-// GetExternalImageScanRawResult returns the raw scan result from object storage.
-func GetExternalImageScanRawResult(ctx context.Context, digest, arch string) (string, error) {
-	store, err := newBlobStore(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to create blob store: %w", err)
-	}
-	return store.getRawResult(ctx, digest, arch)
-}
-
-// GetExternalImageScanParsedResultsDetails returns parsed vulnerability details from object storage.
-func GetExternalImageScanParsedResultsDetails(ctx context.Context, digest, arch string) (string, error) {
-	store, err := newBlobStore(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to create blob store: %w", err)
-	}
-	return store.getParsedResultsDetails(ctx, digest, arch)
-}
-
-// GetExternalImageSBOMContent returns the SBOM JSON from object storage.
-func GetExternalImageSBOMContent(ctx context.Context, digest, arch string) (string, error) {
-	store, err := newBlobStore(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to create blob store: %w", err)
-	}
-	return store.getSBOM(ctx, digest, arch)
-}
-
 func GetExternalImageSBOM(ctx context.Context, digest string) (*string, error) {
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
 	// Query metadata only (no sbom column) to find which arch has an SBOM
 	query := `
-		select arch
-		from external_image_sbom
-		where digest = $1
+		select esbom.arch
+		from external_image_sbom esbom
+		inner join external_image_sbom_status status on status.digest = esbom.digest
+		where esbom.digest = $1
+		  and esbom.is_in_object_store = true
+		  and status.status = $2
 		limit 1
 	`
 
-	row := conn.QueryRow(ctx, query, digest)
+	row := conn.QueryRow(ctx, query, digest, string(SBOMStatusSucceeded))
 
 	var arch string
 	err := row.Scan(&arch)
@@ -443,25 +415,23 @@ func GetExternalImageSBOMs(ctx context.Context, digest string) ([]types.External
 
 	// Query metadata only (no sbom column)
 	query := `
-		select digest, arch, source, created_at, image_digest
-		from external_image_sbom
-		where digest = $1
-		order by arch
+		select esbom.digest, esbom.arch, esbom.source, esbom.created_at, esbom.image_digest
+		from external_image_sbom esbom
+		inner join external_image_sbom_status status on status.digest = esbom.digest
+		where esbom.digest = $1
+		  and esbom.is_in_object_store = true
+		  and status.status = $2
+		order by esbom.arch
 	`
 
-	rows, err := conn.Query(ctx, query, digest)
+	rows, err := conn.Query(ctx, query, digest, string(SBOMStatusSucceeded))
 	if err != nil {
 		return nil, fmt.Errorf("failed to query external image SBOMs for digest %s: %w", digest, err)
 	}
 	defer rows.Close()
 
-	// Fetch SBOM content from object store
-	store, err := newBlobStore(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create blob store: %w", err)
-	}
-
 	var sboms []types.ExternalImageSBOM
+	var store *blobStore
 	for rows.Next() {
 		var sbom types.ExternalImageSBOM
 		var imageDigest sql.NullString
@@ -472,6 +442,12 @@ func GetExternalImageSBOMs(ctx context.Context, digest string) ([]types.External
 		if imageDigest.Valid {
 			sbom.ImageDigest = imageDigest.String
 		}
+		if store == nil {
+			store, err = newBlobStore(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create blob store: %w", err)
+			}
+		}
 		// Fetch SBOM content from object store
 		content, err := store.getSBOM(ctx, sbom.Digest, sbom.Arch)
 		if err != nil {
@@ -479,6 +455,9 @@ func GetExternalImageSBOMs(ctx context.Context, digest string) ([]types.External
 		}
 		sbom.SBOM = content
 		sboms = append(sboms, sbom)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed while reading external image SBOM rows for digest %s: %w", digest, err)
 	}
 
 	return sboms, nil
@@ -529,7 +508,7 @@ func SetExternalImageSBOM(ctx context.Context, digest string, sbom string, sourc
 	defer conn.Release()
 
 	// Step 1: Upload SBOM to object store (mandatory — fail on error)
-	blobsUploaded := false
+	blobUploaded := false
 	if sbom != "" {
 		store, err := newBlobStore(ctx)
 		if err != nil {
@@ -538,18 +517,18 @@ func SetExternalImageSBOM(ctx context.Context, digest string, sbom string, sourc
 		if err := store.putSBOM(ctx, digest, arch, sbom); err != nil {
 			return fmt.Errorf("failed to upload sbom to object store: %w", err)
 		}
-		blobsUploaded = true
+		blobUploaded = true
 	}
 
-	// Step 2: DB write — fail on error (S3 object stays, will be overwritten on retry)
+	// Step 2: Write metadata to DB. SBOM content lives only in object storage.
 	query := `
-		insert into external_image_sbom (digest, arch, sbom, source, image_size_bytes, image_digest, created_at, is_in_object_store)
-		values ($1, $2, $3, $4, $5, $6, $7, $8)
+		insert into external_image_sbom (digest, arch, source, image_size_bytes, image_digest, created_at, is_in_object_store)
+		values ($1, $2, $3, $4, $5, $6, $7)
 		on conflict (digest, arch) do update
-		set sbom = $3, source = $4, image_size_bytes = $5, image_digest = $6, created_at = $7, is_in_object_store = $8
+		set source = $3, image_size_bytes = $4, image_digest = $5, created_at = $6, is_in_object_store = $7
 	`
 
-	_, err := conn.Exec(ctx, query, digest, arch, sbom, source, imageSizeBytes, imageDigest, time.Now(), blobsUploaded)
+	_, err := conn.Exec(ctx, query, digest, arch, source, imageSizeBytes, imageDigest, time.Now(), blobUploaded)
 	if err != nil {
 		return fmt.Errorf("failed to insert/update external image SBOM for digest %s, arch %s: %w", digest, arch, err)
 	}

--- a/securebuild-api/integration/api/v1/external-image/on-demand-scan.test.ts
+++ b/securebuild-api/integration/api/v1/external-image/on-demand-scan.test.ts
@@ -2,6 +2,8 @@ import * as path from 'path';
 import { Client } from 'pg';
 import { setupTestEnvironment, TestEnvironment } from '../../../fixtures/environment';
 
+const DIGEST_WITH_STALE_SCAN = 'sha256:stale1234567890123456789012345678901234567890123456789012345';
+
 /**
  * Integration tests for the on-demand scan trigger (Part 3).
  *
@@ -123,7 +125,7 @@ describe('On-demand scan trigger', () => {
   }
 
   describe('Stale image (scan >4h old)', () => {
-    const digest = () => env.existingDigest;
+    const digest = () => DIGEST_WITH_STALE_SCAN;
 
     it('GET /scan enqueues work queue message with correct digest payload', async () => {
       // The seeded scan for this digest has scan_completed_at = 2024-01-01
@@ -158,26 +160,6 @@ describe('On-demand scan trigger', () => {
 
   describe('Non-stale image (scan within 4h)', () => {
     const digest = () => env.existingDigest;
-
-    beforeAll(async () => {
-      // Update the scan row to have scan_completed_at within the last 4 hours
-      // so the next request should NOT trigger a new scan.
-      await env.dbPool.query(
-        `UPDATE external_image_scan
-         SET scan_completed_at = NOW(), status = 'succeeded'
-         WHERE digest = $1`,
-        [digest()]
-      );
-      // Also update last_security_scanned_at on the SBOM so the idempotency
-      // check in the Go listener would pass (not directly tested here, but
-      // keeps the data consistent).
-      await env.dbPool.query(
-        `UPDATE external_image_sbom
-         SET last_security_scanned_at = NOW()
-         WHERE digest = $1`,
-        [digest()]
-      );
-    });
 
     it('GET /scan does NOT enqueue a new work queue message', async () => {
       await expectNoScanNotification(async () => {

--- a/securebuild-api/integration/api/v1/external-image/seed-data/external-image-sbom-status.yaml
+++ b/securebuild-api/integration/api/v1/external-image/seed-data/external-image-sbom-status.yaml
@@ -4,6 +4,72 @@ requires:
   - external-image-tag
 seedData:
   rows:
+    # Existing SBOMs were generated successfully before their scans ran.
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:abc123def456789012345678901234567890123456789012345678901234"
+        - column: status
+          value:
+            str: "succeeded"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: status_updated_at
+          value:
+            str: "2024-01-01T00:00:20Z"
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:queued123456789012345678901234567890123456789012345678901234"
+        - column: status
+          value:
+            str: "succeeded"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: status_updated_at
+          value:
+            str: "2024-01-01T00:00:20Z"
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:stale1234567890123456789012345678901234567890123456789012345"
+        - column: status
+          value:
+            str: "succeeded"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: status_updated_at
+          value:
+            str: "2024-01-01T00:00:20Z"
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:running123456789012345678901234567890123456789012345678901234"
+        - column: status
+          value:
+            str: "succeeded"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: status_updated_at
+          value:
+            str: "2024-01-01T00:00:20Z"
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:failed123456789012345678901234567890123456789012345678901234"
+        - column: status
+          value:
+            str: "succeeded"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: status_updated_at
+          value:
+            str: "2024-01-01T00:00:20Z"
     # Pending SBOM status
     - columns:
         - column: digest

--- a/securebuild-api/integration/api/v1/external-image/seed-data/external-image-sbom.yaml
+++ b/securebuild-api/integration/api/v1/external-image/seed-data/external-image-sbom.yaml
@@ -42,6 +42,26 @@ seedData:
         - column: is_in_object_store
           value:
             str: "true"
+    # Stale successful scan SBOM
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:stale1234567890123456789012345678901234567890123456789012345"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: source
+          value:
+            str: "grype"
+        - column: image_size_bytes
+          value:
+            int: 1024000
+        - column: is_in_object_store
+          value:
+            str: "true"
     # Queued scan SBOM
     - columns:
         - column: digest

--- a/securebuild-api/integration/api/v1/external-image/seed-data/external-image-scan.yaml
+++ b/securebuild-api/integration/api/v1/external-image/seed-data/external-image-scan.yaml
@@ -22,7 +22,7 @@ seedData:
             str: "succeeded"
         - column: scan_completed_at
           value:
-            str: "2024-01-01T00:05:00Z"
+            str: "2099-01-01T00:05:00Z"
         - column: scan_status_updated_at
           value:
             str: "2024-01-01T00:05:00Z"
@@ -48,7 +48,36 @@ seedData:
         - column: status
           value:
             str: "succeeded"
+        - column: scan_completed_at
+          value:
+            str: "2099-01-01T00:05:00Z"
         - column: scan_status_updated_at
+          value:
+            str: "2024-01-01T00:05:00Z"
+        - column: is_in_object_store
+          value:
+            str: "true"
+    # Successful but stale scan used by the on-demand scan tests
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:stale1234567890123456789012345678901234567890123456789012345"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: status
+          value:
+            str: "succeeded"
+        - column: scan_completed_at
+          value:
+            str: "2024-01-01T00:05:00Z"
+        - column: scan_status_updated_at
+          value:
+            str: "2024-01-01T00:05:00Z"
+        - column: scan_attempted_at
           value:
             str: "2024-01-01T00:05:00Z"
         - column: is_in_object_store

--- a/securebuild-api/integration/api/v1/external-image/seed-data/external-image-tag.yaml
+++ b/securebuild-api/integration/api/v1/external-image/seed-data/external-image-tag.yaml
@@ -48,6 +48,29 @@ seedData:
         - column: next_scan_at
           value:
             str: "2024-01-02T00:00:00Z"
+    # Stale successful scan tag
+    - columns:
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: image_tag
+          value:
+            str: "stale"
+        - column: digest
+          value:
+            str: "sha256:stale1234567890123456789012345678901234567890123456789012345"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: next_check_digest_at
+          value:
+            str: "2024-01-02T00:00:00Z"
+        - column: next_scan_at
+          value:
+            str: "2024-01-02T00:00:00Z"
     # Queued scan tag
     - columns:
         - column: registry

--- a/securebuild-api/integration/api/v1/external-image/seed-data/external-image-team.yaml
+++ b/securebuild-api/integration/api/v1/external-image/seed-data/external-image-team.yaml
@@ -37,6 +37,23 @@ seedData:
         - column: created_at
           value:
             str: "2024-01-01T00:00:00Z"
+    # Stale successful scan team access
+    - columns:
+        - column: team_id
+          value:
+            str: "test-team-alpha"
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: image_tag
+          value:
+            str: "stale"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
     # Queued scan team access
     - columns:
         - column: team_id

--- a/securebuild-api/lib/externalimage/externalimage.ts
+++ b/securebuild-api/lib/externalimage/externalimage.ts
@@ -271,25 +271,31 @@ export const getExternalImageSBOM = traceFunction('lib.externalimage.getExternal
     const db = getDB(await getParam("DB_URI"))
 
     // Query metadata only — sbom content is fetched from object store
-    const query = `select arch, source, is_in_object_store from external_image_sbom where digest = $1`
+    const query = `
+      select esbom.arch, esbom.source, esbom.is_in_object_store, status.status as sbom_status
+      from external_image_sbom esbom
+      left join external_image_sbom_status status on status.digest = esbom.digest
+      where esbom.digest = $1
+    `
     const result = await db.query(query, [digest])
 
     if (result.rows.length === 0) {
       return null
     }
 
-    let sbom: string | null = null
-    if (result.rows[0].is_in_object_store) {
+    const row = result.rows[0]
+    let sbom = ''
+    if (row.sbom_status === 'succeeded' && row.is_in_object_store) {
       try {
-        sbom = await getSBOM(digest, result.rows[0].arch)
+        sbom = await getSBOM(digest, row.arch)
       } catch (err) {
-        throw new Error(`getExternalImageSBOM: failed to fetch sbom blob for digest=${digest} arch=${result.rows[0].arch}: ${err}`)
+        throw new Error(`getExternalImageSBOM: failed to fetch sbom blob for digest=${digest} arch=${row.arch}: ${err}`)
       }
     }
 
     return {
-      sbom: sbom || '',
-      source: result.rows[0].source,
+      sbom,
+      source: row.source,
     }
   } catch (err) {
     console.error(`getExternalImageSBOM error:`, err)
@@ -418,9 +424,9 @@ export const getExternalImageScan = traceFunction('lib.externalimage.getExternal
 
     const row = result.rows[0]
 
-    // Fetch scan result from object store (only when blobs have been uploaded)
+    // Only successful scans have result blobs in object storage.
     let scanResult: string | null = null
-    if (row.is_in_object_store) {
+    if (row.status === 'succeeded' && row.is_in_object_store) {
       try {
         scanResult = format === 'raw'
           ? await getRawResult(digest, arch)
@@ -462,21 +468,27 @@ export const getExternalImageSbom = traceFunction('lib.externalimage.getExternal
     const db = getDB(await getParam("DB_URI"))
 
     // Query metadata only — sbom content is fetched from object store
-    const query = `select arch, is_in_object_store from external_image_sbom where digest = $1`
+    const query = `
+      select esbom.arch, esbom.is_in_object_store, status.status as sbom_status
+      from external_image_sbom esbom
+      left join external_image_sbom_status status on status.digest = esbom.digest
+      where esbom.digest = $1
+    `
     const result = await db.query(query, [digest])
 
     if (result.rows.length === 0) {
       return null
     }
 
-    if (!result.rows[0].is_in_object_store) {
+    const row = result.rows[0]
+    if (row.sbom_status !== 'succeeded' || !row.is_in_object_store) {
       return null
     }
 
     try {
-      return await getSBOM(digest, result.rows[0].arch)
+      return await getSBOM(digest, row.arch)
     } catch (err) {
-      throw new Error(`getExternalImageSbom: failed to fetch sbom blob for digest=${digest} arch=${result.rows[0].arch}: ${err}`)
+      throw new Error(`getExternalImageSbom: failed to fetch sbom blob for digest=${digest} arch=${row.arch}: ${err}`)
     }
   } catch (err) {
     console.error(`getExternalImageSbom error:`, err)
@@ -894,10 +906,10 @@ export const getBatchExternalImageScans = traceFunction('lib.externalimage.getBa
 
       const scanResult = await db.query(scanQuery, [arch, ownedDigestList])
 
-      // Process scan results — fetch blob content from object store (only when blobs have been uploaded)
+      // Process scan results. Only successful scans have result blobs.
       for (const row of scanResult.rows) {
         let scanResultBlob: string | null = null
-        if (row.is_in_object_store) {
+        if (row.scan_status === 'succeeded' && row.is_in_object_store) {
           try {
             scanResultBlob = format === 'raw'
               ? await getRawResult(row.digest, arch)
@@ -1030,9 +1042,12 @@ export const getBatchExternalSboms = traceFunction('lib.externalimage.getBatchEx
         esbom.arch,
         esbom.source,
         esbom.is_in_object_store,
+        esbom_status.status as sbom_status,
         esbom.created_at as sbom_created_at,
         esbom.image_size_bytes
       FROM external_image_sbom esbom
+        LEFT JOIN external_image_sbom_status esbom_status
+          ON esbom_status.digest = esbom.digest
         INNER JOIN external_image_tag etag
           ON etag.digest = esbom.digest
         INNER JOIN external_image_team eteam
@@ -1052,7 +1067,7 @@ export const getBatchExternalSboms = traceFunction('lib.externalimage.getBatchEx
 
     for (const row of result.rows) {
       let sbomContent: string | null = null
-      if (row.is_in_object_store) {
+      if (row.sbom_status === 'succeeded' && row.is_in_object_store) {
         try {
           sbomContent = await getSBOM(row.digest, row.arch)
         } catch (err) {


### PR DESCRIPTION
Following fields is no longer written to db

- external_image_scan.parsed_results_details
- external_image_scan.raw_result
- external_image_sbom.sbom