### PR TITLE
Try base64 encoded encryption secret

### DIFF
--- a/pkg/image/external.go
+++ b/pkg/image/external.go
@@ -86,7 +86,26 @@ func DecryptExternalRegistryPassword(ctx context.Context, password string) (stri
 	iv := combined[:12]
 	encryptedData := combined[12:]
 
-	// Create a 32-byte key from the secret using SHA-256
+	decrypted, err := decryptExternalRegistryPasswordWithSecret(iv, encryptedData, secret)
+	if err == nil {
+		return decrypted, nil
+	}
+
+	// Credentials written by securebuild-api while it treated the injected
+	// base64 value as the secret were encrypted with this encoded form. The Go
+	// worker receives the decoded secret, so try the encoded form as a
+	// compatibility fallback.
+	encodedSecret := base64.StdEncoding.EncodeToString([]byte(secret))
+	fallbackDecrypted, fallbackErr := decryptExternalRegistryPasswordWithSecret(iv, encryptedData, encodedSecret)
+	if fallbackErr == nil {
+		return fallbackDecrypted, nil
+	}
+
+	return "", fmt.Errorf("failed to decrypt password with primary key (%v) and base64-encoded fallback: %w", err, fallbackErr)
+}
+
+func decryptExternalRegistryPasswordWithSecret(iv, encryptedData []byte, secret string) (string, error) {
+	// Create a 32-byte key from the secret using SHA-256.
 	hash := sha256.Sum256([]byte(secret))
 	key := hash[:]
 
@@ -105,7 +124,7 @@ func DecryptExternalRegistryPassword(ctx context.Context, password string) (stri
 	// Decrypt the data
 	decrypted, err := gcm.Open(nil, iv, encryptedData, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to decrypt password: %w", err)
+		return "", err
 	}
 
 	return string(decrypted), nil

--- a/pkg/listener/external-image-sbom-builder.go
+++ b/pkg/listener/external-image-sbom-builder.go
@@ -244,7 +244,7 @@ func buildSyftLaunchCommand(workDir, platform, registry, imageName, digest strin
 func buildSbomDockerConfig(ctx context.Context, teamID, registry, imageName string) (string, error) {
 	username, password, err := externalimage.GetExternalImageCredentials(ctx, teamID, registry, imageName)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get external image credentials: %w", err)
 	}
 	if username == "" || password == "" {
 		return "", nil

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -56,8 +56,9 @@ func FetchSBOM(ctx context.Context, teamID string, registry string, imageName st
 
 	username, password, err := externalimage.GetExternalImageCredentials(ctx, teamID, registry, imageName)
 	if err != nil {
-		logger.Warn("failed to get external image credentials, continuing with anonymous auth", zap.Error(err))
-	} else if username != "" && password != "" {
+		return nil, fmt.Errorf("failed to get external image credentials: %w", err)
+	}
+	if username != "" && password != "" {
 		logger.Info("using external image credentials")
 		// Use registry package to get credentials - this handles ECR token exchange
 		auth, err = registrypkg.GetCredentialsForEndpoint(ctx, registry, username, password)

--- a/securebuild-api/integration/fixtures/environment.ts
+++ b/securebuild-api/integration/fixtures/environment.ts
@@ -22,7 +22,7 @@ export const SEEDED_EXISTING_DIGEST = 'sha256:abc123def4567890123456789012345678
 export const SEED_TEAM_ID = 'test-team-alpha';
 
 // Encryption secret for storing registry pull credentials.
-const TEST_ENCRYPTION_SECRET = 'test-encryption-secret-32bytes!!';
+const TEST_ENCRYPTION_SECRET = Buffer.from('test-encryption-secret-32bytes!!').toString('base64');
 
 export interface TestEnvironment {
   client: HttpClient;

--- a/securebuild-api/lib/externalimage/externalimage.ts
+++ b/securebuild-api/lib/externalimage/externalimage.ts
@@ -159,10 +159,11 @@ export async function listExternalImages(teamId: string): Promise<TrackedExterna
 
 
 export async function encryptPassword(password: string): Promise<string> {
-  const secret = process.env.EXTERNAL_REGISTRY_ENCRYPTION_SECRET;
-  if (!secret) {
+  const secretEncoded = process.env.EXTERNAL_REGISTRY_ENCRYPTION_SECRET;
+  if (!secretEncoded) {
     throw new Error("EXTERNAL_REGISTRY_ENCRYPTION_SECRET environment variable is required");
   }
+  const secret = Buffer.from(secretEncoded, 'base64').toString('utf-8');
 
   // Generate a random IV for each encryption
   const iv = crypto.getRandomValues(new Uint8Array(12));
@@ -198,10 +199,11 @@ export async function encryptPassword(password: string): Promise<string> {
 }
 
 export async function decryptPassword(encryptedPassword: string): Promise<string> {
-  const secret = process.env.EXTERNAL_REGISTRY_ENCRYPTION_SECRET;
-  if (!secret) {
+  const secretEncoded = process.env.EXTERNAL_REGISTRY_ENCRYPTION_SECRET;
+  if (!secretEncoded) {
     throw new Error("EXTERNAL_REGISTRY_ENCRYPTION_SECRET environment variable is required");
   }
+  const secret = Buffer.from(secretEncoded, 'base64').toString('utf-8');
 
   // Decode the base64 combined data
   const combined = Buffer.from(encryptedPassword, 'base64');


### PR DESCRIPTION
`EXTERNAL_REGISTRY_ENCRYPTION_SECRET` in Doppler is not base64 encoded, but it is when used as an environment variable in securebuild-api container. There are some secrets that were encrypted with base64 encoded value. We need to handle those.