### PR TITLE
Package rebuild chains support 'provides' package names

### DIFF
--- a/cmd/cli/migrate-package-selectors.go
+++ b/cmd/cli/migrate-package-selectors.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"fmt"
+	"os/signal"
+	"syscall"
+
+	sbpackage "github.com/securebuildhq/securebuild/pkg/package"
+	"github.com/securebuildhq/securebuild/pkg/param"
+	"github.com/securebuildhq/securebuild/pkg/persistence"
+	"github.com/spf13/cobra"
+)
+
+func MigratePackageSelectorsCmd() *cobra.Command {
+	var dryRun bool
+	cmd := &cobra.Command{
+		Use:   "migrate-package-selectors",
+		Short: "Backfill dependency and provides selectors from stored Melange YAML",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			initSource, err := param.ResolveInitSource()
+			if err != nil {
+				return err
+			}
+			ctx, err := param.Init(initSource, nil)
+			if err != nil {
+				return err
+			}
+			ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+			defer stop()
+			if err := persistence.InitPostgres(ctx); err != nil {
+				return fmt.Errorf("initialize postgres: %w", err)
+			}
+			defer persistence.ClosePool(ctx)
+
+			result, err := sbpackage.BackfillPackageSelectors(ctx, sbpackage.SelectorMigrationOptions{DryRun: dryRun})
+			fmt.Fprintf(cmd.OutOrStdout(), "package_versions=%d dependency_rows=%d provides_rows=%d unmatched=%d failed=%d\n",
+				result.PackageVersions, result.DependencyRows, result.ProvidesRows, result.Unmatched, result.Failed)
+			return err
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "inspect selectors without updating PostgreSQL")
+	return cmd
+}

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -23,5 +23,6 @@ func RootCmd() *cobra.Command {
 	rootCmd.AddCommand(DeleteAPKCmd())
 	rootCmd.AddCommand(RepublishImageToExternalRegistryCmd())
 	rootCmd.AddCommand(BuildOrderCmd())
+	rootCmd.AddCommand(MigratePackageSelectorsCmd())
 	return &rootCmd
 }

--- a/db/schema/tables/package-version-dependency-buildtime.yaml
+++ b/db/schema/tables/package-version-dependency-buildtime.yaml
@@ -30,6 +30,8 @@ schema:
         type: text
         constraints:
           notNull: true
+      - name: dependency_spec
+        type: text
       - name: depends_on_package_version_id
         type: text
         constraints:

--- a/db/schema/tables/package-version-dependency-runtime.yaml
+++ b/db/schema/tables/package-version-dependency-runtime.yaml
@@ -30,6 +30,8 @@ schema:
         type: text
         constraints:
           notNull: true
+      - name: dependency_spec
+        type: text
       - name: depends_on_package_version_id
         type: text
         constraints:

--- a/db/schema/tables/package-version-provides.yaml
+++ b/db/schema/tables/package-version-provides.yaml
@@ -21,6 +21,8 @@ schema:
         type: text
         constraints:
           notNull: true
+      - name: provides_spec
+        type: text
       - name: is_subpackage
         type: boolean
         constraints:

--- a/integration/worker/package_dependency_graph/package_dependency_graph_test.go
+++ b/integration/worker/package_dependency_graph/package_dependency_graph_test.go
@@ -1,0 +1,200 @@
+package package_dependency_graph_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/securebuildhq/securebuild/integration/testutil"
+	"github.com/securebuildhq/securebuild/pkg/buildgraph"
+	sbpackage "github.com/securebuildhq/securebuild/pkg/package"
+	"github.com/securebuildhq/securebuild/pkg/param"
+	"github.com/securebuildhq/securebuild/pkg/persistence"
+	pkgtestutil "github.com/securebuildhq/securebuild/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConstraintAwarePackageDependencyMap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	testDB := testutil.SetupTestDatabase(ctx, t)
+	defer testutil.TeardownTestDatabase(ctx, t, testDB)
+
+	ctx, err := param.Init(param.InitSourceEnvironment, map[string]string{
+		"DB_URI": testDB.ConnStr, "PIPELINE_DIR": pkgtestutil.SetupTestPipelineDir(t),
+	})
+	require.NoError(t, err)
+	require.NoError(t, persistence.InitPostgres(ctx))
+	defer persistence.ClosePool(ctx)
+
+	now := time.Now().UTC()
+	packages := []struct{ id, name string }{
+		{"pkg-go-125", "go-1.25"},
+		{"pkg-go-126", "go-1.26"},
+		{"pkg-unpinned", "schemahero-unpinned"},
+		{"pkg-pinned", "schemahero-pinned"},
+		{"pkg-exact", "schemahero-exact"},
+	}
+	for _, pkg := range packages {
+		_, err := testDB.Pool.Exec(ctx, `
+			INSERT INTO package (id, name, created_at, updated_at, is_delete_protection_enabled, is_deleted)
+			VALUES ($1, $2, $3, $3, false, false)
+		`, pkg.id, pkg.name, now)
+		require.NoError(t, err)
+	}
+
+	versions := []struct {
+		id, packageID, version string
+		release                int
+	}{
+		{"pv-go-125", "pkg-go-125", "1.25.9", 1},
+		{"pv-go-126", "pkg-go-126", "1.26.5", 0},
+		{"pv-unpinned-old", "pkg-unpinned", "0.24.0", 0},
+		{"pv-unpinned", "pkg-unpinned", "0.25.0", 0},
+		{"pv-pinned", "pkg-pinned", "0.25.0", 0},
+		{"pv-exact", "pkg-exact", "0.25.0", 0},
+	}
+	for _, version := range versions {
+		_, err := testDB.Pool.Exec(ctx, `
+			INSERT INTO package_version
+			(id, package_id, version, melange_yaml, created_at, apk_release, has_securebuild_edits, use_root, bootstrap_enabled)
+			VALUES ($1, $2, $3, '', $4, $5, false, false, false)
+		`, version.id, version.packageID, version.version, now, version.release)
+		require.NoError(t, err)
+	}
+
+	_, err = testDB.Pool.Exec(ctx, `
+		INSERT INTO execution (id, created_at, package_id, package_version_id, version_label, status)
+		VALUES ('exec-go-125', $1, 'pkg-go-125', 'pv-go-125', '1.25.9-r1', 'success')
+	`, now)
+	require.NoError(t, err)
+
+	for _, provide := range []struct{ id, versionID, packageName, spec string }{
+		{"provide-go-125", "pv-go-125", "go-1.25", "go=1.25.9-r1"},
+		{"provide-go-126", "pv-go-126", "go-1.26", "go=1.26.5-r0"},
+	} {
+		_, err := testDB.Pool.Exec(ctx, `
+			INSERT INTO package_version_provides
+			(id, package_version_id, package_name, provides_name, provides_spec, is_subpackage)
+			VALUES ($1, $2, $3, 'go', $4, false)
+		`, provide.id, provide.versionID, provide.packageName, provide.spec)
+		require.NoError(t, err)
+	}
+
+	buildDependencies := []struct{ versionID, consumerName, providerID, selector string }{
+		{"pv-unpinned-old", "schemahero-unpinned", "pkg-go-125", "go~1.25"},
+		{"pv-unpinned", "schemahero-unpinned", "pkg-go-125", "go"},
+		{"pv-pinned", "schemahero-pinned", "pkg-go-125", "go~1.25"},
+	}
+	for _, dependency := range buildDependencies {
+		_, err := testDB.Pool.Exec(ctx, `
+			INSERT INTO package_version_dependency_buildtime
+			(package_version_id, package_name, package_version, package_apk_release,
+			 depends_on_package_id, depends_on_package_name, dependency_spec, depends_on_package_is_external)
+			SELECT $1, $2, pv.version, pv.apk_release, $3, 'go', $4, false
+			FROM package_version pv WHERE pv.id = $1
+		`, dependency.versionID, dependency.consumerName, dependency.providerID, dependency.selector)
+		require.NoError(t, err)
+	}
+	_, err = testDB.Pool.Exec(ctx, `
+		INSERT INTO package_version_dependency_runtime
+		(package_version_id, package_name, package_version, package_apk_release,
+		 depends_on_package_id, depends_on_package_name, dependency_spec, depends_on_package_is_external)
+		VALUES ('pv-exact', 'schemahero-exact', '0.25.0', 0,
+		        'pkg-go-126', 'go', 'go=1.26.5-r0', false)
+	`)
+	require.NoError(t, err)
+
+	dependencyMap, diagnostics, err := sbpackage.GetConstraintAwarePackageDependencyMap(ctx, "pv-go-126")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"schemahero-exact", "schemahero-unpinned"}, dependencyMap["go-1.26"])
+	require.ElementsMatch(t, []string{"schemahero-pinned"}, dependencyMap["go-1.25"])
+	require.NotContains(t, dependencyMap["go-1.25"], "schemahero-unpinned", "historical consumer pin must not create a stale edge")
+	require.Equal(t, 3, diagnostics.Dependencies)
+	require.Equal(t, 1, diagnostics.Unpinned)
+	require.Equal(t, 2, diagnostics.Pinned)
+	require.Equal(t, 1, diagnostics.StoredProviderMove)
+
+	nodes, edges := buildgraph.BuildDAG(dependencyMap, "go-1.26")
+	require.ElementsMatch(t, []string{"go-1.26", "schemahero-exact", "schemahero-unpinned"}, nodes)
+	chain, err := sbpackage.CreateRebuildChain(ctx, "pkg-go-126", stringPointer("pv-go-126"), nodes, edges, "go-1.26")
+	require.NoError(t, err)
+
+	var pinnedLinks int
+	err = testDB.Pool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM rebuild_chain_link rcl
+		JOIN package p ON p.id = rcl.package_id
+		WHERE rcl.rebuild_chain_id = $1 AND p.name = 'schemahero-pinned'
+	`, chain.ID).Scan(&pinnedLinks)
+	require.NoError(t, err)
+	require.Zero(t, pinnedLinks)
+
+	// Selector migration reconstructs complete selectors without rewriting the
+	// existing provider identity columns.
+	_, err = testDB.Pool.Exec(ctx, `
+		INSERT INTO package (id, name, created_at, updated_at, is_delete_protection_enabled, is_deleted)
+		VALUES ('pkg-migrate', 'selector-migrate', $1, $1, false, false)
+	`, now)
+	require.NoError(t, err)
+	melangeYAML := `
+package:
+  name: selector-migrate
+  version: 1.0.0
+  epoch: 0
+  dependencies:
+    runtime:
+      - go~1.25
+    provides:
+      - selector-migrate=${{package.full-version}}
+environment:
+  contents:
+    packages:
+      - go~1.25
+pipeline:
+  - runs: echo test
+`
+	_, err = sbpackage.ExtractProvidesFromMelangeYAML(ctx, []byte(melangeYAML))
+	require.NoError(t, err)
+	_, err = testDB.Pool.Exec(ctx, `
+		INSERT INTO package_version
+		(id, package_id, version, melange_yaml, created_at, apk_release, has_securebuild_edits, use_root, bootstrap_enabled)
+		VALUES ('pv-migrate', 'pkg-migrate', '1.0.0', $1, $2, 0, false, false, false)
+	`, melangeYAML, now)
+	require.NoError(t, err)
+	for _, table := range []string{"package_version_dependency_runtime", "package_version_dependency_buildtime"} {
+		_, err = testDB.Pool.Exec(ctx, `INSERT INTO `+table+`
+			(package_version_id, package_name, package_version, package_apk_release,
+			 depends_on_package_id, depends_on_package_name, depends_on_package_is_external)
+			VALUES ('pv-migrate', 'selector-migrate', '1.0.0', 0, 'pkg-go-125', 'go', false)`)
+		require.NoError(t, err)
+	}
+	_, err = testDB.Pool.Exec(ctx, `
+		INSERT INTO package_version_provides
+		(id, package_version_id, package_name, provides_name, is_subpackage)
+		VALUES ('provide-migrate', 'pv-migrate', 'selector-migrate', 'selector-migrate', false)
+	`)
+	require.NoError(t, err)
+
+	dryRun, err := sbpackage.BackfillPackageSelectors(ctx, sbpackage.SelectorMigrationOptions{DryRun: true})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, dryRun.DependencyRows)
+	require.EqualValues(t, 1, dryRun.ProvidesRows)
+	var selector *string
+	require.NoError(t, testDB.Pool.QueryRow(ctx, `SELECT dependency_spec FROM package_version_dependency_buildtime WHERE package_version_id = 'pv-migrate'`).Scan(&selector))
+	require.Nil(t, selector)
+
+	migrated, err := sbpackage.BackfillPackageSelectors(ctx, sbpackage.SelectorMigrationOptions{})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, migrated.DependencyRows)
+	require.EqualValues(t, 1, migrated.ProvidesRows)
+	var dependencySpec, providesSpec string
+	require.NoError(t, testDB.Pool.QueryRow(ctx, `SELECT dependency_spec FROM package_version_dependency_buildtime WHERE package_version_id = 'pv-migrate'`).Scan(&dependencySpec))
+	require.NoError(t, testDB.Pool.QueryRow(ctx, `SELECT provides_spec FROM package_version_provides WHERE package_version_id = 'pv-migrate'`).Scan(&providesSpec))
+	require.Equal(t, "go~1.25", dependencySpec)
+	require.Equal(t, "selector-migrate=1.0.0-r0", providesSpec)
+}
+
+func stringPointer(value string) *string { return &value }

--- a/pkg/listener/build-package-chain.go
+++ b/pkg/listener/build-package-chain.go
@@ -35,10 +35,21 @@ func handleBuildPackageChain(ctx context.Context, payload string) error {
 		return fmt.Errorf("failed to get package: %w", err)
 	}
 
-	// Create dependency map from database
-	dependencyMap, err := sbpackage.GetPackageDependencyMap(ctx)
+	dependencyMap, diagnostics, err := sbpackage.GetConstraintAwarePackageDependencyMap(ctx, buildPackageChainPayload.PackageVersionID)
 	if err != nil {
-		return fmt.Errorf("failed to create dependency map: %w", err)
+		return fmt.Errorf("failed to create constraint-aware dependency map: %w", err)
+	}
+	logger.Info("calculated constraint-aware dependency map",
+		zap.Int("dependencies", diagnostics.Dependencies),
+		zap.Int("pinned", diagnostics.Pinned),
+		zap.Int("unpinned", diagnostics.Unpinned),
+		zap.Int("unresolved", diagnostics.Unresolved),
+		zap.Int("ambiguous", diagnostics.Ambiguous),
+		zap.Int("missingSelectors", diagnostics.MissingSelectors),
+		zap.Int("storedProviderMoves", diagnostics.StoredProviderMove))
+	if diagnostics.MissingSelectors > 0 {
+		logger.Warn("constraint-aware dependency graph used package-name fallback for dependencies without selectors; run migrate-package-selectors",
+			zap.Int("missingSelectors", diagnostics.MissingSelectors))
 	}
 
 	// Check if package exists in the dependency map

--- a/pkg/listener/update-build-package-status.go
+++ b/pkg/listener/update-build-package-status.go
@@ -339,27 +339,15 @@ func updateBuildPackageStatus(ctx context.Context, executionID string) error {
 		if err != nil {
 			return fmt.Errorf("failed to list package version build dependencies: %w", err)
 		}
+		resolvedProviders, err := sbpackage.GetPreferredAvailableProviderVersions(ctx, append(append([]string{}, runtimeDeps...), buildDeps...))
+		if err != nil {
+			return fmt.Errorf("failed to resolve dependency providers: %w", err)
+		}
 
 		for _, dep := range runtimeDeps {
-			pkgID, err := sbpackage.GetPackageIDByName(ctx, dep)
-			if err != nil {
-				logger.Debug("failed to get runtime dependency package id by name", zap.String("packageName", dep), zap.Error(err))
-				continue
-			}
-
-			pkg, err := sbpackage.GetPackage(ctx, pkgID)
-			if err != nil {
-				return fmt.Errorf("failed to get runtime dep package: %w", err)
-			}
-
-			// if the package has a parent, we actually depend on the parent
-			if pkg.ParentID != nil {
-				pkgID = *pkg.ParentID
-			}
-
-			latestPackageVersion, err := sbpackage.GetLatestBuiltPackageVersion(ctx, pkgID)
-			if err != nil {
-				// there might not be a built version yet, so we can just continue
+			latestPackageVersion, ok := resolvedProviders[dep]
+			if !ok {
+				logger.Debug("failed to resolve runtime dependency provider", zap.String("dependency", dep))
 				continue
 			}
 
@@ -369,25 +357,9 @@ func updateBuildPackageStatus(ctx context.Context, executionID string) error {
 		}
 
 		for _, dep := range buildDeps {
-			pkgID, err := sbpackage.GetPackageIDByName(ctx, dep)
-			if err != nil {
-				logger.Debug("failed to get build dependency package id by name", zap.String("packageName", dep), zap.Error(err))
-				continue
-			}
-
-			pkg, err := sbpackage.GetPackage(ctx, pkgID)
-			if err != nil {
-				return fmt.Errorf("failed to get build dep package: %w", err)
-			}
-
-			// if the package has a parent, we actually depend on the parent
-			if pkg.ParentID != nil {
-				pkgID = *pkg.ParentID
-			}
-
-			latestPackageVersion, err := sbpackage.GetLatestBuiltPackageVersion(ctx, pkgID)
-			if err != nil {
-				// there might not be a built version yet, so we can just continue
+			latestPackageVersion, ok := resolvedProviders[dep]
+			if !ok {
+				logger.Debug("failed to resolve build dependency provider", zap.String("dependency", dep))
 				continue
 			}
 

--- a/pkg/package/constraint_dependency_graph.go
+++ b/pkg/package/constraint_dependency_graph.go
@@ -1,0 +1,394 @@
+package sbpackage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+
+	apkopackage "chainguard.dev/apko/pkg/apk/apk"
+	"github.com/jackc/pgx/v5"
+	"github.com/securebuildhq/securebuild/pkg/package/types"
+	"github.com/securebuildhq/securebuild/pkg/persistence"
+)
+
+// DependencyGraphDiagnostics describes decisions made while resolving the
+// active package dependency graph.
+type DependencyGraphDiagnostics struct {
+	Dependencies       int
+	Pinned             int
+	Unpinned           int
+	Unresolved         int
+	Ambiguous          int
+	MissingSelectors   int
+	StoredProviderMove int
+}
+
+type providerCandidate struct {
+	CapabilityName    string
+	CapabilityVersion string
+	PackageID         string
+	PackageName       string
+	PackageVersionID  string
+	ExactName         bool
+}
+
+type activeDependency struct {
+	ConsumerName     string
+	Selector         string
+	RequestedName    string
+	StoredProvider   string
+	PackageVersion   string
+	PackageRelease   int
+	PackageVersionID string
+}
+
+func apkVersionString(version string, release int) string {
+	if strings.HasSuffix(version, fmt.Sprintf("-r%d", release)) {
+		return version
+	}
+	return fmt.Sprintf("%s-r%d", version, release)
+}
+
+func compareAPKVersions(left, right string) int {
+	lv, leftErr := apkopackage.ParseVersion(left)
+	rv, rightErr := apkopackage.ParseVersion(right)
+	switch {
+	case leftErr == nil && rightErr == nil:
+		return apkopackage.CompareVersions(lv, rv)
+	case leftErr == nil:
+		return 1
+	case rightErr == nil:
+		return -1
+	default:
+		return strings.Compare(left, right)
+	}
+}
+
+func selectPreferredProvider(candidates []providerCandidate, selector string) (providerCandidate, bool, error) {
+	constraint := apkopackage.ResolvePackageNameVersionPin(selector)
+	matching := make([]providerCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.CapabilityName != constraint.Name {
+			continue
+		}
+		version, err := apkopackage.ParseVersion(candidate.CapabilityVersion)
+		if err != nil {
+			continue
+		}
+		satisfied, err := constraint.SatisfiedBy(version)
+		if err != nil {
+			return providerCandidate{}, false, fmt.Errorf("evaluate selector %q against %q: %w", selector, candidate.CapabilityVersion, err)
+		}
+		if satisfied {
+			matching = append(matching, candidate)
+		}
+	}
+	if len(matching) == 0 {
+		return providerCandidate{}, false, fmt.Errorf("no available provider satisfies %q: %w", selector, ErrPackageNotFound)
+	}
+
+	sort.SliceStable(matching, func(i, j int) bool {
+		if comparison := compareAPKVersions(matching[i].CapabilityVersion, matching[j].CapabilityVersion); comparison != 0 {
+			return comparison > 0
+		}
+		if matching[i].ExactName != matching[j].ExactName {
+			return matching[i].ExactName
+		}
+		if matching[i].PackageName != matching[j].PackageName {
+			return matching[i].PackageName < matching[j].PackageName
+		}
+		return matching[i].PackageVersionID < matching[j].PackageVersionID
+	})
+
+	ambiguous := len(matching) > 1 &&
+		compareAPKVersions(matching[0].CapabilityVersion, matching[1].CapabilityVersion) == 0 &&
+		matching[0].ExactName == matching[1].ExactName
+	return matching[0], ambiguous, nil
+}
+
+// GetConstraintAwarePackageDependencyMap resolves each dependency in the active
+// package spec to the latest available concrete provider satisfying its selector.
+// A successful execution is the availability signal; rootPackageVersionID is
+// also eligible because this graph describes repository state after the root build.
+func GetConstraintAwarePackageDependencyMap(ctx context.Context, rootPackageVersionID string) (map[string][]string, DependencyGraphDiagnostics, error) {
+	db := persistence.MustGetPooledPostgresSession(ctx)
+	defer db.Release()
+
+	activeVersionIDs, err := listActiveTopLevelPackageVersionIDs(ctx, db)
+	if err != nil {
+		return nil, DependencyGraphDiagnostics{}, err
+	}
+
+	dependencies, err := listActiveDependencies(ctx, db, activeVersionIDs)
+	if err != nil {
+		return nil, DependencyGraphDiagnostics{}, err
+	}
+
+	providerIndex, err := listAvailableProviders(ctx, db, rootPackageVersionID)
+	if err != nil {
+		return nil, DependencyGraphDiagnostics{}, err
+	}
+
+	graphSets := make(map[string]map[string]struct{})
+	diagnostics := DependencyGraphDiagnostics{}
+	for _, dependency := range dependencies {
+		diagnostics.Dependencies++
+		selector := dependency.Selector
+		if selector == "" {
+			selector = dependency.RequestedName
+			diagnostics.MissingSelectors++
+		}
+		parsed := apkopackage.ResolvePackageNameVersionPin(selector)
+		if parsed.Version == "" {
+			diagnostics.Unpinned++
+		} else {
+			diagnostics.Pinned++
+		}
+
+		selected, ambiguous, err := selectPreferredProvider(providerIndex[parsed.Name], selector)
+		if err != nil {
+			diagnostics.Unresolved++
+			continue
+		}
+		if ambiguous {
+			diagnostics.Ambiguous++
+		}
+		if dependency.StoredProvider != "" && dependency.StoredProvider != selected.PackageID {
+			diagnostics.StoredProviderMove++
+		}
+		if graphSets[selected.PackageName] == nil {
+			graphSets[selected.PackageName] = make(map[string]struct{})
+		}
+		graphSets[selected.PackageName][dependency.ConsumerName] = struct{}{}
+	}
+
+	graph := make(map[string][]string, len(graphSets))
+	for provider, consumers := range graphSets {
+		for consumer := range consumers {
+			graph[provider] = append(graph[provider], consumer)
+		}
+		sort.Strings(graph[provider])
+	}
+	for _, consumers := range graph {
+		for _, consumer := range consumers {
+			if _, ok := graph[consumer]; !ok {
+				graph[consumer] = []string{}
+			}
+		}
+	}
+	return graph, diagnostics, nil
+}
+
+// GetPreferredAvailableProviderVersions resolves selectors against one snapshot
+// of the available provider set. Unmatched selectors are omitted from the result.
+func GetPreferredAvailableProviderVersions(ctx context.Context, selectors []string) (map[string]*types.PackageVersion, error) {
+	db := persistence.MustGetPooledPostgresSession(ctx)
+	providers, err := listAvailableProviders(ctx, db, "")
+	db.Release()
+	if err != nil {
+		return nil, err
+	}
+	selectedIDs := make(map[string]string, len(selectors))
+	for _, selector := range selectors {
+		parsed := apkopackage.ResolvePackageNameVersionPin(selector)
+		selected, _, selectErr := selectPreferredProvider(providers[parsed.Name], selector)
+		if selectErr == nil {
+			selectedIDs[selector] = selected.PackageVersionID
+		}
+	}
+	resolved := make(map[string]*types.PackageVersion, len(selectedIDs))
+	for selector, versionID := range selectedIDs {
+		version, getErr := GetPackageVersion(ctx, versionID)
+		if getErr != nil {
+			return nil, fmt.Errorf("get selected provider version %s: %w", versionID, getErr)
+		}
+		resolved[selector] = version
+	}
+	return resolved, nil
+}
+
+// dbQueryer is the subset implemented by pgxpool.Conn and used here to keep
+// graph construction independently testable at the selection layer.
+type dbQueryer interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+}
+
+func listActiveTopLevelPackageVersionIDs(ctx context.Context, db dbQueryer) ([]string, error) {
+	rows, err := db.Query(ctx, `
+		SELECT pv.id, pv.package_id, pv.version, pv.apk_release
+		FROM package_version pv
+		JOIN package p ON p.id = pv.package_id
+		WHERE p.parent_id IS NULL
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list top-level package versions: %w", err)
+	}
+	defer rows.Close()
+
+	type versionChoice struct {
+		id      string
+		version string
+		release int
+	}
+	active := make(map[string]versionChoice)
+	for rows.Next() {
+		var id, packageID, version string
+		var release int
+		if err := rows.Scan(&id, &packageID, &version, &release); err != nil {
+			return nil, fmt.Errorf("scan top-level package version: %w", err)
+		}
+		choice, exists := active[packageID]
+		if !exists || compareAPKVersions(apkVersionString(version, release), apkVersionString(choice.version, choice.release)) > 0 {
+			active[packageID] = versionChoice{id: id, version: version, release: release}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate top-level package versions: %w", err)
+	}
+	ids := make([]string, 0, len(active))
+	for _, choice := range active {
+		ids = append(ids, choice.id)
+	}
+	sort.Strings(ids)
+	return ids, nil
+}
+
+func listActiveDependencies(ctx context.Context, db dbQueryer, activeVersionIDs []string) ([]activeDependency, error) {
+	if len(activeVersionIDs) == 0 {
+		return nil, nil
+	}
+	rows, err := db.Query(ctx, `
+		SELECT dependent.name, d.dependency_spec, d.depends_on_package_name,
+		       d.depends_on_package_id, pv.id, pv.version, pv.apk_release
+		FROM (
+			SELECT package_version_id, dependency_spec, depends_on_package_name, depends_on_package_id, depends_on_package_is_external
+			FROM package_version_dependency_runtime
+			UNION ALL
+			SELECT package_version_id, dependency_spec, depends_on_package_name, depends_on_package_id, depends_on_package_is_external
+			FROM package_version_dependency_buildtime
+		) d
+		JOIN package_version pv ON pv.id = d.package_version_id
+		JOIN package dependent ON dependent.id = pv.package_id
+		WHERE d.package_version_id = ANY($1)
+		  AND d.depends_on_package_is_external = false
+		  AND dependent.parent_id IS NULL
+	`, activeVersionIDs)
+	if err != nil {
+		return nil, fmt.Errorf("list active dependencies: %w", err)
+	}
+	defer rows.Close()
+
+	var dependencies []activeDependency
+	for rows.Next() {
+		var dependency activeDependency
+		var selector sql.NullString
+		if err := rows.Scan(&dependency.ConsumerName, &selector, &dependency.RequestedName,
+			&dependency.StoredProvider, &dependency.PackageVersionID, &dependency.PackageVersion, &dependency.PackageRelease); err != nil {
+			return nil, fmt.Errorf("scan active dependency: %w", err)
+		}
+		if selector.Valid {
+			dependency.Selector = selector.String
+		}
+		dependencies = append(dependencies, dependency)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate active dependencies: %w", err)
+	}
+	return dependencies, nil
+}
+
+func listAvailableProviders(ctx context.Context, db dbQueryer, rootPackageVersionID string) (map[string][]providerCandidate, error) {
+	rows, err := db.Query(ctx, `
+		WITH eligible AS (
+			SELECT pv.id, pv.package_id, p.name AS package_name, pv.version, pv.apk_release
+			FROM package_version pv
+			JOIN package p ON p.id = pv.package_id
+			WHERE p.parent_id IS NULL
+			  AND (pv.id = $1 OR EXISTS (
+				SELECT 1 FROM execution e
+				WHERE e.package_version_id = pv.id AND e.status = 'success'
+			  ))
+		)
+		SELECT e.id, e.package_id, e.package_name, e.version, e.apk_release,
+		       pvp.provides_name, pvp.provides_spec
+		FROM eligible e
+		LEFT JOIN package_version_provides pvp ON pvp.package_version_id = e.id
+	`, rootPackageVersionID)
+	if err != nil {
+		return nil, fmt.Errorf("list available providers: %w", err)
+	}
+	defer rows.Close()
+
+	index := make(map[string][]providerCandidate)
+	seenImplicit := make(map[string]struct{})
+	for rows.Next() {
+		var versionID, packageID, packageName, version string
+		var release int
+		var providesName, providesSpec sql.NullString
+		if err := rows.Scan(&versionID, &packageID, &packageName, &version, &release, &providesName, &providesSpec); err != nil {
+			return nil, fmt.Errorf("scan available provider: %w", err)
+		}
+		implicitKey := versionID + "\x00" + packageName
+		if _, ok := seenImplicit[implicitKey]; !ok {
+			seenImplicit[implicitKey] = struct{}{}
+			index[packageName] = append(index[packageName], providerCandidate{
+				CapabilityName: packageName, CapabilityVersion: apkVersionString(version, release),
+				PackageID: packageID, PackageName: packageName, PackageVersionID: versionID, ExactName: true,
+			})
+		}
+		if providesName.Valid {
+			capabilityVersion := apkVersionString(version, release)
+			if providesSpec.Valid {
+				parsed := apkopackage.ResolvePackageNameVersionPin(providesSpec.String)
+				if parsed.Version != "" {
+					capabilityVersion = parsed.Version
+				}
+			}
+			index[providesName.String] = append(index[providesName.String], providerCandidate{
+				CapabilityName: providesName.String, CapabilityVersion: capabilityVersion,
+				PackageID: packageID, PackageName: packageName, PackageVersionID: versionID,
+			})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate available providers: %w", err)
+	}
+
+	// Every subpackage name is an implicit capability supplied by its parent build.
+	subpackageRows, err := db.Query(ctx, `
+		WITH eligible AS (
+			SELECT pv.id, pv.package_id, p.name AS package_name, pv.version, pv.apk_release
+			FROM package_version pv
+			JOIN package p ON p.id = pv.package_id
+			WHERE p.parent_id IS NULL
+			  AND (pv.id = $1 OR EXISTS (
+				SELECT 1 FROM execution e
+				WHERE e.package_version_id = pv.id AND e.status = 'success'
+			  ))
+		)
+		SELECT e.id, e.package_id, e.package_name, e.version, e.apk_release, child.name
+		FROM eligible e
+		JOIN package child ON child.parent_id = e.package_id
+	`, rootPackageVersionID)
+	if err != nil {
+		return nil, fmt.Errorf("list available subpackage providers: %w", err)
+	}
+	defer subpackageRows.Close()
+	for subpackageRows.Next() {
+		var versionID, packageID, packageName, version, childName string
+		var release int
+		if err := subpackageRows.Scan(&versionID, &packageID, &packageName, &version, &release, &childName); err != nil {
+			return nil, fmt.Errorf("scan available subpackage provider: %w", err)
+		}
+		index[childName] = append(index[childName], providerCandidate{
+			CapabilityName: childName, CapabilityVersion: apkVersionString(version, release),
+			PackageID: packageID, PackageName: packageName, PackageVersionID: versionID, ExactName: true,
+		})
+	}
+	if err := subpackageRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate available subpackage providers: %w", err)
+	}
+	return index, nil
+}

--- a/pkg/package/dependency.go
+++ b/pkg/package/dependency.go
@@ -64,7 +64,7 @@ func ListPackageVersionRuntimeDependencies(ctx context.Context, packageVersionID
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
-	query := `select depends_on_package_name from package_version_dependency_runtime where package_version_id = $1`
+	query := `select COALESCE(dependency_spec, depends_on_package_name) from package_version_dependency_runtime where package_version_id = $1`
 	rows, err := conn.Query(ctx, query, packageVersionID)
 	if err != nil {
 		return nil, fmt.Errorf("list package version runtime dependencies: %w", err)
@@ -89,8 +89,8 @@ func SetPackageVersionRuntimeDependencyVersion(ctx context.Context, pkgVersion *
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
-	query := `update package_version_dependency_runtime set depends_on_package_version_id = $1 where package_version_id = $2 and depends_on_package_name = $3`
-	_, err := conn.Exec(ctx, query, dependsOnPackageVersion.ID, pkgVersion.ID, runtimeDep)
+	query := `update package_version_dependency_runtime set depends_on_package_version_id = $1 where package_version_id = $2 and (dependency_spec = $3 or depends_on_package_name = $4)`
+	_, err := conn.Exec(ctx, query, dependsOnPackageVersion.ID, pkgVersion.ID, runtimeDep, ParsePackageName(runtimeDep))
 	if err != nil {
 		return fmt.Errorf("update package version dependency runtime: %w", err)
 	}
@@ -262,7 +262,14 @@ func resolveDependencyPackageID(ctx context.Context, tx pgx.Tx, dep string) (str
 	// First, try to find a package by exact name
 	depPkgID, err := getPackageIDByName(ctx, tx, depName)
 	if err == nil {
-		// Found by exact name
+		// An exact dependency can name a subpackage. Rebuild its parent package.
+		pkg, getErr := GetPackageWithTx(ctx, tx, depPkgID)
+		if getErr != nil {
+			return "", fmt.Errorf("get exact dependency package: %w", getErr)
+		}
+		if pkg.ParentID != nil {
+			return *pkg.ParentID, nil
+		}
 		return depPkgID, nil
 	}
 	if err != ErrPackageNotFound {
@@ -336,7 +343,7 @@ func resolveDependencyPackageID(ctx context.Context, tx pgx.Tx, dep string) (str
 	return pkgID, nil
 }
 
-func writePackageVersionDependencies(ctx context.Context, tx pgx.Tx, packageVersion *types.PackageVersion, deps []string, depType DependencyType) error {
+func writePackageVersionDependencies(ctx context.Context, tx pgx.Tx, packageVersion *types.PackageVersion, deps []DependencySpec, depType DependencyType) error {
 	var tableName string
 
 	switch depType {
@@ -373,13 +380,11 @@ func writePackageVersionDependencies(ctx context.Context, tx pgx.Tx, packageVers
 		zap.Int(fmt.Sprintf("%s_deps", depType), len(deps)),
 		zap.Any(fmt.Sprintf("%s_deps", depType), deps))
 
-	// Deduplicate dependencies by name (e.g., "glibc=2.41-r6" and "glibc=2.42-r1" -> keep one "glibc")
-	// We use a map to track unique package names and keep the first occurrence
-	uniqueDeps := make(map[string]string) // map[packageName]originalDepString
+	// Deduplicate dependencies by normalized name and keep the first selector.
+	uniqueDeps := make(map[string]string)
 	for _, dep := range deps {
-		depName := ParsePackageName(dep)
-		if _, exists := uniqueDeps[depName]; !exists {
-			uniqueDeps[depName] = dep
+		if _, exists := uniqueDeps[dep.Name]; !exists {
+			uniqueDeps[dep.Name] = dep.Spec
 		}
 	}
 
@@ -404,8 +409,8 @@ func writePackageVersionDependencies(ctx context.Context, tx pgx.Tx, packageVers
 			return fmt.Errorf("resolve %s dependency %s: %w", depType, depName, err)
 		}
 
-		query := fmt.Sprintf(`INSERT INTO %s (package_version_id, package_name, package_version, package_apk_release, depends_on_package_id, depends_on_package_name, depends_on_package_is_external) VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (package_version_id, depends_on_package_id) DO NOTHING`, tableName)
-		_, err = tx.Exec(ctx, query, packageVersion.ID, pkgName, packageVersion.Version, packageVersion.APKRelease, depPkgID, depName, false)
+		query := fmt.Sprintf(`INSERT INTO %s (package_version_id, package_name, package_version, package_apk_release, depends_on_package_id, depends_on_package_name, dependency_spec, depends_on_package_is_external) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT (package_version_id, depends_on_package_id) DO UPDATE SET depends_on_package_name = EXCLUDED.depends_on_package_name, dependency_spec = EXCLUDED.dependency_spec, depends_on_package_is_external = EXCLUDED.depends_on_package_is_external`, tableName)
+		_, err = tx.Exec(ctx, query, packageVersion.ID, pkgName, packageVersion.Version, packageVersion.APKRelease, depPkgID, depName, originalDep, false)
 		if err != nil {
 			return fmt.Errorf("insert package version dependency %s: %w", depType, err)
 		}
@@ -414,7 +419,7 @@ func writePackageVersionDependencies(ctx context.Context, tx pgx.Tx, packageVers
 	return nil
 }
 
-func WritePackageVersionRuntimeDependencies(ctx context.Context, tx pgx.Tx, packageVersion *types.PackageVersion, runtimeDeps []string) error {
+func WritePackageVersionRuntimeDependencies(ctx context.Context, tx pgx.Tx, packageVersion *types.PackageVersion, runtimeDeps []DependencySpec) error {
 	return writePackageVersionDependencies(ctx, tx, packageVersion, runtimeDeps, DependencyTypeRuntime)
 }
 
@@ -422,8 +427,8 @@ func SetPackageVersionBuildDependencyVersion(ctx context.Context, pkgVersion *ty
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
-	query := `update package_version_dependency_buildtime set depends_on_package_version_id = $1 where package_version_id = $2 and depends_on_package_name = $3`
-	_, err := conn.Exec(ctx, query, dependsOnPackageVersion.ID, pkgVersion.ID, buildDep)
+	query := `update package_version_dependency_buildtime set depends_on_package_version_id = $1 where package_version_id = $2 and (dependency_spec = $3 or depends_on_package_name = $4)`
+	_, err := conn.Exec(ctx, query, dependsOnPackageVersion.ID, pkgVersion.ID, buildDep, ParsePackageName(buildDep))
 	if err != nil {
 		return fmt.Errorf("update package version dependency buildtime: %w", err)
 	}
@@ -435,7 +440,7 @@ func ListPackageVersionBuildDependencies(ctx context.Context, packageVersionID s
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
-	query := `select depends_on_package_name from package_version_dependency_buildtime where package_version_id = $1`
+	query := `select COALESCE(dependency_spec, depends_on_package_name) from package_version_dependency_buildtime where package_version_id = $1`
 	rows, err := conn.Query(ctx, query, packageVersionID)
 	if err != nil {
 		return nil, fmt.Errorf("list package version build dependencies: %w", err)
@@ -456,7 +461,7 @@ func ListPackageVersionBuildDependencies(ctx context.Context, packageVersionID s
 	return dependencies, nil
 }
 
-func WritePackageVersionBuildDependencies(ctx context.Context, tx pgx.Tx, packageVersion *types.PackageVersion, buildDeps []string) error {
+func WritePackageVersionBuildDependencies(ctx context.Context, tx pgx.Tx, packageVersion *types.PackageVersion, buildDeps []DependencySpec) error {
 	return writePackageVersionDependencies(ctx, tx, packageVersion, buildDeps, DependencyTypeBuild)
 }
 

--- a/pkg/package/dependency_test.go
+++ b/pkg/package/dependency_test.go
@@ -193,3 +193,72 @@ func Test_selectMatchingCandidate(t *testing.T) {
 		})
 	}
 }
+
+func TestSelectPreferredProvider(t *testing.T) {
+	candidates := []providerCandidate{
+		{
+			CapabilityName:    "go",
+			CapabilityVersion: "1.25.9-r1",
+			PackageID:         "go-1.25-id",
+			PackageName:       "go-1.25",
+			PackageVersionID:  "go-1.25-version",
+		},
+		{
+			CapabilityName:    "go",
+			CapabilityVersion: "1.26.5-r0",
+			PackageID:         "go-1.26-id",
+			PackageName:       "go-1.26",
+			PackageVersionID:  "go-1.26-version",
+		},
+	}
+
+	tests := []struct {
+		name     string
+		selector string
+		want     string
+		wantErr  bool
+	}{
+		{name: "unpinned chooses latest provider", selector: "go", want: "go-1.26"},
+		{name: "tilde pin chooses latest matching provider", selector: "go~1.25", want: "go-1.25"},
+		{name: "upper bound excludes newer provider", selector: "go<1.26", want: "go-1.25"},
+		{name: "exact pin chooses matching provider", selector: "go=1.26.5-r0", want: "go-1.26"},
+		{name: "unmatched pin returns error", selector: "go~1.24", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			selected, _, err := selectPreferredProvider(candidates, tt.selector)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, selected.PackageName)
+		})
+	}
+}
+
+func TestSelectPreferredProviderTieBreaks(t *testing.T) {
+	candidates := []providerCandidate{
+		{
+			CapabilityName:    "go",
+			CapabilityVersion: "1.26.5-r0",
+			PackageID:         "virtual-id",
+			PackageName:       "go-virtual-provider",
+			PackageVersionID:  "virtual-version",
+		},
+		{
+			CapabilityName:    "go",
+			CapabilityVersion: "1.26.5-r0",
+			PackageID:         "exact-id",
+			PackageName:       "go",
+			PackageVersionID:  "exact-version",
+			ExactName:         true,
+		},
+	}
+
+	selected, ambiguous, err := selectPreferredProvider(candidates, "go")
+	assert.NoError(t, err)
+	assert.False(t, ambiguous)
+	assert.Equal(t, "go", selected.PackageName)
+}

--- a/pkg/package/import.go
+++ b/pkg/package/import.go
@@ -18,7 +18,6 @@ import (
 	"github.com/securebuildhq/securebuild/pkg/logger"
 	"github.com/securebuildhq/securebuild/pkg/package/types"
 	"github.com/securebuildhq/securebuild/pkg/persistence"
-	"github.com/securebuildhq/securebuild/pkg/util"
 	"github.com/tuvistavie/securerandom"
 	"go.uber.org/zap"
 )
@@ -367,8 +366,8 @@ func WritePackageVersionDependencies(ctx context.Context, tx pgx.Tx, packageVers
 		return fmt.Errorf("get parents of build dependencies: %w", err)
 	}
 
-	runtimeDeps := util.Deduplicate(parentRuntimeDeps)
-	buildDeps := util.Deduplicate(parentBuildDeps)
+	runtimeDeps := deduplicateDependencySpecs(parentRuntimeDeps)
+	buildDeps := deduplicateDependencySpecs(parentBuildDeps)
 
 	logger.Debug("writing package version dependencies",
 		zap.String("package_version_id", packageVersion.ID),
@@ -399,14 +398,34 @@ func WritePackageVersionDependencies(ctx context.Context, tx pgx.Tx, packageVers
 	return nil
 }
 
-func getParentDependencies(ctx context.Context, tx pgx.Tx, depNames []string) ([]string, error) {
-	deps := []string{}
+// DependencySpec retains the complete Melange/APK selector while also recording
+// the normalized dependency name used by the existing dependency tables.
+type DependencySpec struct {
+	Name string
+	Spec string
+}
+
+func deduplicateDependencySpecs(deps []DependencySpec) []DependencySpec {
+	seen := make(map[string]struct{}, len(deps))
+	result := make([]DependencySpec, 0, len(deps))
+	for _, dep := range deps {
+		if _, ok := seen[dep.Name]; ok {
+			continue
+		}
+		seen[dep.Name] = struct{}{}
+		result = append(result, dep)
+	}
+	return result
+}
+
+func getParentDependencies(ctx context.Context, tx pgx.Tx, depNames []string) ([]DependencySpec, error) {
+	deps := make([]DependencySpec, 0, len(depNames))
 	for _, dep := range depNames {
 		depName, _, err := GetPackageInfoWithParentRedirection(ctx, tx, dep)
 		if err != nil {
 			return nil, fmt.Errorf("get package name with parent redirection: %w", err)
 		}
-		deps = append(deps, depName)
+		deps = append(deps, DependencySpec{Name: depName, Spec: dep})
 	}
 	return deps, nil
 }

--- a/pkg/package/package.go
+++ b/pkg/package/package.go
@@ -288,6 +288,11 @@ func FindPackageVersion(ctx context.Context, name string, version string, releas
 	return pv, nil
 }
 
+// ErrInvalidMelangeConfig identifies errors returned by Melange while parsing
+// or compiling a package configuration. Errors preparing the local compile
+// environment do not wrap this sentinel.
+var ErrInvalidMelangeConfig = errors.New("invalid Melange configuration")
+
 func CompileMelangeYAML(ctx context.Context, melangeYAML []byte) (*config.Configuration, error) {
 	// we need to create a tmp directory that has our embedded build filesystem
 	// b/c some of the pipelines reference external files
@@ -336,12 +341,12 @@ func CompileMelangeYAML(ctx context.Context, melangeYAML []byte) (*config.Config
 
 	b, err := build.New(ctx, buildOpts...)
 	if err != nil {
-		return nil, fmt.Errorf("create build: %w", err)
+		return nil, fmt.Errorf("%w: create build: %w", ErrInvalidMelangeConfig, err)
 	}
 	defer b.Close(ctx)
 
 	if err := b.Compile(ctx); err != nil {
-		return nil, fmt.Errorf("compile: %w", err)
+		return nil, fmt.Errorf("%w: compile: %w", ErrInvalidMelangeConfig, err)
 	}
 
 	return b.Configuration, nil

--- a/pkg/package/provides.go
+++ b/pkg/package/provides.go
@@ -17,6 +17,7 @@ import (
 type ProvidesEntry struct {
 	PackageName  string
 	ProvidesName string
+	ProvidesSpec string
 	IsSubpackage bool
 }
 
@@ -41,6 +42,7 @@ func extractProvidesFromConfig(compiled *config.Configuration) []ProvidesEntry {
 			entries = append(entries, ProvidesEntry{
 				PackageName:  compiled.Package.Name,
 				ProvidesName: parsed.Name,
+				ProvidesSpec: provides,
 				IsSubpackage: false,
 			})
 		}
@@ -54,6 +56,7 @@ func extractProvidesFromConfig(compiled *config.Configuration) []ProvidesEntry {
 				entries = append(entries, ProvidesEntry{
 					PackageName:  subpkg.Name,
 					ProvidesName: parsed.Name,
+					ProvidesSpec: provides,
 					IsSubpackage: true,
 				})
 			}
@@ -96,14 +99,15 @@ func WritePackageVersionProvides(ctx context.Context, tx pgx.Tx, packageVersion 
 
 		insertQuery := `
 			INSERT INTO package_version_provides
-			(id, package_version_id, package_name, provides_name, is_subpackage)
-			VALUES ($1, $2, $3, $4, $5)
+			(id, package_version_id, package_name, provides_name, provides_spec, is_subpackage)
+			VALUES ($1, $2, $3, $4, $5, $6)
 		`
 		_, err = tx.Exec(ctx, insertQuery,
 			id,
 			packageVersion.ID,
 			entry.PackageName,
 			entry.ProvidesName,
+			entry.ProvidesSpec,
 			entry.IsSubpackage,
 		)
 		if err != nil {

--- a/pkg/package/selector_migration.go
+++ b/pkg/package/selector_migration.go
@@ -1,0 +1,155 @@
+package sbpackage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/securebuildhq/securebuild/pkg/logger"
+	"github.com/securebuildhq/securebuild/pkg/persistence"
+	"go.uber.org/zap"
+)
+
+type SelectorMigrationOptions struct {
+	DryRun bool
+}
+
+type SelectorMigrationResult struct {
+	PackageVersions int
+	DependencyRows  int64
+	ProvidesRows    int64
+	Unmatched       int
+	Failed          int
+}
+
+// BackfillPackageSelectors reconstructs dependency_spec and provides_spec from
+// the immutable Melange YAML stored on top-level package versions with missing
+// selector data. Work is committed per version, so reruns skip completed rows.
+func BackfillPackageSelectors(ctx context.Context, opts SelectorMigrationOptions) (SelectorMigrationResult, error) {
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx, `
+		SELECT pv.id, pv.melange_yaml
+		FROM package_version pv
+		JOIN package p ON p.id = pv.package_id
+		WHERE p.parent_id IS NULL
+		  AND pv.melange_yaml IS NOT NULL
+		  AND pv.melange_yaml != ''
+		  AND (
+			EXISTS (SELECT 1 FROM package_version_dependency_runtime d WHERE d.package_version_id = pv.id AND COALESCE(d.dependency_spec, '') = '')
+			OR EXISTS (SELECT 1 FROM package_version_dependency_buildtime d WHERE d.package_version_id = pv.id AND COALESCE(d.dependency_spec, '') = '')
+			OR EXISTS (SELECT 1 FROM package_version_provides pr WHERE pr.package_version_id = pv.id AND COALESCE(pr.provides_spec, '') = '')
+		  )
+		ORDER BY pv.created_at, pv.id
+	`)
+	if err != nil {
+		return SelectorMigrationResult{}, fmt.Errorf("list package versions for selector migration: %w", err)
+	}
+	defer rows.Close()
+
+	type migrationCandidate struct{ id, yaml string }
+	var candidates []migrationCandidate
+	for rows.Next() {
+		var candidate migrationCandidate
+		if err := rows.Scan(&candidate.id, &candidate.yaml); err != nil {
+			return SelectorMigrationResult{}, fmt.Errorf("scan selector migration candidate: %w", err)
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return SelectorMigrationResult{}, fmt.Errorf("iterate selector migration candidates: %w", err)
+	}
+	rows.Close()
+
+	result := SelectorMigrationResult{}
+	for _, candidate := range candidates {
+		result.PackageVersions++
+		compiled, err := CompileMelangeYAML(ctx, []byte(candidate.yaml))
+		if err != nil {
+			result.Failed++
+			if errors.Is(err, ErrInvalidMelangeConfig) && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+				logger.Warn("skipping package version with invalid Melange configuration during selector migration",
+					zap.String("packageVersionId", candidate.id), zap.Error(err))
+				continue
+			}
+			return result, fmt.Errorf("prepare package version %s for selector migration: %w", candidate.id, err)
+		}
+		if opts.DryRun {
+			result.DependencyRows += int64(len(compiled.Package.Dependencies.Runtime) + len(compiled.Environment.Contents.Packages))
+			result.ProvidesRows += int64(len(extractProvidesFromConfig(compiled)))
+			continue
+		}
+
+		tx, err := conn.Begin(ctx)
+		if err != nil {
+			return result, fmt.Errorf("begin selector migration transaction: %w", err)
+		}
+		var migrationErr error
+		var dependencyRows, providesRows int64
+		for table, specs := range map[string][]string{
+			"package_version_dependency_runtime":   compiled.Package.Dependencies.Runtime,
+			"package_version_dependency_buildtime": compiled.Environment.Contents.Packages,
+		} {
+			for _, spec := range specs {
+				name, _, resolveErr := GetPackageInfoWithParentRedirection(ctx, tx, spec)
+				if resolveErr != nil {
+					migrationErr = resolveErr
+					break
+				}
+				command := fmt.Sprintf(`UPDATE %s SET dependency_spec = $1 WHERE package_version_id = $2 AND depends_on_package_name = $3 AND COALESCE(dependency_spec, '') = ''`, table)
+				tag, updateErr := tx.Exec(ctx, command, spec, candidate.id, name)
+				if updateErr != nil {
+					migrationErr = updateErr
+					break
+				}
+				if tag.RowsAffected() > 0 {
+					dependencyRows += tag.RowsAffected()
+				}
+			}
+			if migrationErr != nil {
+				break
+			}
+		}
+		if migrationErr == nil {
+			for _, entry := range extractProvidesFromConfig(compiled) {
+				tag, updateErr := tx.Exec(ctx, `
+					UPDATE package_version_provides
+					SET provides_spec = $1
+					WHERE package_version_id = $2 AND package_name = $3 AND provides_name = $4
+					  AND COALESCE(provides_spec, '') = ''
+				`, entry.ProvidesSpec, candidate.id, entry.PackageName, entry.ProvidesName)
+				if updateErr != nil {
+					migrationErr = updateErr
+					break
+				}
+				if tag.RowsAffected() > 0 {
+					providesRows += tag.RowsAffected()
+				}
+			}
+		}
+		if migrationErr != nil {
+			_ = tx.Rollback(ctx)
+			result.Failed++
+			return result, fmt.Errorf("backfill selectors for package version %s: %w", candidate.id, migrationErr)
+		}
+		var remainingMissing int
+		if err := tx.QueryRow(ctx, `
+			SELECT
+				(SELECT count(*) FROM package_version_dependency_runtime WHERE package_version_id = $1 AND COALESCE(dependency_spec, '') = '') +
+				(SELECT count(*) FROM package_version_dependency_buildtime WHERE package_version_id = $1 AND COALESCE(dependency_spec, '') = '') +
+				(SELECT count(*) FROM package_version_provides WHERE package_version_id = $1 AND COALESCE(provides_spec, '') = '')
+		`, candidate.id).Scan(&remainingMissing); err != nil {
+			_ = tx.Rollback(ctx)
+			result.Failed++
+			return result, fmt.Errorf("count remaining selectors for package version %s: %w", candidate.id, err)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return result, fmt.Errorf("commit selector migration for %s: %w", candidate.id, err)
+		}
+		result.DependencyRows += dependencyRows
+		result.ProvidesRows += providesRows
+		result.Unmatched += remainingMissing
+	}
+	return result, nil
+}

--- a/pkg/package/types/types.go
+++ b/pkg/package/types/types.go
@@ -123,5 +123,6 @@ type PackageVersionProvides struct {
 	PackageVersionID string `json:"packageVersionId"`
 	PackageName      string `json:"packageName"`
 	ProvidesName     string `json:"providesName"`
+	ProvidesSpec     string `json:"providesSpec"`
 	IsSubpackage     bool   `json:"isSubpackage"`
 }

--- a/proposals/canonical-package-names-in-rebuild-chains.md
+++ b/proposals/canonical-package-names-in-rebuild-chains.md
@@ -1,0 +1,458 @@
+# Proposal: Constraint-Aware Provider Selection in Rebuild Chains
+
+Research: [canonical-package-names-in-rebuild-chains_research.md](canonical-package-names-in-rebuild-chains_research.md)
+
+## TL;DR
+
+Preserve complete dependency and `provides` selectors in the database, then calculate each active consumer’s preferred concrete provider whenever a rebuild chain is created. An unpinned selector such as `go` maps only to the latest available Go provider; a pinned selector such as `go~1.25` maps only to the latest available provider satisfying that constraint. The reverse graph uses the selected provider’s canonical package name, so updates rebuild exactly the consumers that APKO/Melange are expected to resolve to that provider. This replaces the proposed static use of `depends_on_package_id`, which can become stale as new providers are added.
+
+## The problem
+
+Multiple concrete packages can provide the same virtual package:
+
+```text
+go-1.25 --provides--> go
+go-1.26 --provides--> go
+```
+
+Consumers can express different intent:
+
+```text
+schemahero-0.25: go          # unpinned
+consumer-a:       go~1.25    # compatible-version pin
+consumer-b:       go=1.26.5  # exact pin
+```
+
+Automatic rebuild chains must follow two selection rules:
+
+1. An unpinned consumer rebuilds only for the latest available provider version.
+2. A pinned consumer rebuilds only for the latest available provider version satisfying its pin.
+
+The current system cannot reliably enforce these rules:
+
+- dependency ingestion strips version operators and versions before persistence;
+- `provides` ingestion strips provided capability versions;
+- the stored provider package ID is selected only when the consumer metadata is written and can become stale;
+- the rebuild graph keys edges by the requested virtual name, while chains start from concrete package names;
+- dependency rows from historical consumer versions are unioned into the graph.
+
+The original SchemaHero incident is one manifestation: its `go` edge was not reachable from `go-1.26`. Simply changing that edge to use the stored `go-1.26` ID fixes the incident but fails once a newer Go provider becomes preferred.
+
+## Prototype / design
+
+### Persist selectors without losing intent
+
+Store the compiled selector strings alongside the existing parsed names:
+
+```text
+dependency_spec = "go~1.25"
+depends_on_package_name = "go"
+
+provides_spec = "go=1.25.7-r0"
+provides_name = "go"
+```
+
+The full string is necessary because APKO’s public `ParsedConstraint` exposes the name and version but not a serializable public operator. Retaining the exact compiled selector also protects compatibility with parser behavior.
+
+### Build a provider index
+
+At graph construction time, load eligible provider capabilities from:
+
+1. Concrete package names, treated as implicit capabilities at the package version.
+2. `package_version_provides`, using the persisted provided capability selector/version.
+
+Normalize subpackage providers to the parent package that must be rebuilt, while retaining the subpackage capability version for constraint evaluation.
+
+Provider eligibility is limited to:
+
+- package versions with a successful build; and
+- the root package version named by the current `build_package_chain` event.
+
+This approximates the repository visible to builders after the root link succeeds. The implementation spike must verify that successful execution is an accurate publication signal.
+
+### Select one preferred provider per active dependency
+
+For each dependency in the latest package version of each top-level consumer:
+
+1. Parse `dependency_spec` with `ResolvePackageNameVersionPin`.
+2. Find eligible concrete-name and virtual-provider candidates for the parsed name.
+3. Discard candidates whose capability version does not satisfy the selector.
+4. Sort by APK version semantics, then APK release.
+5. Select exactly one preferred concrete provider package.
+6. Add `selected provider canonical name -> consumer canonical name` to the reverse graph.
+
+Tie-breaking for candidates with identical capability version and release must be deterministic. The implementation should first reproduce repository priority if that information is available. If it is not represented in the database, prefer an exact package-name candidate and then canonical package name as a stable final tie-breaker, and emit a warning for the ambiguity.
+
+### Resulting behavior
+
+Assume the latest available providers are `go-1.25@1.25.9` and `go-1.26@1.26.5`:
+
+| Consumer selector | Selected provider | Rebuilt for `go-1.25` | Rebuilt for `go-1.26` |
+|---|---|---:|---:|
+| `go` | `go-1.26` | no | yes |
+| `go~1.25` | `go-1.25` | yes | no |
+| `go=1.26.5` | `go-1.26` | no | yes |
+| `go<1.26` | `go-1.25` | yes | no |
+
+When `go-1.27` becomes the latest available provider, an unpinned consumer moves to `go-1.27` without needing to be re-imported first. A `go~1.26` consumer remains attached to `go-1.26`.
+
+```text
+active consumer dependency specs
+              |
+              v
+constraint-aware provider selection <--- eligible concrete/provided capabilities
+              |
+              v
+selected concrete provider -> consumer edges
+              |
+              v
+BuildDAG(root concrete package) -> rebuild_chain links
+```
+
+## New Subagents / Commands
+
+No new development subagents will be created.
+
+A one-time CLI migration command will be added to backfill dependency and `provides` selectors from stored Melange YAML. This is an operational command, not an agent command.
+
+## Database
+
+Add the complete selector to each dependency table and the complete provided capability selector to `package_version_provides`.
+
+The first deployment keeps these columns nullable for compatibility during backfill.
+
+```yaml
+database: securebuild
+name: package_version_dependency_buildtime
+schema:
+  postgres:
+    columns:
+      - name: dependency_spec
+        type: text
+        constraints:
+          notNull: false
+```
+
+```yaml
+database: securebuild
+name: package_version_dependency_runtime
+schema:
+  postgres:
+    columns:
+      - name: dependency_spec
+        type: text
+        constraints:
+          notNull: false
+```
+
+```yaml
+database: securebuild
+name: package_version_provides
+schema:
+  postgres:
+    columns:
+      - name: provides_spec
+        type: text
+        constraints:
+          notNull: false
+```
+
+No new index is required for the first version. Provider selection will load candidates in bounded queries and group them in Go; existing primary-key and `package_version_provides` indexes support the joins. Query plans and row counts must be recorded before rollout.
+
+After all writers are upgraded and backfill validation reports no missing selectors for valid Melange specs, a later schema checkpoint may make the new columns non-null. That hardening is deliberately separate so rollback remains safe during adoption.
+
+The existing columns remain:
+
+- `depends_on_package_name` and `provides_name` support indexed/grouped lookup.
+- `depends_on_package_id` remains the provider selected when the row was written and can be used for diagnostics, but not as the source of truth for future graph selection.
+- `depends_on_package_version_id` remains build-observation metadata and is not used to decide future rebuild eligibility.
+
+## Implementation plan
+
+### Selector persistence
+
+Modify `pkg/package/import.go`:
+
+- Replace the string-only parent-dependency transformation with a structured value containing the original compiled selector, parsed name, and any parent-build normalization.
+- Do not discard the version operator or version before writing dependencies.
+
+Modify `pkg/package/dependency.go`:
+
+- Accept structured dependency selectors in the runtime and build-time writers.
+- Populate `dependency_spec` and the existing parsed-name/provider fields.
+- Keep APKO’s parser as the constraint authority.
+
+Modify `pkg/package/provides.go`:
+
+- Extend `ProvidesEntry` with the full compiled selector.
+- Populate `provides_spec` while retaining `provides_name`.
+
+Modify the three SchemaHero table definitions:
+
+- `db/schema/tables/package-version-dependency-buildtime.yaml`
+- `db/schema/tables/package-version-dependency-runtime.yaml`
+- `db/schema/tables/package-version-provides.yaml`
+
+### Constraint-aware graph construction
+
+Modify `pkg/package/dependency.go`:
+
+- Replace static adjacency construction with a function that accepts the root package-version ID.
+- Select only the latest package version for each dependent package.
+- Load dependency selectors for those active versions.
+- Load eligible concrete and virtual provider candidates.
+- Resolve every dependency selector to one preferred concrete parent package.
+- Deduplicate the resulting provider-to-consumer edges.
+- Return diagnostics for unresolved and ambiguous selectors.
+
+Modify `pkg/listener/build-package-chain.go`:
+
+- Pass the root package-version ID into graph construction.
+- Log counts for unpinned selections, pinned selections, unresolved selectors, ambiguous ties, and selected-provider changes from the stored provider ID.
+- Preserve the existing root-only fallback only when there are genuinely no selected dependents.
+
+No changes are expected in `pkg/buildgraph/build_ordering.go`, `pkg/package/rebuild_chain.go`, or `pkg/buildqueue/buildqueue.go`; they continue operating on concrete package names.
+
+### Build-observation metadata
+
+Modify `pkg/listener/update-build-package-status.go`:
+
+- Stop assuming every dependency has an exact package row with the requested name.
+- Resolve virtual dependencies through the shared provider-selection helper when recording `depends_on_package_version_id`, or use the builder’s resolved package output if available.
+- Treat this field as observed metadata, not future graph policy.
+
+### Backfill command
+
+Add a migration function in `pkg/package` and a CLI entry under `cmd/cli`:
+
+- Select package versions that still have missing selector data.
+- Compile each stored Melange YAML.
+- Re-extract runtime dependencies, build-time dependencies, and provides.
+- Match and populate new selector columns transactionally per package version.
+- Report malformed YAML, unmatched rows, and progress.
+- Support dry-run; reruns naturally skip selector rows already populated.
+
+Do not enqueue builds or mutate package versions during backfill.
+
+### Pseudocode
+
+```text
+function BuildConstraintAwareDependencyMap(rootPackageVersionID):
+    activeConsumers = latest package version for every top-level package
+    dependencies = selectors belonging to activeConsumers
+
+    eligibleProviderVersions = successful package versions
+    eligibleProviderVersions += rootPackageVersionID
+
+    providerIndex = index concrete names and provides specs
+
+    graph = empty map
+    diagnostics = empty counters
+
+    for dependency in dependencies:
+        selector = parse(dependency.dependency_spec)
+        candidates = providerIndex[selector.name]
+        matching = candidates satisfying selector
+
+        if matching is empty:
+            record unresolved selector
+            continue
+
+        selected = highest capability version and APK release
+        selected = deterministic tie-break(selected)
+        provider = selected parent build package
+        graph[provider.name].add(dependency.consumer.name)
+
+    return graph, diagnostics
+```
+
+### APIs, events, and toggles
+
+- No public API or Swagger/OpenAPI changes.
+- The `build_package_chain` event schema is unchanged; it already carries the root package-version ID required for selection.
+- No entitlement change.
+- The worker always uses the constraint-aware graph. If an active dependency is
+  missing its persisted selector, chain creation fails closed and instructs the
+  operator to run the selector migration rather than treating a former pin as
+  unpinned.
+
+## Testing
+
+### Unit tests
+
+Extend `pkg/package/dependency_test.go` with table-driven cases for:
+
+- unpinned selection across `go-1.25` and `go-1.26`;
+- compatible, exact, lower-bound, and upper-bound constraints;
+- selection using provided capability version rather than owning package version;
+- semantic version and APK release ordering;
+- exact-name and virtual candidates in one candidate set;
+- deterministic equal-version ties;
+- subpackage-to-parent normalization;
+- unavailable candidates;
+- inclusion of the pending root version;
+- unresolved and malformed selectors.
+
+Add import/provides extraction tests proving that operators and versions survive persistence preparation.
+
+### Integration tests
+
+Use database-backed fixtures with:
+
+- two concrete Go providers that both provide `go`;
+- successful versions for both providers;
+- one newer pending root version;
+- unpinned and pinned consumers;
+- an older consumer spec with a different pin;
+- build-time and runtime dependencies;
+- a subpackage provider;
+- a failed/unpublished provider version.
+
+Assert that:
+
+1. An unpinned consumer appears only under the latest eligible provider.
+2. A pinned consumer appears only under the latest eligible provider satisfying the pin.
+3. A newer provider causes unpinned selection to move without rewriting the consumer row.
+4. Historical consumer constraints do not add stale edges.
+5. Failed or unpublished provider versions are ignored.
+6. The pending root version participates in selection.
+7. Persisted rebuild-chain links and dependencies match the selected graph.
+8. Runtime and build-time dependencies follow identical selection rules.
+
+### Migration tests
+
+- Dry-run performs no writes.
+- Re-running a completed migration is idempotent.
+- Mixed old/new rows are handled safely.
+- Malformed Melange YAML is reported without losing progress.
+- Exact, compatible, and unpinned selectors are recovered correctly.
+- Provides templates compile to concrete persisted selectors.
+
+### Performance and compatibility tests
+
+- Benchmark provider indexing and selection using production-scale row counts.
+- Record SQL `EXPLAIN (ANALYZE, BUFFERS)` output for active dependencies and eligible providers.
+- Compare pre-migration and constraint-aware graph fixtures, grouped by reason for each difference.
+- Run all package, listener, buildgraph, and affected worker integration suites.
+
+No browser end-to-end test is required because this is an internal event-driven workflow.
+
+## Backward compatibility
+
+The schema rollout is additive. Old binaries ignore nullable selector columns; new writers populate them.
+
+The new graph reader remains available while backfill is in progress:
+
+- missing `dependency_spec` is counted, logged, and temporarily treated as an unpinned request for the stored dependency name;
+- missing `provides_spec` may temporarily use the owning package version, matching current behavior;
+- new writes populate both selectors immediately.
+
+The compatibility fallback cannot recover a historical version constraint, so operators should run the selector migration promptly after deployment.
+
+The `build_package_chain` payload, rebuild-chain tables, and build queue contracts do not change.
+
+Behavior changes intentionally when enforcement begins:
+
+- unpinned consumers stop rebuilding for older providers;
+- pinned consumers rebuild only for the preferred matching provider;
+- consumers no longer inherit edges from historical Melange specs;
+- provider preference can move when a newer eligible provider becomes available.
+
+## Migrations
+
+### Forward plan
+
+1. Add nullable selector columns.
+2. Deploy dual-writing dependency/provides ingestion and the backfill command.
+3. Run the backfill in dry-run mode and review malformed or ambiguous records.
+4. Run the backfill; rerun it after correcting any reported failure.
+5. Validate selector coverage and compare reconstructed selectors with stored parsed names.
+6. Deploy the constraint-aware graph and monitor selection diagnostics.
+7. Resolve unexpected selections and verify repository-availability assumptions.
+9. Optionally make selector columns non-null in a later schema change.
+
+### Rollback plan
+
+- Roll back application code normally; additive nullable columns and backfilled data remain harmless.
+- Backfill only adds selector values reconstructed from immutable Melange YAML; no reverse data migration is needed.
+- Rebuild chains already persisted should be allowed to complete because graph mode is evaluated at chain creation.
+
+### Operational verification
+
+- Track unresolved selectors, ambiguous provider ties, missing selector columns, and provider changes from stored IDs.
+- For representative Go updates, inspect the logged provider choice for unpinned and pinned consumers.
+- Query `rebuild_chain_link` and `rebuild_chain_dependency` to confirm selected consumers are attached to the expected concrete provider.
+- Catch up the original missed SchemaHero rebuild explicitly after enforcement; existing completed chains are not rewritten.
+
+## Trade-offs
+
+This design optimizes for rebuild behavior that follows dependency intent as the provider set evolves.
+
+- Dynamic selection is more expensive than reading a stored provider ID, but it avoids stale provider assignments.
+- Persisting full selectors duplicates information present in Melange YAML, but avoids recompiling every package spec during each graph build and preserves parser-ready intent.
+- Restricting consumers to their latest package version removes stale edges and matches the version used for a new release, but changes the graph from historical union semantics.
+- Using successful execution as repository availability is practical but must be validated against actual publication behavior.
+- Exact parity with APKO repository priority may require additional repository metadata. Ambiguous equal-version candidates are surfaced rather than silently hidden.
+- The phased rollout is larger than a query-only correction, but it is reversible and supports production comparison before behavior changes.
+
+## Alternative solutions considered
+
+### Use the stored `depends_on_package_id`
+
+Rejected as the final design. It fixes virtual-to-concrete naming for the provider selected at import time but becomes stale when a newer provider appears. It cannot implement automatic movement of unpinned consumers.
+
+### Re-resolve from `depends_on_package_name` only
+
+Rejected because the current column cannot distinguish `go`, `go~1.25`, and `go=1.26.5`. Pinned and unpinned consumers would be treated identically.
+
+### Compile every Melange YAML during every graph build
+
+This avoids schema changes but makes a frequent operational path CPU-heavy and vulnerable to one malformed historical spec. It also requires repeatedly extracting `provides`. Rejected in favor of compiling once at write/backfill time.
+
+### Update all stored provider IDs whenever a provider changes
+
+Viable, but it introduces a global fan-out mutation for every new provider version and still requires persisted constraints. Dynamic graph selection is easier to audit and avoids synchronization races between provider updates and chain creation.
+
+### Delegate selection entirely to builders and rebuild every possible consumer
+
+Rejected because it would rebuild unpinned consumers for every older provider and pinned consumers for providers they cannot use, violating both required rules and creating unnecessary work.
+
+### Refactor the DAG to package IDs
+
+Package-ID nodes would remove name identity ambiguity after provider selection, but they do not solve constraint-aware selection itself. This can be considered separately after the selection model is correct.
+
+## Research
+
+Detailed findings are documented in [canonical-package-names-in-rebuild-chains_research.md](canonical-package-names-in-rebuild-chains_research.md).
+
+Codebase foundations reused by this proposal:
+
+- APKO `ResolvePackageNameVersionPin` and `ParsedConstraint.SatisfiedBy` already implement supported constraint semantics.
+- `selectMatchingCandidate` already expresses semantic-version and APK-release preference.
+- `resolvePackageIDFromCandidate` already normalizes subpackage providers to parent packages.
+- `GetLatestPackageVersion` already identifies the consumer version used as the basis for new releases.
+- the chain event already includes the pending root package-version ID.
+
+No external reference is required for the core design. The applicable resolver semantics are supplied by the APKO library already used by the repository.
+
+## Checkpoints (PR plan)
+
+Use multiple PRs so persistence, migration, observation, and enforcement remain independently reviewable and reversible.
+
+1. **Selector persistence**
+   - Add nullable SchemaHero columns.
+   - Preserve full dependency and provides selectors in new writes.
+   - Add extraction and writer tests.
+
+2. **Backfill tooling**
+   - Add rerunnable dry-run/backfill command for missing selectors.
+   - Add migration tests and validation queries.
+
+3. **Constraint-aware resolver**
+   - Add active-consumer and eligible-provider loading.
+   - Add provider selection, diagnostics, unit tests, and integration fixtures.
+   - Fail closed when active dependency selectors have not been migrated.
+   - Add chain-level regression coverage and operational verification.
+
+4. **Optional schema hardening**
+   - Make selector columns non-null after every supported writer and row is verified.

--- a/proposals/canonical-package-names-in-rebuild-chains_research.md
+++ b/proposals/canonical-package-names-in-rebuild-chains_research.md
@@ -1,0 +1,176 @@
+# Research: Constraint-Aware Provider Selection for Rebuild Chains
+
+## Question
+
+When several packages provide the same virtual package name, which consumers should be included in an automatic rebuild chain?
+
+The required rules are:
+
+1. An unpinned dependency is assigned to the latest available provider version.
+2. A pinned dependency is assigned to the latest available provider version satisfying the pin.
+3. A consumer is rebuilt only when the updated concrete package is the selected provider under those rules.
+
+For example, both `go-1.25` and `go-1.26` can provide `go`. An unpinned `go` dependency belongs in the `go-1.26` chain when `go-1.26` is the latest provider. A `go~1.25` dependency belongs in the `go-1.25` chain even while `go-1.26` exists.
+
+## Confirmed production evidence
+
+The current rows for `schemahero-0.25` contain:
+
+| package | version | release | stored dependency name | stored resolved package |
+|---|---:|---:|---|---|
+| `schemahero-0.25` | `0.25.1` | `2` | `go` | `go-1.26` |
+| `schemahero-0.25` | `0.25.1` | `1` | `go` | `go-1.26` |
+| `schemahero-0.25` | `0.25.0` | `0` | `go` | `go-1.26` |
+
+These rows show that `go-1.26` was the selected provider when the dependency metadata was written. They do not, by themselves, prove that `go-1.26` must remain the selected provider after the provider set changes.
+
+## Current dependency ingestion
+
+Package import compiles the Melange YAML and obtains runtime and build-time dependency strings. Before writing them, `getParentDependencies` calls `GetPackageInfoWithParentRedirection`. That function calls `ParsePackageName`, which uses APKO’s `ResolvePackageNameVersionPin` and returns only `ParsedConstraint.Name`.
+
+As a result:
+
+```text
+go          -> go
+go~1.25     -> go
+go=1.25.7-r0 -> go
+```
+
+The operator and version are lost before `WritePackageVersionBuildDependencies` or `WritePackageVersionRuntimeDependencies` runs.
+
+The dependency tables currently store:
+
+- the unversioned requested name;
+- the concrete provider package ID selected during import;
+- optionally, a concrete provider package-version ID recorded after a successful build.
+
+They do not store the original dependency selector. Therefore existing rows cannot distinguish an unpinned dependency from an exact, compatible, lower-bound, or upper-bound constraint.
+
+Relevant files:
+
+- `pkg/package/import.go`
+- `pkg/package/dependency.go`
+- `db/schema/tables/package-version-dependency-buildtime.yaml`
+- `db/schema/tables/package-version-dependency-runtime.yaml`
+
+## Current provides ingestion
+
+`ExtractProvidesFromMelangeYAML` parses each `provides` entry but retains only `ParsedConstraint.Name`. `package_version_provides` consequently records that a package provides `go`, but not the version it provides.
+
+For the common declaration:
+
+```yaml
+provides:
+  - go=${{package.full-version}}
+```
+
+the compiled selector contains the capability version used by the APK solver, but the database drops it. Existing provider selection compensates by comparing the owning package version. That works when the provided version equals the package version, but it is not a general representation of APK `provides` semantics.
+
+Relevant files:
+
+- `pkg/package/provides.go`
+- `db/schema/tables/package-version-provides.yaml`
+
+## Current provider selection
+
+`resolveDependencyPackageID` performs provider selection while writing dependency rows:
+
+1. Prefer a package whose concrete name exactly matches the dependency name.
+2. Otherwise, find all package versions with a matching `package_version_provides.provides_name`.
+3. Sort candidates by semantic version and APK release.
+4. For an unpinned selector, choose the latest candidate.
+5. For a pinned selector, choose the latest candidate satisfying APKO’s `ParsedConstraint.SatisfiedBy`.
+6. Normalize subpackage candidates to their parent package ID.
+
+The selection algorithm largely expresses the requested rules, but it runs only when dependency metadata is written. Its result is a snapshot. If a newer provider package is introduced later, old consumer rows remain attached to the former provider until those consumers are imported or rebuilt again.
+
+There are two additional fidelity gaps:
+
+- Exact-name packages are preferred before comparing their versions with virtual providers. That may differ from repository solver behavior when both forms are candidates.
+- Virtual-provider pins are evaluated against the owning package version because the provided capability version is not stored.
+
+## Current rebuild graph
+
+Patch updates enqueue `build_package_chain` using a concrete root package ID and package-version ID. The handler loads the root’s concrete name and calls `GetPackageDependencyMap`.
+
+`GetPackageDependencyMap` reads dependency rows for all historical package versions and creates edges keyed by `depends_on_package_name`:
+
+```text
+requested dependency name -> dependent package name
+```
+
+For SchemaHero this produces:
+
+```text
+go -> schemahero-0.25
+```
+
+The chain starts at:
+
+```text
+go-1.26
+```
+
+The names do not match, so SchemaHero is omitted. Keying the edge by the stored resolved package ID would fix this individual incident, but it would not implement the required rules after a newer provider appears. The stored ID may then be stale.
+
+Relevant files:
+
+- `pkg/listener/package-family-update-check.go`
+- `pkg/listener/build-package-chain.go`
+- `pkg/package/dependency.go`
+- `pkg/buildgraph/build_ordering.go`
+- `pkg/package/rebuild_chain.go`
+
+## Active versus historical consumer specifications
+
+The graph query currently unions dependencies from every package version. This can violate constraint-aware selection even after selectors are preserved. For example:
+
+```text
+old SchemaHero spec: go~1.25
+new SchemaHero spec: go~1.26
+```
+
+If both rows contribute edges, SchemaHero is rebuilt from both Go chains even though only the latest SchemaHero spec will be copied into the new release. Rebuild eligibility must be calculated from the active package version—the version that `CreateNewReleaseForLatestPackageVersion` would use—not from the union of historical specs.
+
+The existing `GetLatestPackageVersion` logic selects the highest semantic version and then the highest APK release. That is the appropriate starting definition of the active consumer spec because rebuild-chain execution creates the next release from that latest version.
+
+## Available versus merely recorded provider versions
+
+APKO and Melange resolve dependencies from repository contents. A package-version row can exist before a successful build publishes it, so “latest database row” is not necessarily “latest available provider.”
+
+For chain construction, provider candidates should be:
+
+- successfully built package versions already available to builders; plus
+- the root package version that the current chain is about to build.
+
+Including the root version lets the graph model the repository state expected after the root link succeeds. Excluding other failed or never-built versions avoids assigning consumers to artifacts that builders cannot select.
+
+The `execution` table records successful package builds. Exact publication parity should be verified because execution success is being used as the database proxy for repository availability.
+
+## Build-completion metadata
+
+After a successful consumer build, `update-build-package-status.go` attempts to populate `depends_on_package_version_id`. It looks up dependencies by exact package name. A virtual dependency such as `go` has no package row named `go`, so this path does not reliably record the provider version actually selected by the builder.
+
+Constraint-aware graph construction should not depend on this field. Separately, the field should be updated using the same provider-selection model or, preferably, actual build output if the builder exposes the resolved APK set.
+
+## Existing test coverage and gaps
+
+- `pkg/package/dependency_test.go` covers candidate ordering and APKO constraint satisfaction in isolation.
+- `pkg/buildgraph/build_ordering_test.go` covers traversal and cycles after an adjacency map has been built.
+- The package-family integration suite checks that patch versions enqueue a chain message, but not which links are created.
+- The build-queue integration suite starts from pre-created links.
+
+Missing coverage includes:
+
+- preserving dependency selectors during import;
+- preserving provided capability versions;
+- choosing between multiple providers of one virtual name;
+- re-evaluating the preferred provider after a newer provider appears;
+- separating unpinned and pinned consumers;
+- excluding historical consumer constraints;
+- excluding unavailable provider versions;
+- persisting the resulting concrete-provider chain links.
+
+## Conclusion
+
+The initial canonical-name query correction is insufficient. Correct rebuild eligibility requires the same information used by package resolution: the complete consumer selector, the provided capability version, the current set of available providers, and the active consumer spec. The graph must select a preferred provider dynamically and attach the consumer only to that concrete provider’s node.

--- a/securebuild-app/lib/package/provides.ts
+++ b/securebuild-app/lib/package/provides.ts
@@ -9,6 +9,7 @@ import { getPipelineDirectory } from '@/lib/pipeline/directory';
 interface ProvidesEntry {
   packageName: string;
   providesName: string;
+  providesSpec: string;
   isSubpackage: boolean;
 }
 
@@ -61,8 +62,7 @@ export async function compileMelangeYAML(melangeYaml: string): Promise<MelangeCo
  * Parse package name from provides string (e.g., "kotsadm=1.127.1-r7" -> "kotsadm")
  */
 function parsePackageName(provides: string): string {
-  const parts = provides.split('=');
-  return parts[0];
+  return provides.match(/^([^@=><~]+)/)?.[1] ?? provides;
 }
 
 /**
@@ -78,6 +78,7 @@ function extractProvidesFromConfig(compiled: MelangeConfig): ProvidesEntry[] {
       entries.push({
         packageName: compiled.package.name,
         providesName,
+        providesSpec: provides,
         isSubpackage: false,
       });
     }
@@ -92,6 +93,7 @@ function extractProvidesFromConfig(compiled: MelangeConfig): ProvidesEntry[] {
           entries.push({
             packageName: subpkg.name,
             providesName,
+            providesSpec: provides,
             isSubpackage: true,
           });
         }
@@ -138,10 +140,10 @@ export async function writePackageVersionProvides(
       await client.query(
         `
         INSERT INTO package_version_provides
-        (id, package_version_id, package_name, provides_name, is_subpackage)
-        VALUES ($1, $2, $3, $4, $5)
+        (id, package_version_id, package_name, provides_name, provides_spec, is_subpackage)
+        VALUES ($1, $2, $3, $4, $5, $6)
       `,
-        [id, packageVersionId, entry.packageName, entry.providesName, entry.isSubpackage]
+        [id, packageVersionId, entry.packageName, entry.providesName, entry.providesSpec, entry.isSubpackage]
       );
     }
   } catch (error) {


### PR DESCRIPTION
## Summary

Fix automatic rebuild chains for dependencies that use virtual package names such as `go`.

- Preserve complete Melange dependency and `provides` selectors.
- Resolve unpinned selectors to the latest provider and pinned selectors to the latest matching provider.
- Use the constraint-aware dependency graph for worker rebuild chains.
- Add an unattended migration for selectors stored before this change.

## Migration

```sh
worker migrate-package-selectors
```

## Validation

Verified locally that an automatic `go-1.26` update created a rebuild chain containing for a package that uses `go` as a dependency and queued its rebuild.
