### PR TITLE
Pre-load grype db on builders when grype is installed

### DIFF
--- a/pkg/builder/pool.go
+++ b/pkg/builder/pool.go
@@ -1321,6 +1321,8 @@ echo "Installing grype..."
 curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sudo sh -s -- -b /usr/local/bin
 echo "Checking grype version..."
 grype version
+echo "Downloading grype vulnerability database..."
+grype db update
 `
 
 	stdoutCh := make(chan string)


### PR DESCRIPTION
Seeing errors like this:

> Aug 14 16:24:40 securebuild-01 securebuild-worker[1918743]: [0115]  WARN error updating db error=unable to update vulnerability database: unable to download db: write /home/builder/.cache/grype/db/grype-db-download4041956587/vulnerability.db: no space left on device

When multiple scans run at the same time, they all try to update the database at the same time, causing the VM to run out of disk space. So instead we initialize it one time, when VM is created.