### PR TITLE
Add package name template when creating linked package family

### DIFF
--- a/pkg/listener/package-family-update-check.go
+++ b/pkg/listener/package-family-update-check.go
@@ -702,14 +702,7 @@ func getExistingGitTagsForFamily(ctx context.Context, pf *package_family.Package
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
-	tmpl := "{name}-{major}.{minor}"
-	if pf.PackageNameTemplate != "" {
-		tmpl = pf.PackageNameTemplate
-	}
-	tmpl = strings.ReplaceAll(tmpl, "{name}", regexp.QuoteMeta(pf.Name))
-	tmpl = strings.ReplaceAll(tmpl, "{major}", "[0-9]+")
-	tmpl = strings.ReplaceAll(tmpl, "{minor}", "[0-9]+")
-	familyPattern := "^" + tmpl + "$"
+	familyPattern := package_family.GeneratePackageNamePattern(pf.PackageNameTemplate, pf.Name)
 
 	query := `
 		SELECT pv.git_tag, pv.git_commit_sha
@@ -2376,14 +2369,7 @@ func getExistingVersionsForFamily(ctx context.Context, pf *package_family.Packag
 	// - "go" with template "{name}-{major}.{minor}" → "^go-[0-9]+\.[0-9]+$" matches go-1.26 but NOT go-boring-1.26
 	// - "eclipse-temurin" with template "{name}-{major}-jre" → "^eclipse-temurin-[0-9]+-jre$"
 	// Default to "{name}-{major}.{minor}" if no template is set.
-	tmpl := "{name}-{major}.{minor}"
-	if pf.PackageNameTemplate != "" {
-		tmpl = pf.PackageNameTemplate
-	}
-	tmpl = strings.ReplaceAll(tmpl, "{name}", regexp.QuoteMeta(pf.Name))
-	tmpl = strings.ReplaceAll(tmpl, "{major}", "[0-9]+")
-	tmpl = strings.ReplaceAll(tmpl, "{minor}", "[0-9]+")
-	familyPattern := "^" + tmpl + "$"
+	familyPattern := package_family.GeneratePackageNamePattern(pf.PackageNameTemplate, pf.Name)
 
 	query := `
 		SELECT DISTINCT p.name, pv.version

--- a/pkg/package_family/family_detection.go
+++ b/pkg/package_family/family_detection.go
@@ -2,6 +2,7 @@ package package_family
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/Masterminds/semver"
@@ -23,6 +24,23 @@ func GeneratePackageName(template, familyName string, major, minor int) string {
 	result = strings.ReplaceAll(result, "{major}", fmt.Sprintf("%d", major))
 	result = strings.ReplaceAll(result, "{minor}", fmt.Sprintf("%d", minor))
 	return result
+}
+
+// GeneratePackageNamePattern converts a package name template into an anchored
+// regular expression. Literal template characters are escaped before the
+// supported placeholders are expanded so valid package-name characters such
+// as "." and "+" retain their literal meaning.
+func GeneratePackageNamePattern(template, familyName string) string {
+	if template == "" {
+		template = "{name}-{major}.{minor}"
+	}
+
+	pattern := regexp.QuoteMeta(template)
+	pattern = strings.ReplaceAll(pattern, regexp.QuoteMeta("{name}"), regexp.QuoteMeta(familyName))
+	pattern = strings.ReplaceAll(pattern, regexp.QuoteMeta("{major}"), "[0-9]+")
+	pattern = strings.ReplaceAll(pattern, regexp.QuoteMeta("{minor}"), "[0-9]+")
+
+	return "^" + pattern + "$"
 }
 
 // IdentifyFamilyPackages filters a list of packages to return only those that belong

--- a/pkg/package_family/family_detection_test.go
+++ b/pkg/package_family/family_detection_test.go
@@ -1,6 +1,7 @@
 package package_family
 
 import (
+	"regexp"
 	"testing"
 )
 
@@ -125,6 +126,54 @@ func TestIdentifyFamilyPackages(t *testing.T) {
 				}
 				if resultPkg.Name != expectedPkg.Name || resultPkg.Version != expectedPkg.Version {
 					t.Errorf("Package mismatch for ID %s: expected %+v, got %+v", id, expectedPkg, resultPkg)
+				}
+			}
+		})
+	}
+}
+
+func TestGeneratePackageNamePattern(t *testing.T) {
+	tests := []struct {
+		name       string
+		template   string
+		familyName string
+		matches    []string
+		rejects    []string
+	}{
+		{
+			name:       "default template",
+			template:   "{name}-{major}.{minor}",
+			familyName: "go",
+			matches:    []string{"go-1.24"},
+			rejects:    []string{"go-1x24", "go-boring-1.24"},
+		},
+		{
+			name:       "literal plus",
+			template:   "lib{name}_{major}+compat",
+			familyName: "ssl",
+			matches:    []string{"libssl_3+compat"},
+			rejects:    []string{"libssl_33compat", "libssl_3compat"},
+		},
+		{
+			name:       "regex characters in family name",
+			template:   "{name}-{major}",
+			familyName: "lib.foo+bar",
+			matches:    []string{"lib.foo+bar-2"},
+			rejects:    []string{"libXfooobar-2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pattern := regexp.MustCompile(GeneratePackageNamePattern(tt.template, tt.familyName))
+			for _, value := range tt.matches {
+				if !pattern.MatchString(value) {
+					t.Errorf("pattern %q did not match %q", pattern, value)
+				}
+			}
+			for _, value := range tt.rejects {
+				if pattern.MatchString(value) {
+					t.Errorf("pattern %q unexpectedly matched %q", pattern, value)
 				}
 			}
 		})

--- a/securebuild-app/app/(dashboard)/package-families/new/page.tsx
+++ b/securebuild-app/app/(dashboard)/package-families/new/page.tsx
@@ -19,6 +19,7 @@ import { formatVersion, parseVersion } from "@/lib/types/packagefamily"
 import { listAvailablePackagesAction, AvailablePackage } from "@/lib/packagefamily/actions/list-available-packages"
 import { getUpstreamConfigFromPackageAction } from "@/lib/packagefamily/actions/get-upstream-config"
 import { UpstreamConfig } from "@/lib/packagefamily/packagefamily"
+import { validatePackageNameTemplate } from "@/lib/packagefamily/package-name-template"
 
 interface SelectedPackage extends AvailablePackage {
   versionMajor: number;
@@ -61,6 +62,7 @@ export default function NewPackageFamilyPage() {
 
   // Linked repository form state
   const [linkedName, setLinkedName] = useState("")
+  const [linkedPackageNameTemplate, setLinkedPackageNameTemplate] = useState("{name}-{major}.{minor}")
   const [gitRemote, setGitRemote] = useState("")
   const [melangeFilePath, setMelangeFilePath] = useState("")
   const [initialTag, setInitialTag] = useState("")
@@ -234,6 +236,11 @@ export default function NewPackageFamilyPage() {
       setLinkedError("Name is required.")
       return
     }
+    const packageNameTemplateError = validatePackageNameTemplate(linkedPackageNameTemplate)
+    if (packageNameTemplateError) {
+      setLinkedError(packageNameTemplateError)
+      return
+    }
     if (!gitRemote.trim()) {
       setLinkedError("Git remote is required.")
       return
@@ -253,6 +260,7 @@ export default function NewPackageFamilyPage() {
     try {
       const newFamily = await createLinkedPackageFamilyAction({
         name: linkedName.trim(),
+        packageNameTemplate: linkedPackageNameTemplate.trim(),
         gitRemote: gitRemote.trim(),
         melangeFilePath: melangeFilePath.trim(),
         initialTag: initialTag.trim(),
@@ -736,6 +744,19 @@ export default function NewPackageFamilyPage() {
                   />
                   <p className="text-sm text-slate-600 dark:text-slate-400">
                     A unique identifier for this package family.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="linked-package-name-template">Package Name Template</Label>
+                  <Input
+                    id="linked-package-name-template"
+                    placeholder="{name}-{major}.{minor}"
+                    value={linkedPackageNameTemplate}
+                    onChange={(e) => setLinkedPackageNameTemplate(e.target.value)}
+                  />
+                  <p className="text-sm text-slate-600 dark:text-slate-400">
+                    Template for package names using {"{name}"}, {"{major}"}, and {"{minor}"} variables.
                   </p>
                 </div>
 

--- a/securebuild-app/lib/packagefamily/actions/create-linked-package-family.ts
+++ b/securebuild-app/lib/packagefamily/actions/create-linked-package-family.ts
@@ -4,9 +4,10 @@ import { getServerSession } from "@/lib/auth/server-session";
 
 import { PackageFamily } from "@/lib/types/packagefamily";
 import { createLinkedPackageFamily } from "../packagefamily";
+import { validatePackageNameTemplate } from "../package-name-template";
 
 export async function createLinkedPackageFamilyAction(
-  request: { name: string; gitRemote: string; melangeFilePath: string; initialTag: string }
+  request: { name: string; packageNameTemplate: string; gitRemote: string; melangeFilePath: string; initialTag: string }
 ): Promise<PackageFamily> {
   const session = await getServerSession();
   if (!session) {
@@ -16,6 +17,10 @@ export async function createLinkedPackageFamilyAction(
 
   if (!request.name?.trim()) {
     throw new Error("Name is required");
+  }
+  const packageNameTemplateError = validatePackageNameTemplate(request.packageNameTemplate ?? "");
+  if (packageNameTemplateError) {
+    throw new Error(packageNameTemplateError);
   }
   if (!request.gitRemote?.trim()) {
     throw new Error("Git remote is required");

--- a/securebuild-app/lib/packagefamily/package-name-template.test.ts
+++ b/securebuild-app/lib/packagefamily/package-name-template.test.ts
@@ -1,0 +1,30 @@
+import {
+  renderPackageNameTemplate,
+  validatePackageNameTemplate,
+} from "./package-name-template";
+
+describe("package name templates", () => {
+  test("renders supported placeholders", () => {
+    expect(renderPackageNameTemplate("{name}-{major}.{minor}", "go", 1, 24))
+      .toBe("go-1.24");
+  });
+
+  test.each([
+    "{name}-{major}.{minor}",
+    "lib{name}_{major}+compat",
+    "package",
+  ])("accepts template %s when it generates a valid Melange package name", (template) => {
+    expect(validatePackageNameTemplate(template)).toBeNull();
+  });
+
+  test.each([
+    "",
+    "   ",
+    "-{name}",
+    "{name}/{major}",
+    "{name}-{version}",
+    "{name} [debug]",
+  ])("rejects template %s when it cannot generate a valid Melange package name", (template) => {
+    expect(validatePackageNameTemplate(template)).not.toBeNull();
+  });
+});

--- a/securebuild-app/lib/packagefamily/package-name-template.ts
+++ b/securebuild-app/lib/packagefamily/package-name-template.ts
@@ -1,0 +1,26 @@
+const melangePackageNamePattern = /^[a-zA-Z\d][a-zA-Z\d+_.-]*$/;
+
+export function renderPackageNameTemplate(
+  template: string,
+  name = "example",
+  major = 1,
+  minor = 2,
+): string {
+  return template
+    .replaceAll("{name}", name)
+    .replaceAll("{major}", String(major))
+    .replaceAll("{minor}", String(minor));
+}
+
+export function validatePackageNameTemplate(template: string): string | null {
+  if (!template.trim()) {
+    return "Package name template is required.";
+  }
+
+  const packageName = renderPackageNameTemplate(template);
+  if (!melangePackageNamePattern.test(packageName)) {
+    return "Package name template must generate a name that starts with a letter or number and contains only letters, numbers, +, _, ., and -.";
+  }
+
+  return null;
+}

--- a/securebuild-app/lib/packagefamily/packagefamily.ts
+++ b/securebuild-app/lib/packagefamily/packagefamily.ts
@@ -4,7 +4,6 @@ import { PackageFamily, PackageFamilyWithPackages, PackageFamilyPackage, CreateP
 import { randomBytes } from "crypto";
 import semver from "semver";
 import * as yaml from "js-yaml";
-import { enqueueWork } from "@/lib/utils/queue";
 
 export async function listPackageFamilies(): Promise<PackageFamily[]> {
   const pool = getDB(process.env.DB_URI!);
@@ -554,13 +553,14 @@ export async function getUpstreamConfigFromLatestPackage(packageFamilyId: string
 
 export interface CreateLinkedPackageFamilyRequest {
   name: string;
+  packageNameTemplate: string;
   gitRemote: string;
   melangeFilePath: string;
   initialTag: string;
 }
 
 export async function createLinkedPackageFamily(req: CreateLinkedPackageFamilyRequest): Promise<PackageFamily> {
-  const { name, gitRemote, melangeFilePath, initialTag } = req;
+  const { name, packageNameTemplate, gitRemote, melangeFilePath, initialTag } = req;
 
   const pool = getDB(process.env.DB_URI!);
   const client = await pool.connect();
@@ -582,11 +582,11 @@ export async function createLinkedPackageFamily(req: CreateLinkedPackageFamilyRe
         notify_on_build_failure, check_for_updates_at, consecutive_errors,
         created_at, updated_at, git_remote, melange_file_path, initial_tag
       ) VALUES (
-        $1, $2, true, 360, null, null, null,
-        false, null, false, true, $3, 0,
-        $4, $5, $6, $7, $8
+        $1, $2, false, 360, null, null, $3,
+        false, null, false, true, $4, 0,
+        $5, $6, $7, $8, $9
       )
-    `, [familyId, name, checkAt, now, now, gitRemote, melangeFilePath, initialTag]);
+    `, [familyId, name, packageNameTemplate, checkAt, now, now, gitRemote, melangeFilePath, initialTag]);
 
     await client.query('COMMIT');
 
@@ -594,10 +594,6 @@ export async function createLinkedPackageFamily(req: CreateLinkedPackageFamilyRe
     if (!created) {
       throw new Error('Failed to create linked package family');
     }
-
-    await enqueueWork('package_family_update_check', { packageFamilyId: familyId }).catch(err => {
-      console.warn('Failed to enqueue update check:', err);
-    });
 
     return created;
   } catch (error) {


### PR DESCRIPTION
- Package name template was being set to NULL causing an error when viewing the package family
- Automatic checks should be disabled for linked package families