### PR TITLE
Fix completed scan dispatch race

### DIFF
--- a/integration/worker/external_image/scan_dispatch_test.go
+++ b/integration/worker/external_image/scan_dispatch_test.go
@@ -1,0 +1,148 @@
+package worker_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/securebuildhq/securebuild/integration/testutil"
+	"github.com/securebuildhq/securebuild/pkg/externalimage"
+	"github.com/securebuildhq/securebuild/pkg/listener"
+	"github.com/securebuildhq/securebuild/pkg/persistence"
+	"github.com/securebuildhq/securebuild/pkg/scan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExternalImageScanDispatchClaim(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	testDB := testutil.SetupTestDatabase(ctx, t)
+	defer testutil.TeardownTestDatabase(ctx, t, testDB)
+
+	projectRoot, err := testutil.FindProjectRoot()
+	require.NoError(t, err)
+	require.NoError(t, testutil.ApplySchemaHero(ctx, testDB.ConnStr, filepath.Join(projectRoot, "db", "schema", "tables"), false))
+
+	ctx, minioStorage := setupMinIOOverrides(ctx, t, testDB.ConnStr)
+	defer testutil.TeardownMinIO(ctx, t, minioStorage)
+
+	require.NoError(t, persistence.InitPostgres(ctx))
+	defer persistence.ClosePool(ctx)
+
+	cache, err := scan.InitScanCapacityCache(ctx)
+	require.NoError(t, err)
+	ctx = listener.WithScanCapacityCache(ctx, cache)
+
+	t.Run("recent terminal scans are not reclaimed", func(t *testing.T) {
+		const digest = "sha256:recent-terminal-dispatch-claim"
+		seedExternalImageScanForDispatch(t, ctx, digest)
+		setScanStatus(t, ctx, digest, "x86_64", externalimage.ScanStatusSucceeded)
+		setScanStatus(t, ctx, digest, "aarch64", externalimage.ScanStatusFailed)
+
+		require.NoError(t, listener.HandleExternalImageScanOnBuilder(ctx, scanPayload(digest)))
+		require.Equal(t, map[string]string{
+			"aarch64": "failed",
+			"x86_64":  "succeeded",
+		}, scanStatusesByArch(t, ctx, digest))
+	})
+
+	t.Run("only eligible architectures are reverted after dispatch failure", func(t *testing.T) {
+		const digest = "sha256:partial-dispatch-claim"
+		seedExternalImageScanForDispatch(t, ctx, digest)
+		setScanStatus(t, ctx, digest, "x86_64", externalimage.ScanStatusSucceeded)
+
+		require.NoError(t, listener.HandleExternalImageScanOnBuilder(ctx, scanPayload(digest)))
+		require.Equal(t, map[string]string{
+			"aarch64": "queued",
+			"x86_64":  "succeeded",
+		}, scanStatusesByArch(t, ctx, digest))
+	})
+
+	t.Run("stale terminal scans remain eligible", func(t *testing.T) {
+		const digest = "sha256:stale-terminal-dispatch-claim"
+		seedExternalImageScanForDispatch(t, ctx, digest)
+		setScanStatus(t, ctx, digest, "x86_64", externalimage.ScanStatusSucceeded)
+		setScanStatus(t, ctx, digest, "aarch64", externalimage.ScanStatusFailed)
+		setScanCompletedAt(t, ctx, digest, time.Now().Add(-4*time.Hour-time.Minute))
+
+		require.NoError(t, listener.HandleExternalImageScanOnBuilder(ctx, scanPayload(digest)))
+		// No builders exist in the test database, so a successful claim is
+		// reverted to queued after dispatch cannot reserve a builder.
+		require.Equal(t, map[string]string{
+			"aarch64": "queued",
+			"x86_64":  "queued",
+		}, scanStatusesByArch(t, ctx, digest))
+	})
+
+	t.Run("queued retries may retain a recent prior completion", func(t *testing.T) {
+		const digest = "sha256:queued-prior-completion-dispatch-claim"
+		seedExternalImageScanForDispatch(t, ctx, digest)
+		setScanStatus(t, ctx, digest, "x86_64", externalimage.ScanStatusSucceeded)
+		setScanStatus(t, ctx, digest, "aarch64", externalimage.ScanStatusSucceeded)
+		queuedAt := time.Now().Add(-time.Hour)
+		setScanQueuedAt(t, ctx, digest, "x86_64", queuedAt)
+
+		require.NoError(t, listener.HandleExternalImageScanOnBuilder(ctx, scanPayload(digest)))
+		statuses := getScanStatuses(t, ctx, digest)
+		require.Len(t, statuses, 2)
+		require.Equal(t, "queued", statuses[1].Status)
+		require.NotNil(t, statuses[1].ScanStatusUpdatedAt)
+		require.True(t, statuses[1].ScanStatusUpdatedAt.After(queuedAt), "queued row should be claimed and reverted")
+	})
+}
+
+func seedExternalImageScanForDispatch(t *testing.T, ctx context.Context, digest string) {
+	t.Helper()
+	require.NoError(t, externalimage.InitializeSBOMStatusPending(ctx, digest))
+	for _, arch := range []string{"x86_64", "aarch64"} {
+		require.NoError(t, externalimage.SetExternalImageSBOM(ctx, digest, `{"artifacts":[]}`, "syft", arch, 1, digest))
+		require.NoError(t, externalimage.InitializeScanStatusQueued(ctx, digest, arch))
+	}
+	require.NoError(t, externalimage.SetSBOMStatusSucceeded(ctx, digest))
+}
+
+func setScanStatus(t *testing.T, ctx context.Context, digest, arch string, status externalimage.ScanStatus) {
+	t.Helper()
+	require.NoError(t, externalimage.SetExternalImageScanStatus(ctx, externalimage.SetExternalImageScanStatusParams{
+		Digest: digest,
+		Arch:   arch,
+		Status: status,
+	}))
+}
+
+func setScanCompletedAt(t *testing.T, ctx context.Context, digest string, completedAt time.Time) {
+	t.Helper()
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+	_, err := conn.Exec(ctx, `UPDATE external_image_scan SET scan_completed_at = $2 WHERE digest = $1`, digest, completedAt)
+	require.NoError(t, err)
+}
+
+func setScanQueuedAt(t *testing.T, ctx context.Context, digest, arch string, queuedAt time.Time) {
+	t.Helper()
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+	_, err := conn.Exec(ctx, `
+		UPDATE external_image_scan
+		SET status = 'queued', scan_status_updated_at = $3
+		WHERE digest = $1 AND arch = $2
+	`, digest, arch, queuedAt)
+	require.NoError(t, err)
+}
+
+func scanStatusesByArch(t *testing.T, ctx context.Context, digest string) map[string]string {
+	t.Helper()
+	statuses := map[string]string{}
+	for _, status := range getScanStatuses(t, ctx, digest) {
+		statuses[status.Arch] = status.Status
+	}
+	return statuses
+}
+
+func scanPayload(digest string) string {
+	return `{"digest":"` + digest + `"}`
+}

--- a/pkg/listener/external-image-scan-builder.go
+++ b/pkg/listener/external-image-scan-builder.go
@@ -37,6 +37,11 @@ func getScanCapacityCache(ctx context.Context) *scan.ScanCapacityCache {
 // expectedArchs is the list of architectures that external image scans check for.
 var expectedArchs = []string{"x86_64", "aarch64"}
 
+// externalImageScanRecencyThreshold is the minimum age of a completed scan
+// before it can be claimed for another dispatch. It matches the active-image
+// rescan interval used by the scheduler.
+const externalImageScanRecencyThreshold = 4 * time.Hour
+
 // HandleExternalImageScanOnBuilder dispatches an external image CVE scan to a
 // builder VM. It copies the SBOM to the builder, launches grype CLI via nohup
 // for each architecture, and returns immediately. The scan status poller
@@ -61,7 +66,7 @@ func HandleExternalImageScanOnBuilder(ctx context.Context, payloadJSON string) e
 		return fmt.Errorf("scan capacity cache is not ready")
 	}
 
-	recent, err := externalimage.WasScannedRecently(ctx, p.Digest, 4*time.Hour)
+	recent, err := externalimage.WasScannedRecently(ctx, p.Digest, externalImageScanRecencyThreshold)
 	if err != nil {
 		logger.Warn("failed to check scan recency, proceeding with scan",
 			zap.String("digest", p.Digest),
@@ -120,16 +125,15 @@ func HandleExternalImageScanOnBuilder(ctx context.Context, payloadJSON string) e
 		return NewNonRetryableError(fmt.Errorf("no architectures with SBOMs to scan for digest %s", p.Digest))
 	}
 
-	// Atomically claim the scan: set status to "running" for archs that are
-	// not already running. If 0 rows are updated, another handler already
-	// claimed it.
-	claimed, claimErr := claimScanForDispatch(ctx, p.Digest, archsToScan)
+	// Atomically claim eligible architectures. Rows that are already running
+	// or that just completed are excluded by the claim query.
+	claimedArchs, claimErr := claimScanForDispatch(ctx, p.Digest, archsToScan)
 	if claimErr != nil {
 		// DB error during claim — return error so the listener retries.
 		return fmt.Errorf("failed to claim scan for dispatch: %w", claimErr)
 	}
-	if !claimed {
-		logger.Info("discarding external_image_scan message: scan already claimed by another handler",
+	if len(claimedArchs) == 0 {
+		logger.Info("discarding external_image_scan message: no eligible architectures to claim",
 			zap.String("digest", p.Digest))
 		return nil
 	}
@@ -140,9 +144,9 @@ func HandleExternalImageScanOnBuilder(ctx context.Context, payloadJSON string) e
 	// that happens when all builders are full. We return nil so the message
 	// is cleanly completed (not retried by the listener) and the scheduler
 	// re-enqueues when capacity frees up.
-	dispatchErr := dispatchScanToBuilder(ctx, cache, p.Digest, sbomByArch, archsToScan)
+	dispatchErr := dispatchScanToBuilder(ctx, cache, p.Digest, sbomByArch, claimedArchs)
 	if dispatchErr != nil {
-		if revertErr := revertScanToQueued(ctx, p.Digest, archsToScan); revertErr != nil {
+		if revertErr := revertScanToQueued(ctx, p.Digest, claimedArchs); revertErr != nil {
 			// Revert failed — return the revert error so the listener retries
 			// the message instead of acking it. Without this, the scan row
 			// stays "running" with no builder work directory until the 1-hour
@@ -401,29 +405,55 @@ func isScanAlreadyRunning(ctx context.Context, digest string) bool {
 // results are preserved so the API can still serve the last successful scan
 // while waiting for the retry.
 //
-// Returns (true, nil) if at least one row was claimed, (false, nil) if another
-// handler already claimed it, or (false, err) if the claim failed due to a
-// database error. On DB error, the caller returns the error so the listener
-// retries the message instead of dispatching without a durable claim.
-func claimScanForDispatch(ctx context.Context, digest string, archs []string) (bool, error) {
+// Succeeded or failed rows with a recent scan_completed_at are excluded
+// atomically. This closes a race with the result collector: it stores each
+// architecture's result before updating last_security_scanned_at for the
+// digest, so a duplicate queue handler can otherwise reclaim a just-completed
+// row during that window and revert it to "queued" when no builder is
+// available. Queued rows are not subject to this guard because they can retain
+// an earlier scan_completed_at while waiting to retry a failed dispatch.
+//
+// Returns the architectures actually claimed. The caller must dispatch and,
+// on failure, revert only these architectures so a partial claim cannot
+// overwrite or redispatch a concurrently completed architecture.
+func claimScanForDispatch(ctx context.Context, digest string, archs []string) ([]string, error) {
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
 	staleThreshold := fmt.Sprintf("%d minutes", int(scan.ScanStalenessThreshold.Minutes()))
+	recentThreshold := fmt.Sprintf("%d minutes", int(externalImageScanRecencyThreshold.Minutes()))
 
-	tag, err := conn.Exec(ctx,
+	rows, err := conn.Query(ctx,
 		`UPDATE external_image_scan
 		 SET status = 'running',
 		     scan_status_updated_at = NOW(),
 		     scan_status_message = NULL,
 		     scan_attempted_at = COALESCE(scan_attempted_at, NOW())
 		 WHERE digest = $1 AND arch = ANY($2::text[])
-		   AND (status != 'running' OR scan_status_updated_at <= NOW() - interval '`+staleThreshold+`')`,
+		   AND (status NOT IN ('succeeded', 'failed')
+		        OR scan_completed_at IS NULL
+		        OR scan_completed_at <= NOW() - interval '`+recentThreshold+`')
+		   AND (status != 'running' OR scan_status_updated_at <= NOW() - interval '`+staleThreshold+`')
+		 RETURNING arch`,
 		digest, archs)
 	if err != nil {
-		return false, fmt.Errorf("failed to claim scan rows: %w", err)
+		return nil, fmt.Errorf("failed to claim scan rows: %w", err)
 	}
-	return tag.RowsAffected() > 0, nil
+	defer rows.Close()
+
+	claimedArchs := make([]string, 0, len(archs))
+	for rows.Next() {
+		var arch string
+		if err := rows.Scan(&arch); err != nil {
+			return nil, fmt.Errorf("failed to read claimed scan architecture: %w", err)
+		}
+		claimedArchs = append(claimedArchs, arch)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed while reading claimed scan architectures: %w", err)
+	}
+
+	return claimedArchs, nil
 }
 
 // revertScanToQueued transitions scan rows from "running" back to "queued"


### PR DESCRIPTION
## Summary

- prevent duplicate external-image scan messages from reclaiming recently completed succeeded or failed architecture rows
- dispatch and revert only the architectures atomically claimed by the handler
- preserve stale rescan eligibility and queued retry behavior

## Root cause

The result collector stores each architecture result before updating the digest-level last_security_scanned_at timestamp. A duplicate queue message can arrive in that window, pass the preliminary recency check, reclaim the newly succeeded rows, and then revert them to queued when no builder capacity is available. This was observed for proxy.replicated.com/proxy/docker.io/traefik:v3.6.15 at sha256:8cb20d16e01a53d8d7f7696ac2f1af7d200d5c9984d226ce2299731d9eab6d6c.

The claim now excludes recent terminal rows in the same atomic update that transitions eligible rows to running. It returns the exact claimed architecture set so dispatch failure cannot overwrite an architecture that completed concurrently.

## Testing

- go test ./integration/worker/external_image -run TestExternalImageScanDispatchClaim -count=1 -v
- go test ./integration/worker/external_image -count=1
- go test -short ./pkg/... ./cmd/...
- git diff --check