### PR TITLE
Don't use status to return image scan results

### DIFF
--- a/securebuild-api/integration/api/v1/external-image/scan.test.ts
+++ b/securebuild-api/integration/api/v1/external-image/scan.test.ts
@@ -121,6 +121,38 @@ describe('Read endpoints /scan, /scan-summary, /sbom', () => {
       expect(res.headers.get('X-SecureBuild-Result_Count')).toBe('1');
     });
 
+    it('serves the previous scan result while a rescan is queued', async () => {
+      await env.dbPool.query(
+        `UPDATE external_image_scan SET status = 'queued' WHERE digest = $1`,
+        [digest()],
+      );
+
+      try {
+        const getRes = await env.client.get(
+          `/api/v1/external-image/scan?digest=${encodeURIComponent(digest())}&arch=amd64&format=parsed`,
+        );
+        expect(getRes.status).toBe(200);
+        expect(getRes.data.scan_status).toBe('queued');
+        expect(getRes.data.counts.high).toBe(1);
+        expect(getRes.data.counts.total).toBe(1);
+
+        const batchRes = await env.client.post('/api/v1/external-image/scan', {
+          digests: [digest()],
+          arch: 'amd64',
+          format: 'parsed',
+        });
+        expect(batchRes.status).toBe(200);
+        expect(batchRes.data[0].scan_status).toBe('queued');
+        expect(batchRes.data[0].result.counts.high).toBe(1);
+        expect(batchRes.data[0].result.counts.total).toBe(1);
+      } finally {
+        await env.dbPool.query(
+          `UPDATE external_image_scan SET status = 'succeeded' WHERE digest = $1`,
+          [digest()],
+        );
+      }
+    });
+
     it('GET /sbom?digest returns SPDX SBOM', async () => {
       const res = await env.client.get(`/api/v1/external-image/sbom?digest=${encodeURIComponent(digest())}`);
       expect(res.status).toBe(200);

--- a/securebuild-api/integration/fixtures/seed-blobs.ts
+++ b/securebuild-api/integration/fixtures/seed-blobs.ts
@@ -7,6 +7,7 @@
  */
 
 const EXISTING_DIGEST = 'sha256:abc123def456789012345678901234567890123456789012345678901234';
+const STALE_SCAN_DIGEST = 'sha256:stale1234567890123456789012345678901234567890123456789012345';
 
 const PARSED_RESULTS_DETAILS = JSON.stringify({
   descriptor: { name: 'grype', version: '0.95.0' },
@@ -155,6 +156,15 @@ export const SEED_BLOBS: SeedBlob[] = [
   {
     digest: EXISTING_DIGEST,
     arch: 'aarch64',
+    rawResult: RAW_RESULT,
+    parsedResultsDetails: PARSED_RESULTS_DETAILS,
+    sbom: SBOM,
+  },
+  // Stale scan — its DB row still points at the last successful result while
+  // the on-demand scan tests transition the current status back to queued.
+  {
+    digest: STALE_SCAN_DIGEST,
+    arch: 'x86_64',
     rawResult: RAW_RESULT,
     parsedResultsDetails: PARSED_RESULTS_DETAILS,
     sbom: SBOM,

--- a/securebuild-api/lib/externalimage/externalimage.ts
+++ b/securebuild-api/lib/externalimage/externalimage.ts
@@ -426,9 +426,11 @@ export const getExternalImageScan = traceFunction('lib.externalimage.getExternal
 
     const row = result.rows[0]
 
-    // Only successful scans have result blobs in object storage.
+    // is_in_object_store records whether a completed result is available. A
+    // subsequent rescan may move status back to queued/running/failed while
+    // preserving that previous result, so status must not gate blob reads.
     let scanResult: string | null = null
-    if (row.status === 'succeeded' && row.is_in_object_store) {
+    if (row.is_in_object_store) {
       try {
         scanResult = format === 'raw'
           ? await getRawResult(digest, arch)
@@ -908,10 +910,11 @@ export const getBatchExternalImageScans = traceFunction('lib.externalimage.getBa
 
       const scanResult = await db.query(scanQuery, [arch, ownedDigestList])
 
-      // Process scan results. Only successful scans have result blobs.
+      // Process scan results. A queued/running/failed rescan may still have a
+      // result from the previous successful scan in object storage.
       for (const row of scanResult.rows) {
         let scanResultBlob: string | null = null
-        if (row.scan_status === 'succeeded' && row.is_in_object_store) {
+        if (row.is_in_object_store) {
           try {
             scanResultBlob = format === 'raw'
               ? await getRawResult(row.digest, arch)


### PR DESCRIPTION
The status column can be changed from `succeeded` to `queued` (or another value), but still need to return scan result if it's available.