### PR TITLE
Allow using multiple tags when building images

### DIFF
--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -109,6 +109,25 @@ func UpdateImageBuildStatus(ctx context.Context, buildID string, status types.Im
 	return nil
 }
 
+// UpdateImageBuildStatusIfCurrent updates a build only if it is still in the
+// expected status. This prevents a delayed producer update from overwriting a
+// status already advanced by a worker.
+func UpdateImageBuildStatusIfCurrent(ctx context.Context, buildID string, current, next types.ImageBuildStatus) error {
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+
+	_, err := conn.Exec(ctx, `
+		UPDATE image_build
+		SET status = $1
+		WHERE id = $2 AND status = $3
+	`, next, buildID, current)
+	if err != nil {
+		return fmt.Errorf("failed to conditionally update image build status: %w", err)
+	}
+
+	return nil
+}
+
 // GetImageBuildStatus retrieves the status of an image build
 func GetImageBuildStatus(ctx context.Context, buildID string) (types.ImageBuildStatus, error) {
 	conn := persistence.MustGetPooledPostgresSession(ctx)

--- a/pkg/listener/image-update-check.go
+++ b/pkg/listener/image-update-check.go
@@ -23,8 +23,89 @@ import (
 )
 
 type ImageUpdateCheckPayload struct {
-	ImageID string `json:"imageId"`
-	Tag     string `json:"tag"`
+	ImageID   string   `json:"imageId"`
+	Tag       string   `json:"tag"`
+	ImageTags []string `json:"imageTags,omitempty"`
+}
+
+func deduplicateImageTags(tags []string) []string {
+	seen := make(map[string]struct{}, len(tags))
+	result := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		if _, ok := seen[tag]; ok {
+			continue
+		}
+		seen[tag] = struct{}{}
+		result = append(result, tag)
+	}
+	return result
+}
+
+func hasNewImageTags(existingTags, requestedTags []string) bool {
+	existing := make(map[string]struct{}, len(existingTags))
+	for _, tag := range existingTags {
+		existing[tag] = struct{}{}
+	}
+	for _, tag := range requestedTags {
+		if _, ok := existing[tag]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
+func isReusableImageBuildStatus(status string) bool {
+	switch imagetypes.ImageBuildStatus(status) {
+	case imagetypes.ImageBuildStatusQueued,
+		imagetypes.ImageBuildStatusBuilding,
+		imagetypes.ImageBuildStatusTesting,
+		imagetypes.ImageBuildStatusPublishing,
+		imagetypes.ImageBuildStatusSuccess:
+		return true
+	default:
+		return false
+	}
+}
+
+// assignImageAPKOTags makes targetApkoID the sole owner of tags within an image.
+func assignImageAPKOTags(ctx context.Context, imageID, targetApkoID string, tags []string) error {
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin tag assignment transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	_, err = tx.Exec(ctx, `
+		UPDATE image_apko
+		SET tags = ARRAY(
+			SELECT existing_tag
+			FROM unnest(tags) AS existing_tag
+			WHERE NOT (existing_tag = ANY($3::text[]))
+		), updated_at = NOW()
+		WHERE image_id = $1 AND id <> $2 AND tags && $3::text[]
+	`, imageID, targetApkoID, tags)
+	if err != nil {
+		return fmt.Errorf("remove tags from previous APKOs: %w", err)
+	}
+
+	commandTag, err := tx.Exec(ctx, `
+		UPDATE image_apko SET tags = $1, name = $2, updated_at = NOW()
+		WHERE id = $3 AND image_id = $4
+	`, tags, tags[0], targetApkoID, imageID)
+	if err != nil {
+		return fmt.Errorf("update target APKO tags: %w", err)
+	}
+	if commandTag.RowsAffected() != 1 {
+		return fmt.Errorf("target APKO %s not found for image %s", targetApkoID, imageID)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit tag assignment transaction: %w", err)
+	}
+	return nil
 }
 
 func handleImageUpdateCheck(ctx context.Context, payload string) error {
@@ -64,10 +145,10 @@ func handleImageUpdateCheck(ctx context.Context, payload string) error {
 		logger.Warn("No GitHub API token found, using unauthenticated client")
 	}
 
-	return performImageUpdateCheck(ctx, githubClient, img, p.Tag)
+	return performImageUpdateCheck(ctx, githubClient, img, p.Tag, p.ImageTags)
 }
 
-func performImageUpdateCheck(ctx context.Context, githubClient *github.Client, img *imagetypes.Image, tag string) error {
+func performImageUpdateCheck(ctx context.Context, githubClient *github.Client, img *imagetypes.Image, tag string, additionalTags []string) error {
 	gitRemote := img.GitRemote
 	apkoFilePath := img.ApkoFilePath
 
@@ -77,6 +158,12 @@ func performImageUpdateCheck(ctx context.Context, githubClient *github.Client, i
 		zap.String("git_remote", gitRemote),
 		zap.String("tag", tag))
 
+	// The template-generated tag is always present. Additional tags may repeat it
+	// (or each other), so normalize the complete desired tag set before assigning it.
+	imageTags := deduplicateImageTags(append([]string{
+		package_family.GenerateImageTag(img.TagTemplate, tag),
+	}, additionalTags...))
+
 	// Resolve the tag to a commit SHA
 	currentSHA, err := gitspec.ResolveTagToCommit(ctx, githubClient, gitRemote, tag)
 	if err != nil {
@@ -85,18 +172,24 @@ func performImageUpdateCheck(ctx context.Context, githubClient *github.Client, i
 
 	// Check if an image_apko with this tag already exists for this image
 	var existingApkoID string
+	var existingImageTags []string
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
 	err = conn.QueryRow(ctx,
-		`SELECT id FROM image_apko WHERE image_id = $1 AND git_tag = $2`,
-		img.ID, tag).Scan(&existingApkoID)
+		`SELECT id, tags FROM image_apko WHERE image_id = $1 AND git_tag = $2`,
+		img.ID, tag).Scan(&existingApkoID, &existingImageTags)
 
 	if err != nil && err != pgx.ErrNoRows {
 		return fmt.Errorf("failed to check for existing APKO: %w", err)
 	}
 
 	if existingApkoID != "" {
+		imageTagsAdded := hasNewImageTags(existingImageTags, imageTags)
+		if err := assignImageAPKOTags(ctx, img.ID, existingApkoID, imageTags); err != nil {
+			return fmt.Errorf("failed to assign image tags: %w", err)
+		}
+
 		// APKO exists — check if the SHA matches
 		latestVersion, err := image.GetLatestImageAPKOVersion(ctx, existingApkoID)
 		if err != nil {
@@ -111,7 +204,7 @@ func performImageUpdateCheck(ctx context.Context, githubClient *github.Client, i
 				zap.String("apko_id", existingApkoID))
 
 			existingBuild, err := image.GetLatestImageBuildByImageApkoVersionID(ctx, latestVersion.ID)
-			if err == nil && existingBuild != nil {
+			if err == nil && existingBuild != nil && !imageTagsAdded && isReusableImageBuildStatus(existingBuild.Status) {
 				resultJSON, _ := json.Marshal(map[string]string{
 					"image_build_id": existingBuild.ID,
 				})
@@ -119,10 +212,13 @@ func performImageUpdateCheck(ctx context.Context, githubClient *github.Client, i
 				return nil
 			}
 
-			// No existing build — queue one
-			logger.Info("No existing build for APKO, queuing new build",
+			// A new alias must go through the builder even when this commit was
+			// built previously, otherwise the registry never receives that tag.
+			logger.Info("Queuing image build for APKO",
 				zap.String("apko_id", existingApkoID),
-				zap.String("tag", tag))
+				zap.String("tag", tag),
+				zap.Bool("image_tags_added", imageTagsAdded),
+				zap.Bool("existing_build_found", err == nil && existingBuild != nil))
 
 			if err := queueImageBuildForAPKO(ctx, existingApkoID); err != nil {
 				return fmt.Errorf("failed to queue image build: %w", err)
@@ -220,11 +316,8 @@ func performImageUpdateCheck(ctx context.Context, githubClient *github.Client, i
 		pinnedYAML = apkoSpec.Content
 	}
 
-	// Generate OCI tag
-	ociTag := package_family.GenerateImageTag(img.TagTemplate, tag)
-
 	// Create image_apko + image_apko_version + image_package
-	apkoID, err := createLinkedImageAPKO(ctx, img.ID, gitRemote, apkoFilePath, tag, currentSHA, ociTag, pinnedYAML, packageID, pinnedVersion)
+	apkoID, err := createLinkedImageAPKO(ctx, img.ID, gitRemote, apkoFilePath, tag, currentSHA, imageTags, pinnedYAML, packageID, pinnedVersion)
 	if err != nil {
 		return fmt.Errorf("failed to create linked image APKO: %w", err)
 	}

--- a/pkg/listener/image-update-check_test.go
+++ b/pkg/listener/image-update-check_test.go
@@ -1,0 +1,69 @@
+package listener
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeduplicateImageTags(t *testing.T) {
+	tags := deduplicateImageTags([]string{"1.2.3", "1.2", "latest", "1.2.3", "latest"})
+	assert.Equal(t, []string{"1.2.3", "1.2", "latest"}, tags)
+}
+
+func TestHasNewImageTags(t *testing.T) {
+	tests := []struct {
+		name      string
+		existing  []string
+		requested []string
+		want      bool
+	}{
+		{
+			name:      "new alias requires build",
+			existing:  []string{"1.2.3"},
+			requested: []string{"1.2.3", "latest"},
+			want:      true,
+		},
+		{
+			name:      "same aliases in different order can reuse build",
+			existing:  []string{"latest", "1.2.3"},
+			requested: []string{"1.2.3", "latest"},
+			want:      false,
+		},
+		{
+			name:      "removing alias does not require build",
+			existing:  []string{"1.2.3", "latest"},
+			requested: []string{"1.2.3"},
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, hasNewImageTags(tt.existing, tt.requested))
+		})
+	}
+}
+
+func TestIsReusableImageBuildStatus(t *testing.T) {
+	tests := []struct {
+		status string
+		want   bool
+	}{
+		{status: "pending", want: false},
+		{status: "queued", want: true},
+		{status: "building", want: true},
+		{status: "testing", want: true},
+		{status: "publishing", want: true},
+		{status: "success", want: true},
+		{status: "failed", want: false},
+		{status: "timed_out", want: false},
+		{status: "unknown", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			assert.Equal(t, tt.want, isReusableImageBuildStatus(tt.status))
+		})
+	}
+}

--- a/pkg/listener/package-family-update-check.go
+++ b/pkg/listener/package-family-update-check.go
@@ -1199,7 +1199,7 @@ func generateImageAPKOsForGitLinkedVersion(ctx context.Context, githubClient *gi
 		ociTag := package_family.GenerateImageTag(template, gitTag)
 
 		// Create the image_apko and image_apko_version
-		apkoID, err := createLinkedImageAPKO(ctx, img.ImageID, img.GitRemote, img.ApkoFilePath.String, gitTag, apkoSpec.CommitSHA, ociTag, pinnedApkoYAML, packageID, versionStr)
+		apkoID, err := createLinkedImageAPKO(ctx, img.ImageID, img.GitRemote, img.ApkoFilePath.String, gitTag, apkoSpec.CommitSHA, []string{ociTag}, pinnedApkoYAML, packageID, versionStr)
 		if err != nil {
 			logger.Error(fmt.Errorf("failed to create linked image APKO for image %s: %w", img.ImageID, err))
 			continue
@@ -1215,7 +1215,7 @@ func generateImageAPKOsForGitLinkedVersion(ctx context.Context, githubClient *gi
 }
 
 // createLinkedImageAPKO creates an image_apko and image_apko_version for a linked image.
-func createLinkedImageAPKO(ctx context.Context, imageID, gitRemote, apkoFilePath, gitTag, commitSHA, ociTag, apkoYAML, packageID, pinnedVersion string) (string, error) {
+func createLinkedImageAPKO(ctx context.Context, imageID, gitRemote, apkoFilePath, gitTag, commitSHA string, imageTags []string, apkoYAML, packageID, pinnedVersion string) (string, error) {
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
@@ -1235,10 +1235,30 @@ func createLinkedImageAPKO(ctx context.Context, imageID, gitRemote, apkoFilePath
 	}
 	defer tx.Rollback(ctx)
 
+	imageTags = deduplicateImageTags(imageTags)
+	if len(imageTags) == 0 {
+		return "", fmt.Errorf("at least one image tag is required")
+	}
+
+	// A tag identifies only one APKO file for an image. Reassign requested tags
+	// atomically before creating their new owner.
+	_, err = tx.Exec(ctx, `
+		UPDATE image_apko
+		SET tags = ARRAY(
+			SELECT existing_tag
+			FROM unnest(tags) AS existing_tag
+			WHERE NOT (existing_tag = ANY($2::text[]))
+		), updated_at = NOW()
+		WHERE image_id = $1 AND tags && $2::text[]
+	`, imageID, imageTags)
+	if err != nil {
+		return "", fmt.Errorf("remove reassigned tags from existing APKOs: %w", err)
+	}
+
 	_, err = tx.Exec(ctx, `
 		INSERT INTO image_apko (id, image_id, name, tags, created_at, updated_at, git_remote, git_tag, apko_file_path)
 		VALUES ($1, $2, $3, $4, NOW(), NOW(), $5, $6, $7)
-	`, apkoID, imageID, ociTag, []string{ociTag}, gitRemote, gitTag, apkoFilePath)
+	`, apkoID, imageID, imageTags[0], imageTags, gitRemote, gitTag, apkoFilePath)
 	if err != nil {
 		return "", fmt.Errorf("insert image_apko: %w", err)
 	}
@@ -3951,11 +3971,6 @@ func queueImageBuildForAPKO(ctx context.Context, apkoID string) error {
 		return fmt.Errorf("failed to create image build for APKO %s: %w", apkoID, err)
 	}
 
-	// Update build status to queued
-	if err := image.UpdateImageBuildStatus(ctx, imageBuild.ID, imagetypes.ImageBuildStatusQueued); err != nil {
-		logger.Warn("failed to update image build status to queued", zap.Error(err))
-	}
-
 	// Assign VM using the shared helper
 	vmID, workDir, err := assignVMForImageBuild(ctx, imageBuild.ID)
 	if err != nil {
@@ -3990,6 +4005,13 @@ func queueImageBuildForAPKO(ctx context.Context, apkoID string) error {
 			logger.Warn("failed to update image build status to failed", zap.Error(statusErr))
 		}
 		return fmt.Errorf("failed to enqueue build_image_with_vm_assigned event: %w", err)
+	}
+
+	// Only advertise the build as queued after executable work exists. The
+	// conditional update avoids moving it backwards if a fast worker has
+	// already advanced the status.
+	if err := image.UpdateImageBuildStatusIfCurrent(ctx, imageBuild.ID, imagetypes.ImageBuildStatusPending, imagetypes.ImageBuildStatusQueued); err != nil {
+		logger.Warn("failed to update image build status to queued", zap.Error(err))
 	}
 
 	logger.Info("Queued image build for APKO",

--- a/securebuild-api/app/api/v1/image-update/route.ts
+++ b/securebuild-api/app/api/v1/image-update/route.ts
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { image_name, tag } = body;
+    const { image_name, tag, image_tags } = body;
 
     if (!image_name || typeof image_name !== 'string') {
       return NextResponse.json(
@@ -69,6 +69,14 @@ export async function POST(request: NextRequest) {
     if (!semver.valid(tag) || semver.prerelease(tag) !== null) {
       return NextResponse.json(
         { error: `Tag '${tag}' is not a valid semantic version.` },
+        { status: 400 }
+      );
+    }
+
+    if (image_tags !== undefined &&
+        (!Array.isArray(image_tags) || image_tags.some((imageTag) => typeof imageTag !== 'string' || imageTag.length === 0))) {
+      return NextResponse.json(
+        { error: 'image_tags must be an array of non-empty strings' },
         { status: 400 }
       );
     }
@@ -99,6 +107,7 @@ export async function POST(request: NextRequest) {
     const jobId = await enqueueWork("image_update_check", {
       imageId: image.id,
       tag: tag,
+      imageTags: image_tags ?? [],
     });
 
     return NextResponse.json(

--- a/securebuild-api/integration/api/v1/image-update/test.ts
+++ b/securebuild-api/integration/api/v1/image-update/test.ts
@@ -105,6 +105,26 @@ describe('POST /api/v1/image-update', () => {
       });
       expect(res.status).toBe(400);
     });
+
+    it('POST with invalid image_tags returns 400', async () => {
+      const res = await env.client.post('/api/v1/image-update', {
+        image_name: 'go',
+        tag: '1.24.13',
+        image_tags: ['latest', ''],
+      });
+      expect(res.status).toBe(400);
+      const data = res.data as Record<string, unknown>;
+      expect(data.error).toContain('image_tags');
+    });
+
+    it('POST accepts optional additional image tags', async () => {
+      const res = await env.client.post('/api/v1/image-update', {
+        image_name: 'go',
+        tag: '1.24.13',
+        image_tags: ['1.24', 'latest', '1.24.13'],
+      });
+      expect(res.status).toBe(202);
+    });
   });
 });
 

--- a/securebuild-cmd/cli/build_image.go
+++ b/securebuild-cmd/cli/build_image.go
@@ -37,6 +37,7 @@ func BuildImageCmd() *cobra.Command {
 
 			imageName := v.GetString("image-name")
 			tag := v.GetString("tag")
+			imageTags := v.GetStringSlice("image-tag")
 			apiEndpoint := v.GetString("api-endpoint")
 			apiToken := v.GetString("api-token")
 			debug := v.GetBool("debug")
@@ -54,17 +55,18 @@ func BuildImageCmd() *cobra.Command {
 			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 			defer stop()
 
-			return runBuildImage(ctx, imageName, tag, apiEndpoint, apiToken, debug)
+			return runBuildImage(ctx, imageName, tag, imageTags, apiEndpoint, apiToken, debug)
 		},
 	}
 
 	cmd.Flags().String("image-name", "", "Image name (e.g. go, busybox)")
 	cmd.Flags().String("tag", "", "Git tag to build (e.g. 1.24.13)")
+	cmd.Flags().StringSlice("image-tag", nil, "Additional image tag to apply (may be repeated)")
 
 	return cmd
 }
 
-func runBuildImage(ctx context.Context, imageName, tag, apiEndpoint, apiToken string, debug bool) error {
+func runBuildImage(ctx context.Context, imageName, tag string, imageTags []string, apiEndpoint, apiToken string, debug bool) error {
 	client := NewClient(apiEndpoint, apiToken, debug)
 
 	fmt.Fprintf(os.Stderr, "Triggering image update: %s @ %s\n", imageName, tag)
@@ -72,6 +74,7 @@ func runBuildImage(ctx context.Context, imageName, tag, apiEndpoint, apiToken st
 	triggerResp, err := client.TriggerImage(ctx, ImageTriggerRequest{
 		ImageName: imageName,
 		Tag:       tag,
+		ImageTags: imageTags,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to trigger image update: %w", err)

--- a/securebuild-cmd/cli/client.go
+++ b/securebuild-cmd/cli/client.go
@@ -48,8 +48,9 @@ type JobStatusResponse struct {
 }
 
 type ImageTriggerRequest struct {
-	ImageName string `json:"image_name"`
-	Tag       string `json:"tag"`
+	ImageName string   `json:"image_name"`
+	Tag       string   `json:"tag"`
+	ImageTags []string `json:"image_tags,omitempty"`
 }
 
 type ImageBuildResponse struct {

--- a/securebuild-cmd/cli/client_test.go
+++ b/securebuild-cmd/cli/client_test.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestTriggerImageSendsAdditionalImageTags(t *testing.T) {
+	client := NewClient("https://api.example.test", "token", false)
+	client.httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		var request ImageTriggerRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		require.Equal(t, "go", request.ImageName)
+		require.Equal(t, "1.24.13", request.Tag)
+		require.Equal(t, []string{"1.24", "latest"}, request.ImageTags)
+		return &http.Response{
+			StatusCode: http.StatusAccepted,
+			Body:       io.NopCloser(bytes.NewBufferString(`{"job_id":"job-1"}`)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	response, err := client.TriggerImage(context.Background(), ImageTriggerRequest{
+		ImageName: "go",
+		Tag:       "1.24.13",
+		ImageTags: []string{"1.24", "latest"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "job-1", response.JobID)
+}


### PR DESCRIPTION
We need to change securebuild CLI "build image" command to accept additional tag that should be applied to an image.  For example, if `--tag 1.2.3`, then the user may also want to supply `--image-tag 1.2 --image-tag latest`



the API should do the following:

1. Still use tag template to generate the image tag
2. If an image tag is already used by another APKO file for the same image, it should be removed from that APKO file
3. The tag list for the new image should be deduplicated: --image-tag parameter may also match the generated tag, and it should not be an error.
4. \--image-tag parameters are optional: if non used, only the generated tag will be pushed by the builder