### PR TITLE
Allow git tags to have pre-release components

### DIFF
--- a/pkg/gitspec/semver.go
+++ b/pkg/gitspec/semver.go
@@ -58,16 +58,14 @@ func OverrideVersionAndEpochInMelange(melangeYAML string, gitTag string, epoch i
 	return strings.Join(lines, "\n"), versionStr, nil
 }
 
-// VersionFromTag parses a git tag as semver and returns the canonical version string.
+// VersionFromTag parses a git tag as semver and returns only its major, minor, and
+// patch components, suitable for use as a Melange package version.
 func VersionFromTag(gitTag string) (string, error) {
 	v, err := semver.NewVersion(gitTag)
 	if err != nil {
 		return "", fmt.Errorf("parse git tag %q as semver: %w", gitTag, err)
 	}
-	if v.Prerelease() != "" {
-		return "", fmt.Errorf("pre-release tags are not supported (tag=%q)", gitTag)
-	}
-	return v.String(), nil
+	return fmt.Sprintf("%d.%d.%d", v.Major(), v.Minor(), v.Patch()), nil
 }
 
 // IsSemverTag returns true if the given string is a valid semver tag (with optional v prefix).

--- a/pkg/gitspec/semver_test.go
+++ b/pkg/gitspec/semver_test.go
@@ -1,0 +1,61 @@
+package gitspec
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOverrideVersionAndEpochInMelange(t *testing.T) {
+	tests := []struct {
+		name            string
+		tag             string
+		wantVersion     string
+		wantYAMLVersion string
+	}{
+		{
+			name:            "stable version",
+			tag:             "v2.19.5",
+			wantVersion:     "2.19.5",
+			wantYAMLVersion: `version: "2.19.5"`,
+		},
+		{
+			name:            "build metadata",
+			tag:             "2.19.5+k8s-1.36",
+			wantVersion:     "2.19.5+k8s-1.36",
+			wantYAMLVersion: `version: "2.19.5+k8s-1.36"`,
+		},
+	}
+
+	const input = "package:\n  name: example\n  version: 0.0.0\n  epoch: 7\n"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotYAML, gotVersion, err := OverrideVersionAndEpochInMelange(input, tt.tag, 0, "")
+			if err != nil {
+				t.Fatalf("OverrideVersionAndEpochInMelange() error = %v", err)
+			}
+			if gotVersion != tt.wantVersion {
+				t.Errorf("version = %q, want %q", gotVersion, tt.wantVersion)
+			}
+			if !strings.Contains(gotYAML, tt.wantYAMLVersion) {
+				t.Errorf("YAML = %q, want it to contain %q", gotYAML, tt.wantYAMLVersion)
+			}
+		})
+	}
+}
+
+func TestOverrideVersionAndEpochInMelangeRejectsPrerelease(t *testing.T) {
+	const input = "package:\n  version: 0.0.0\n  epoch: 0\n"
+	if _, _, err := OverrideVersionAndEpochInMelange(input, "v2.19.5-rc.1+k8s-1.36", 0, ""); err == nil {
+		t.Fatal("OverrideVersionAndEpochInMelange() expected prerelease error")
+	}
+}
+
+func TestVersionFromTagReturnsMelangeVersion(t *testing.T) {
+	got, err := VersionFromTag("v2.19.5-rc.1+k8s-1.36")
+	if err != nil {
+		t.Fatalf("VersionFromTag() error = %v", err)
+	}
+	if want := "2.19.5"; got != want {
+		t.Errorf("VersionFromTag() = %q, want %q", got, want)
+	}
+}

--- a/pkg/listener/image-update-check.go
+++ b/pkg/listener/image-update-check.go
@@ -349,8 +349,19 @@ func performImageUpdateCheck(ctx context.Context, githubClient *github.Client, i
 
 // pinCorePackageForImage finds the core package for an image by looking up package families
 // with the same git_remote, then pins the package version in the APKO YAML.
-// Returns the pinned YAML, package ID, and pinned version string.
+// The package record is looked up by the full semantic version from the tag, while
+// the APK pin uses only major.minor.patch to match the version emitted by Melange.
+// Returns the pinned YAML, package ID, and Melange package version string.
 func pinCorePackageForImage(ctx context.Context, conn *pgxpool.Conn, gitRemote, apkoYAML, tag string) (string, string, string, error) {
+	version, err := semver.NewVersion(tag)
+	if err != nil {
+		return apkoYAML, "", "", fmt.Errorf("parse git tag %q as semver: %w", tag, err)
+	}
+	melangeVersion, err := gitspec.VersionFromTag(tag)
+	if err != nil {
+		return apkoYAML, "", "", fmt.Errorf("derive package pin from git tag: %w", err)
+	}
+
 	// Find package families with the same git_remote
 	rows, err := conn.Query(ctx, `
 		SELECT id, name, package_name_template, image_tag_template
@@ -389,14 +400,8 @@ func pinCorePackageForImage(ctx context.Context, conn *pgxpool.Conn, gitRemote, 
 	var pinnedVersion string
 
 	for _, fi := range families {
-		// Parse the tag as semver to get major/minor for the package name
-		v, err := semver.NewVersion(tag)
-		if err != nil {
-			continue
-		}
-
 		// Generate the exact package name from the template
-		packageName := package_family.GeneratePackageName(fi.PackageNameTemplate, fi.Name, int(v.Major()), int(v.Minor()))
+		packageName := package_family.GeneratePackageName(fi.PackageNameTemplate, fi.Name, int(version.Major()), int(version.Minor()))
 
 		// Find the package by exact name and version matching the tag
 		var pkgID string
@@ -412,7 +417,7 @@ func pinCorePackageForImage(ctx context.Context, conn *pgxpool.Conn, gitRemote, 
 			  AND p.parent_id IS NULL
 			ORDER BY pv.apk_release DESC
 			LIMIT 1
-		`, packageName, v.String()).Scan(&pkgID, &pkgName, &pkgVersion)
+		`, packageName, version.String()).Scan(&pkgID, &pkgName, &pkgVersion)
 
 		if err != nil {
 			if err == pgx.ErrNoRows {
@@ -449,7 +454,7 @@ func pinCorePackageForImage(ctx context.Context, conn *pgxpool.Conn, gitRemote, 
 		}
 
 		packageID = pkgID
-		pinnedVersion = pkgVersion
+		pinnedVersion = melangeVersion
 	}
 
 	if packageID == "" {

--- a/pkg/listener/package-family-update-check.go
+++ b/pkg/listener/package-family-update-check.go
@@ -383,14 +383,12 @@ func performGitLinkedUpdateCheck(ctx context.Context, githubClient *github.Clien
 		return fmt.Errorf("failed to list tags from %s: %w", gitRemote, err)
 	}
 
-	// Parse and filter tags: only semver, no pre-release
+	// Parse and filter tags: only semver. Git-linked versions may contain
+	// prerelease or build metadata; their Melange version is normalized later.
 	var semverTags []*semver.Version
 	for _, tag := range tags {
 		v, err := semver.NewVersion(tag)
 		if err != nil {
-			continue
-		}
-		if v.Prerelease() != "" {
 			continue
 		}
 		semverTags = append(semverTags, v)
@@ -568,10 +566,6 @@ func performGitLinkedUpdateCheckForTag(ctx context.Context, githubClient *github
 	if err != nil {
 		return NewNonRetryableError(fmt.Errorf("tag '%s' is not a valid semantic version: %w", tag, err))
 	}
-	if v.Prerelease() != "" {
-		return NewNonRetryableError(fmt.Errorf("tag '%s' has pre-release components, which are not supported", tag))
-	}
-
 	versionStr := v.Original()
 	tagStr := versionStr
 
@@ -747,8 +741,14 @@ func processGitLinkedNewVersion(ctx context.Context, githubClient *github.Client
 	// Determine the package name from the template
 	packageName := package_family.GeneratePackageName(pf.PackageNameTemplate, pf.Name, int(version.Major()), int(version.Minor()))
 
-	// Override name, version, and epoch in the melange YAML from the git tag
-	overriddenYAML, versionStr, err := gitspec.OverrideVersionAndEpochInMelange(specContent.Content, gitTag, 0, packageName)
+	// Preserve the full semantic version for the package record, but pass only the
+	// major, minor, and patch components to Melange.
+	versionStr := version.String()
+	melangeVersion, err := gitspec.VersionFromTag(gitTag)
+	if err != nil {
+		return nil, fmt.Errorf("derive melange version: %w", err)
+	}
+	overriddenYAML, _, err := gitspec.OverrideVersionAndEpochInMelange(specContent.Content, melangeVersion, 0, packageName)
 	if err != nil {
 		return nil, fmt.Errorf("override name/version/epoch: %w", err)
 	}
@@ -983,7 +983,11 @@ func processGitLinkedRetag(ctx context.Context, githubClient *github.Client, pf 
 
 	// Override name, version, and epoch in the melange YAML from the git tag
 	versionStr := version.String()
-	overriddenYAML, _, err := gitspec.OverrideVersionAndEpochInMelange(specContent.Content, gitTag, newEpoch, packageName)
+	melangeVersion, err := gitspec.VersionFromTag(gitTag)
+	if err != nil {
+		return nil, fmt.Errorf("derive melange version: %w", err)
+	}
+	overriddenYAML, _, err := gitspec.OverrideVersionAndEpochInMelange(specContent.Content, melangeVersion, newEpoch, packageName)
 	if err != nil {
 		return nil, fmt.Errorf("override name/version/epoch: %w", err)
 	}
@@ -1078,6 +1082,11 @@ func processGitLinkedRetag(ctx context.Context, githubClient *github.Client, pf 
 // If the image is linked to git, it pulls the APKO spec from the repo. Otherwise, it uses
 // the existing clone logic.
 func generateImageAPKOsForGitLinkedVersion(ctx context.Context, githubClient *github.Client, pf *package_family.PackageFamily, gitTag, gitRemote, melangeFilePath string, packageID, packageName, versionStr string) ([]*ImageAPKOInfo, error) {
+	melangeVersion, err := gitspec.VersionFromTag(gitTag)
+	if err != nil {
+		return nil, fmt.Errorf("derive package pin from git tag: %w", err)
+	}
+
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
@@ -1183,7 +1192,7 @@ func generateImageAPKOsForGitLinkedVersion(ctx context.Context, githubClient *gi
 		}
 
 		// Pin the core package to the correct version in the APKO YAML
-		pinnedApkoYAML, err := pinCorePackageInApkoYAML(apkoSpec.Content, possibleNames, versionStr, true)
+		pinnedApkoYAML, err := pinCorePackageInApkoYAML(apkoSpec.Content, possibleNames, melangeVersion, true)
 		if err != nil {
 			logger.Warn("failed to pin core package in APKO YAML, using as-is",
 				zap.String("image_id", img.ImageID),
@@ -1199,7 +1208,7 @@ func generateImageAPKOsForGitLinkedVersion(ctx context.Context, githubClient *gi
 		ociTag := package_family.GenerateImageTag(template, gitTag)
 
 		// Create the image_apko and image_apko_version
-		apkoID, err := createLinkedImageAPKO(ctx, img.ImageID, img.GitRemote, img.ApkoFilePath.String, gitTag, apkoSpec.CommitSHA, []string{ociTag}, pinnedApkoYAML, packageID, versionStr)
+		apkoID, err := createLinkedImageAPKO(ctx, img.ImageID, img.GitRemote, img.ApkoFilePath.String, gitTag, apkoSpec.CommitSHA, []string{ociTag}, pinnedApkoYAML, packageID, melangeVersion)
 		if err != nil {
 			logger.Error(fmt.Errorf("failed to create linked image APKO for image %s: %w", img.ImageID, err))
 			continue

--- a/pkg/package/package_test.go
+++ b/pkg/package/package_test.go
@@ -409,6 +409,17 @@ test:
 `,
 			wantErr: false,
 		},
+		{
+			name: "reject prerelease version",
+			melangeYAML: `package:
+  name: example
+  version: "1.0.0"
+  epoch: 0
+`,
+			version: "2.19.5-rc.1+k8s-1.36",
+			commit:  "64fdc52855eb284c402ff7680a3b23bd0a0b6582",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/securebuild-api/app/api/v1/image-update/route.ts
+++ b/securebuild-api/app/api/v1/image-update/route.ts
@@ -66,7 +66,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (!semver.valid(tag) || semver.prerelease(tag) !== null) {
+    if (!semver.valid(tag)) {
       return NextResponse.json(
         { error: `Tag '${tag}' is not a valid semantic version.` },
         { status: 400 }

--- a/securebuild-api/app/api/v1/package-update/route.ts
+++ b/securebuild-api/app/api/v1/package-update/route.ts
@@ -66,7 +66,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (!semver.valid(tag) || semver.prerelease(tag) !== null) {
+    if (!semver.valid(tag)) {
       return NextResponse.json(
         { error: `Tag '${tag}' is not a valid semantic version.` },
         { status: 400 }

--- a/securebuild-api/integration/api/v1/image-update/test.ts
+++ b/securebuild-api/integration/api/v1/image-update/test.ts
@@ -125,6 +125,14 @@ describe('POST /api/v1/image-update', () => {
       });
       expect(res.status).toBe(202);
     });
+
+    it('POST accepts a git tag with prerelease and build metadata', async () => {
+      const res = await env.client.post('/api/v1/image-update', {
+        image_name: 'go',
+        tag: '1.24.13-rc.1+k8s-1.35',
+      });
+      expect(res.status).toBe(202);
+    });
   });
 });
 

--- a/securebuild-api/integration/api/v1/package-update/test.ts
+++ b/securebuild-api/integration/api/v1/package-update/test.ts
@@ -101,6 +101,14 @@ describe('POST /api/v1/package-update', () => {
       expect(data.error).toContain('not a valid semantic version');
     });
 
+    it('POST accepts a git tag with prerelease and build metadata', async () => {
+      const res = await env.client.post('/api/v1/package-update', {
+        package_family_name: 'go',
+        tag: '1.24.13-rc.1+k8s-1.35',
+      });
+      expect(res.status).toBe(202);
+    });
+
     it('POST with missing package_family_name returns 400', async () => {
       const res = await env.client.post('/api/v1/package-update', {
         tag: '1.24.13',


### PR DESCRIPTION
Git release may have pre-release components in the tag that are vanity or disambiguation components. They do not technically denote pre-release.  If it is published to securebuild, we need to strip those before injecting them into melange files.

```
2026/08/24 18:59:47 ERRO failed to build package: unable to parse version '2.19.5+k8s-1.35' for melange.yaml: invalid version 2.19.5+k8s-1.35, could not parse
```