### PR TITLE
Use parsed summary from db

### DIFF
--- a/integration/worker/external_image/external_image_test.go
+++ b/integration/worker/external_image/external_image_test.go
@@ -140,6 +140,21 @@ func TestExternalImageScanStatusTransitions(t *testing.T) {
 		assert.Equal(t, "succeeded", scanStatus.Status)
 		assert.NotNil(t, scanStatus.ScanCompletedAt, "Scan completed timestamp should be set")
 		assert.NotEmpty(t, scanStatus.ParsedResults, "Parsed results should be set")
+		storedParsedResults := *scanStatus.ParsedResults
+
+		// A later status-only update must preserve the last successful counts.
+		err = externalimage.SetExternalImageScanStatus(ctx, externalimage.SetExternalImageScanStatusParams{
+			Digest:            testDigest,
+			Arch:              "x86_64",
+			Status:            externalimage.ScanStatusFailed,
+			ScanStatusMessage: "test failure after successful scan",
+		})
+		require.NoError(t, err)
+
+		scanStatuses = getScanStatuses(t, ctx, testDigest)
+		require.Len(t, scanStatuses, 1)
+		require.NotNil(t, scanStatuses[0].ParsedResults)
+		assert.Equal(t, storedParsedResults, *scanStatuses[0].ParsedResults)
 
 		// Verify SBOM status remains succeeded
 		sbomStatuses = getSBOMStatuses(t, ctx, testDigest)

--- a/integration/worker/external_image/external_image_test.go
+++ b/integration/worker/external_image/external_image_test.go
@@ -163,6 +163,63 @@ func TestExternalImageScanStatusTransitions(t *testing.T) {
 	})
 }
 
+func TestMigrateScanStatusColumn(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	testDB := testutil.SetupTestDatabase(ctx, t)
+	defer testutil.TeardownTestDatabase(ctx, t, testDB)
+
+	projectRoot, err := testutil.FindProjectRoot()
+	require.NoError(t, err)
+	err = testutil.ApplySchemaHero(ctx, testDB.ConnStr, filepath.Join(projectRoot, "db", "schema", "tables"), false)
+	require.NoError(t, err)
+
+	ctx, err = param.Init(param.InitSourceEnvironment, map[string]string{"DB_URI": testDB.ConnStr})
+	require.NoError(t, err)
+	require.NoError(t, persistence.InitPostgres(ctx))
+	defer persistence.ClosePool(ctx)
+
+	conn := persistence.MustGetPooledPostgresSession(ctx)
+	defer conn.Release()
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO external_image_scan
+		  (digest, arch, parsed_results, created_at, status, scan_status_message, scan_status_updated_at)
+		VALUES
+		  ('legacy-success', 'x86_64', '{"total":1}', NOW(), 'queued', NULL, NULL),
+		  ('legacy-failure', 'x86_64', '', NOW(), 'queued', 'scan failed', NULL),
+		  ('modern-rescan', 'x86_64', '{"total":1}', NOW(), 'queued', NULL, NOW()),
+		  ('false-success', 'x86_64', '', NOW(), 'succeeded', 'scan failed', NOW())
+	`)
+	require.NoError(t, err)
+
+	require.NoError(t, externalimage.MigrateScanStatusColumn(ctx))
+
+	rows, err := conn.Query(ctx, `
+		SELECT digest, status
+		FROM external_image_scan
+		WHERE digest = ANY($1::text[])
+	`, []string{"legacy-success", "legacy-failure", "modern-rescan", "false-success"})
+	require.NoError(t, err)
+	defer rows.Close()
+
+	statuses := map[string]string{}
+	for rows.Next() {
+		var digest, status string
+		require.NoError(t, rows.Scan(&digest, &status))
+		statuses[digest] = status
+	}
+	require.NoError(t, rows.Err())
+
+	assert.Equal(t, "succeeded", statuses["legacy-success"])
+	assert.Equal(t, "failed", statuses["legacy-failure"])
+	assert.Equal(t, "queued", statuses["modern-rescan"])
+	assert.Equal(t, "failed", statuses["false-success"])
+}
+
 // TestExternalImageScanFailure tests the failure state transition
 func TestExternalImageScanFailure(t *testing.T) {
 	if testing.Short() {
@@ -250,6 +307,7 @@ func TestExternalImageScanFailure(t *testing.T) {
 		scanStatus := scanStatuses[0]
 		assert.Equal(t, "failed", scanStatus.Status)
 		assert.NotNil(t, scanStatus.ScanStatusMessage)
+		assert.Nil(t, scanStatus.ParsedResults, "A failed scan without prior results should store NULL counts")
 		assert.NotNil(t, scanStatus.ScanCompletedAt, "Completion timestamp should be set even on failure")
 
 		// Verify SBOM status remains succeeded

--- a/pkg/externalimage/externalimage.go
+++ b/pkg/externalimage/externalimage.go
@@ -345,7 +345,11 @@ func SetExternalImageScanStatus(ctx context.Context, params SetExternalImageScan
 		INSERT INTO external_image_scan (digest, arch, parsed_results, created_at, status, scan_status_message, updated_at, scan_completed_at, scan_attempted_at, scan_status_updated_at, is_in_object_store)
 		VALUES ($1, $2, $3, $4, $5, $6, $4, $4, $4, $4, $7)
 		ON CONFLICT (digest, arch) DO UPDATE
-		SET parsed_results = $3,
+		SET parsed_results = CASE
+		        WHEN EXCLUDED.status = 'succeeded' AND NULLIF(EXCLUDED.parsed_results, '') IS NOT NULL
+		          THEN EXCLUDED.parsed_results
+		        ELSE external_image_scan.parsed_results
+		    END,
 		    status = $5,
 		    scan_status_message = $6,
 		    updated_at = $4,

--- a/pkg/externalimage/externalimage.go
+++ b/pkg/externalimage/externalimage.go
@@ -343,7 +343,7 @@ func SetExternalImageScanStatus(ctx context.Context, params SetExternalImageScan
 	// Step 2: Write metadata to DB. Blob content lives only in object storage.
 	query := `
 		INSERT INTO external_image_scan (digest, arch, parsed_results, created_at, status, scan_status_message, updated_at, scan_completed_at, scan_attempted_at, scan_status_updated_at, is_in_object_store)
-		VALUES ($1, $2, $3, $4, $5, $6, $4, $4, $4, $4, $7)
+		VALUES ($1, $2, NULLIF($3, ''), $4, $5, $6, $4, $4, $4, $4, $7)
 		ON CONFLICT (digest, arch) DO UPDATE
 		SET parsed_results = CASE
 		        WHEN EXCLUDED.status = 'succeeded' AND NULLIF(EXCLUDED.parsed_results, '') IS NOT NULL
@@ -680,23 +680,34 @@ func GetExternalImageCredentials(ctx context.Context, teamID string, registry st
 	return username.String, clearPassword, nil
 }
 
-// MigrateScanStatusColumn migrates existing external_image_scan rows to have the correct
-// status value based on their data. This is needed because when the status column was added,
-// existing rows received the default value 'queued' even if they had completed scans.
-// This function is idempotent - if no rows match, it updates nothing.
+// MigrateScanStatusColumn migrates legacy external_image_scan rows and repairs
+// rows that an older version of this migration incorrectly marked succeeded.
+// Legacy rows are identified by a NULL scan_status_updated_at; current writers
+// always populate that column, including for legitimate queued rescans that
+// retain results from a previous successful scan.
 func MigrateScanStatusColumn(ctx context.Context) error {
 	conn := persistence.MustGetPooledPostgresSession(ctx)
 	defer conn.Release()
 
-	// Quick check: are there any rows that need migration?
-	// These are rows with status='queued' that have scan data (parsed_results or scan_status_message),
-	// indicating they completed but weren't migrated to the new status values.
+	// Quick check for either an unmigrated legacy row or a false success created
+	// when the old migration treated an empty parsed_results string as data.
 	var needsMigration bool
 	checkQuery := `
 		SELECT EXISTS (
 			SELECT 1 FROM external_image_scan
-			WHERE status = 'queued'
-			  AND (parsed_results IS NOT NULL OR scan_status_message IS NOT NULL)
+			WHERE (
+			        status = 'queued'
+			        AND scan_status_updated_at IS NULL
+			        AND (
+			          NULLIF(BTRIM(parsed_results), '') IS NOT NULL
+			          OR NULLIF(BTRIM(scan_status_message), '') IS NOT NULL
+			        )
+			      )
+			   OR (
+			        status = 'succeeded'
+			        AND NULLIF(BTRIM(parsed_results), '') IS NULL
+			        AND NULLIF(BTRIM(scan_status_message), '') IS NOT NULL
+			      )
 			LIMIT 1
 		)
 	`
@@ -709,19 +720,34 @@ func MigrateScanStatusColumn(ctx context.Context) error {
 		return nil
 	}
 
-	// Migrate rows: parsed_results -> 'succeeded', scan_status_message -> 'failed'
+	// Migrate legacy rows with real counts to succeeded and legacy rows with an
+	// error message to failed. Also repair false successes produced by the old
+	// empty-string check.
 	query := `
 		UPDATE external_image_scan
 		SET status = CASE
-		        WHEN parsed_results IS NOT NULL THEN 'succeeded'
-		        WHEN scan_status_message IS NOT NULL THEN 'failed'
+		        WHEN status = 'succeeded' THEN 'failed'
+		        WHEN NULLIF(BTRIM(parsed_results), '') IS NOT NULL THEN 'succeeded'
+		        WHEN NULLIF(BTRIM(scan_status_message), '') IS NOT NULL THEN 'failed'
 		    END,
 		    scan_status_updated_at = CASE
-		        WHEN parsed_results IS NOT NULL THEN COALESCE(scan_completed_at, updated_at, created_at)
-		        WHEN scan_status_message IS NOT NULL THEN COALESCE(updated_at, created_at)
+		        WHEN status = 'succeeded' THEN COALESCE(scan_status_updated_at, updated_at, created_at)
+		        WHEN NULLIF(BTRIM(parsed_results), '') IS NOT NULL THEN COALESCE(scan_completed_at, updated_at, created_at)
+		        WHEN NULLIF(BTRIM(scan_status_message), '') IS NOT NULL THEN COALESCE(updated_at, created_at)
 		    END
-		WHERE status = 'queued'
-		  AND (parsed_results IS NOT NULL OR scan_status_message IS NOT NULL)
+		WHERE (
+		        status = 'queued'
+		        AND scan_status_updated_at IS NULL
+		        AND (
+		          NULLIF(BTRIM(parsed_results), '') IS NOT NULL
+		          OR NULLIF(BTRIM(scan_status_message), '') IS NOT NULL
+		        )
+		      )
+		   OR (
+		        status = 'succeeded'
+		        AND NULLIF(BTRIM(parsed_results), '') IS NULL
+		        AND NULLIF(BTRIM(scan_status_message), '') IS NOT NULL
+		      )
 	`
 	result, err := conn.Exec(ctx, query)
 	if err != nil {

--- a/securebuild-api/app/api/v1/external-image/scan-summary/route.ts
+++ b/securebuild-api/app/api/v1/external-image/scan-summary/route.ts
@@ -1,4 +1,4 @@
-import { getBatchDigestsForTags, getBatchExternalImageScans, type ImageRefTag, type BatchScanResult } from "@/lib/externalimage/externalimage"
+import { getBatchDigestsForTags, getBatchExternalImageScanSummaries, type ImageRefTag, type BatchScanSummaryResult } from "@/lib/externalimage/externalimage"
 import { parseImageRef } from "@/lib/externalimage/registry"
 import { NextRequest, NextResponse } from "next/server"
 import { findServiceAccountWithValue } from "@/lib/team/service-account"
@@ -168,13 +168,13 @@ const batchListScanSummaries = traceFunction('api.external_image.scan_summary.ba
 
   // Step 4: Get scan results for all digests (team ownership validated via JOIN)
   const scanResults = allDigests.size > 0
-    ? await getBatchExternalImageScans(teamId, [...allDigests], arch, 'parsed')
-    : new Map<string, BatchScanResult>()
+    ? await getBatchExternalImageScanSummaries(teamId, [...allDigests], arch)
+    : new Map<string, BatchScanSummaryResult>()
 
   // Step 5: Build the results array
   for (const input of [...inputDigests, ...inputImages]) {
     const digest = inputToDigestMap.get(input) || null;
-    let scanData: BatchScanResult | null = null;
+    let scanData: BatchScanSummaryResult | null = null;
     if (digest) {
       scanData = scanResults.get(digest) || null;
       if (!scanData?.hasAccess) {
@@ -183,10 +183,10 @@ const batchListScanSummaries = traceFunction('api.external_image.scan_summary.ba
     }
 
     let parsedResult: SeverityCounts | null = null
-    if (scanData?.scanResult) {
+    if (scanData?.parsedResults) {
       try {
-        const details = JSON.parse(scanData.scanResult) as ImageScanResultDetails
-        parsedResult = details?.counts || emptyCounts()
+        const stored = JSON.parse(scanData.parsedResults) as SeverityCounts | ImageScanResultDetails
+        parsedResult = 'counts' in stored ? stored.counts : stored
       } catch (error) {
         console.error(`Failed to parse scan result for input ${input}:`, error)
         // Continue with null result instead of failing the entire request

--- a/securebuild-api/app/api/v1/external-image/scan-summary/route.ts
+++ b/securebuild-api/app/api/v1/external-image/scan-summary/route.ts
@@ -1,4 +1,4 @@
-import { getBatchDigestsForTags, getBatchExternalImageScanSummaries, type ImageRefTag, type BatchScanSummaryResult } from "@/lib/externalimage/externalimage"
+import { getBatchDigestsForTags, getBatchExternalImageScans, getBatchExternalImageScanSummaries, type ImageRefTag, type BatchScanResult, type BatchScanSummaryResult } from "@/lib/externalimage/externalimage"
 import { parseImageRef } from "@/lib/externalimage/registry"
 import { NextRequest, NextResponse } from "next/server"
 import { findServiceAccountWithValue } from "@/lib/team/service-account"
@@ -171,6 +171,16 @@ const batchListScanSummaries = traceFunction('api.external_image.scan_summary.ba
     ? await getBatchExternalImageScanSummaries(teamId, [...allDigests], arch)
     : new Map<string, BatchScanSummaryResult>()
 
+  // Older successful rows may not have compact counts in parsed_results. Keep
+  // the existing API behavior for those rows by falling back to the detailed
+  // object-store result, while avoiding blob reads for the normal path.
+  const fallbackDigests = [...scanResults.values()]
+    .filter(result => result.hasAccess && !result.parsedResults && result.isInObjectStore)
+    .map(result => result.digest)
+  const fallbackResults = fallbackDigests.length > 0
+    ? await getBatchExternalImageScans(teamId, fallbackDigests, arch, 'parsed')
+    : new Map<string, BatchScanResult>()
+
   // Step 5: Build the results array
   for (const input of [...inputDigests, ...inputImages]) {
     const digest = inputToDigestMap.get(input) || null;
@@ -183,9 +193,10 @@ const batchListScanSummaries = traceFunction('api.external_image.scan_summary.ba
     }
 
     let parsedResult: SeverityCounts | null = null
-    if (scanData?.parsedResults) {
+    const storedResult = scanData?.parsedResults || (digest ? fallbackResults.get(digest)?.scanResult : null)
+    if (storedResult) {
       try {
-        const stored = JSON.parse(scanData.parsedResults) as SeverityCounts | ImageScanResultDetails
+        const stored = JSON.parse(storedResult) as SeverityCounts | ImageScanResultDetails
         parsedResult = 'counts' in stored ? stored.counts : stored
       } catch (error) {
         console.error(`Failed to parse scan result for input ${input}:`, error)

--- a/securebuild-api/integration/api/v1/external-image/scan.test.ts
+++ b/securebuild-api/integration/api/v1/external-image/scan.test.ts
@@ -3,6 +3,7 @@ import { setupTestEnvironment, TestEnvironment } from '../../../fixtures/environ
 import { HttpClient } from '../../../fixtures/http-client';
 
 const VALID_SCAN_STATUSES = new Set(['queued', 'running', 'succeeded', 'failed']);
+const SUMMARY_ONLY_DIGEST = 'sha256:summary123456789012345678901234567890123456789012345678901234';
 
 /**
  * Integration tests for the read endpoints (scan, scan-summary, sbom).
@@ -99,40 +100,26 @@ describe('Read endpoints /scan, /scan-summary, /sbom', () => {
     });
 
     it('POST /scan-summary {digests} returns counts', async () => {
-      // Summary counts live in PostgreSQL and must not depend on the detailed
-      // result being available in object storage.
-      await env.dbPool.query(
-        `UPDATE external_image_scan SET is_in_object_store = false WHERE digest = $1`,
-        [digest()],
-      );
+      const res = await env.client.post('/api/v1/external-image/scan-summary', {
+        digests: [SUMMARY_ONLY_DIGEST],
+      });
+      expect(res.status).toBe(200);
 
-      try {
-        const res = await env.client.post('/api/v1/external-image/scan-summary', {
-          digests: [digest()],
-        });
-        expect(res.status).toBe(200);
+      const data = res.data as Record<string, unknown>[];
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBe(1);
 
-        const data = res.data as Record<string, unknown>[];
-        expect(Array.isArray(data)).toBe(true);
-        expect(data.length).toBe(1);
+      const entry = data[0];
+      expect(entry.input).toBe(SUMMARY_ONLY_DIGEST);
+      expect(entry.not_found).toBe(false);
+      const counts = entry.counts as Record<string, unknown>;
+      expect(counts.critical).toBe(2);
+      expect(counts.high).toBe(3);
+      expect(counts.medium).toBe(4);
+      expect(counts.low).toBe(5);
+      expect(counts.total).toBe(14);
 
-        const entry = data[0];
-        expect(entry.input).toBe(digest());
-        expect(entry.not_found).toBe(false);
-        const counts = entry.counts as Record<string, unknown>;
-        expect(counts.critical).toBe(0);
-        expect(counts.high).toBe(1);
-        expect(counts.medium).toBe(0);
-        expect(counts.low).toBe(0);
-        expect(counts.total).toBe(1);
-
-        expect(res.headers.get('X-SecureBuild-Result_Count')).toBe('1');
-      } finally {
-        await env.dbPool.query(
-          `UPDATE external_image_scan SET is_in_object_store = true WHERE digest = $1`,
-          [digest()],
-        );
-      }
+      expect(res.headers.get('X-SecureBuild-Result_Count')).toBe('1');
     });
 
     it('serves the previous scan result while a rescan is queued', async () => {

--- a/securebuild-api/integration/api/v1/external-image/scan.test.ts
+++ b/securebuild-api/integration/api/v1/external-image/scan.test.ts
@@ -99,26 +99,40 @@ describe('Read endpoints /scan, /scan-summary, /sbom', () => {
     });
 
     it('POST /scan-summary {digests} returns counts', async () => {
-      const res = await env.client.post('/api/v1/external-image/scan-summary', {
-        digests: [digest()],
-      });
-      expect(res.status).toBe(200);
+      // Summary counts live in PostgreSQL and must not depend on the detailed
+      // result being available in object storage.
+      await env.dbPool.query(
+        `UPDATE external_image_scan SET is_in_object_store = false WHERE digest = $1`,
+        [digest()],
+      );
 
-      const data = res.data as Record<string, unknown>[];
-      expect(Array.isArray(data)).toBe(true);
-      expect(data.length).toBe(1);
+      try {
+        const res = await env.client.post('/api/v1/external-image/scan-summary', {
+          digests: [digest()],
+        });
+        expect(res.status).toBe(200);
 
-      const entry = data[0];
-      expect(entry.input).toBe(digest());
-      expect(entry.not_found).toBe(false);
-      const counts = entry.counts as Record<string, unknown>;
-      expect(typeof counts.critical).toBe('number');
-      expect(typeof counts.high).toBe('number');
-      expect(typeof counts.medium).toBe('number');
-      expect(typeof counts.low).toBe('number');
-      expect(typeof counts.total).toBe('number');
+        const data = res.data as Record<string, unknown>[];
+        expect(Array.isArray(data)).toBe(true);
+        expect(data.length).toBe(1);
 
-      expect(res.headers.get('X-SecureBuild-Result_Count')).toBe('1');
+        const entry = data[0];
+        expect(entry.input).toBe(digest());
+        expect(entry.not_found).toBe(false);
+        const counts = entry.counts as Record<string, unknown>;
+        expect(counts.critical).toBe(0);
+        expect(counts.high).toBe(1);
+        expect(counts.medium).toBe(0);
+        expect(counts.low).toBe(0);
+        expect(counts.total).toBe(1);
+
+        expect(res.headers.get('X-SecureBuild-Result_Count')).toBe('1');
+      } finally {
+        await env.dbPool.query(
+          `UPDATE external_image_scan SET is_in_object_store = true WHERE digest = $1`,
+          [digest()],
+        );
+      }
     });
 
     it('serves the previous scan result while a rescan is queued', async () => {

--- a/securebuild-api/integration/api/v1/external-image/seed-data/external-image-scan.yaml
+++ b/securebuild-api/integration/api/v1/external-image/seed-data/external-image-scan.yaml
@@ -4,6 +4,33 @@ requires:
   - external-image-sbom
 seedData:
   rows:
+    # Dedicated database-only fixture for scan-summary tests. It deliberately
+    # has no object-store blob so the test cannot pass via the fallback path.
+    - columns:
+        - column: digest
+          value:
+            str: "sha256:summary123456789012345678901234567890123456789012345678901234"
+        - column: arch
+          value:
+            str: "x86_64"
+        - column: parsed_results
+          value:
+            str: '{"critical":2,"high":3,"medium":4,"low":5,"total":14,"fixable":1}'
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: status
+          value:
+            str: "succeeded"
+        - column: scan_completed_at
+          value:
+            str: "2024-01-01T00:05:00Z"
+        - column: scan_status_updated_at
+          value:
+            str: "2024-01-01T00:05:00Z"
+        - column: is_in_object_store
+          value:
+            str: "false"
     - columns:
         - column: digest
           value:

--- a/securebuild-api/integration/api/v1/external-image/seed-data/external-image-tag.yaml
+++ b/securebuild-api/integration/api/v1/external-image/seed-data/external-image-tag.yaml
@@ -13,6 +13,28 @@ seedData:
             str: "test-org/test-image"
         - column: image_tag
           value:
+            str: "summary-only"
+        - column: digest
+          value:
+            str: "sha256:summary123456789012345678901234567890123456789012345678901234"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+        - column: next_check_digest_at
+          value:
+            str: "2024-01-02T00:00:00Z"
+        - column: next_scan_at
+          value:
+            str: "2024-01-02T00:00:00Z"
+    - columns:
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: image_tag
+          value:
             str: "latest"
         - column: digest
           value:

--- a/securebuild-api/integration/api/v1/external-image/seed-data/external-image-team.yaml
+++ b/securebuild-api/integration/api/v1/external-image/seed-data/external-image-team.yaml
@@ -17,6 +17,22 @@ seedData:
             str: "test-org/test-image"
         - column: image_tag
           value:
+            str: "summary-only"
+        - column: created_at
+          value:
+            str: "2024-01-01T00:00:00Z"
+    - columns:
+        - column: team_id
+          value:
+            str: "test-team-alpha"
+        - column: registry
+          value:
+            str: "test-registry.example.com"
+        - column: image_name
+          value:
+            str: "test-org/test-image"
+        - column: image_tag
+          value:
             str: "latest"
         - column: created_at
           value:

--- a/securebuild-api/lib/externalimage/externalimage.ts
+++ b/securebuild-api/lib/externalimage/externalimage.ts
@@ -826,6 +826,18 @@ export interface BatchScanResult {
   sbomStatusUpdatedAt: string | null;
 }
 
+export interface BatchScanSummaryResult {
+  digest: string;
+  parsedResults: string | null;
+  scanCompletedAt: string | null;
+  digestFirstSeenAt: string | null;
+  imageSizeBytes: number;
+  hasAccess: boolean;
+  scanStatus: string | null;
+  scanStatusMessage: string | null;
+  scanStatusUpdatedAt: string | null;
+}
+
 export interface BatchSbomResult {
   digest: string;
   arch: string | null;
@@ -1012,6 +1024,79 @@ export const getBatchExternalImageScans = traceFunction('lib.externalimage.getBa
       'args.format': format,
     })
   })
+
+/**
+ * Batch query for the small vulnerability-count summaries stored in
+ * external_image_scan.parsed_results. Unlike getBatchExternalImageScans, this
+ * does not fetch or decompress detailed scan blobs from object storage.
+ */
+export const getBatchExternalImageScanSummaries = traceFunction('lib.externalimage.getBatchExternalImageScanSummaries', async (
+  teamId: string,
+  digests: string[],
+  arch: string,
+): Promise<Map<string, BatchScanSummaryResult>> => {
+  const db = getDB(await getParam("DB_URI"))
+
+  if (digests.length === 0) {
+    return new Map()
+  }
+
+  const query = `
+    SELECT
+      requested.digest,
+      escan.parsed_results,
+      escan.scan_completed_at,
+      esbom.created_at AS digest_first_seen_at,
+      esbom.image_size_bytes,
+      escan.status AS scan_status,
+      escan.scan_status_message,
+      escan.scan_status_updated_at,
+      (owned.digest IS NOT NULL) AS has_access
+    FROM unnest($2::text[]) AS requested(digest)
+      LEFT JOIN (
+        SELECT DISTINCT etag.digest
+        FROM external_image_tag etag
+          INNER JOIN external_image_team eteam
+            ON eteam.team_id = $1
+            AND eteam.registry = etag.registry
+            AND eteam.image_name = etag.image_name
+            AND eteam.image_tag = etag.image_tag
+        WHERE etag.digest = ANY($2)
+      ) owned ON owned.digest = requested.digest
+      LEFT JOIN external_image_scan escan
+        ON escan.digest = requested.digest
+        AND escan.arch = $3
+        AND owned.digest IS NOT NULL
+      LEFT JOIN external_image_sbom esbom
+        ON esbom.digest = escan.digest
+        AND esbom.arch = escan.arch
+  `
+
+  const queryResult = await db.query(query, [teamId, digests, arch])
+  const resultMap = new Map<string, BatchScanSummaryResult>()
+
+  for (const row of queryResult.rows) {
+    resultMap.set(row.digest, {
+      digest: row.digest,
+      parsedResults: row.parsed_results,
+      scanCompletedAt: row.scan_completed_at,
+      digestFirstSeenAt: row.digest_first_seen_at,
+      imageSizeBytes: parseInt(row.image_size_bytes || '0'),
+      hasAccess: row.has_access,
+      scanStatus: row.scan_status,
+      scanStatusMessage: row.scan_status_message,
+      scanStatusUpdatedAt: row.scan_status_updated_at,
+    })
+  }
+
+  return resultMap
+}, {
+  getTags: (teamId: string, digests: string[], arch: string) => ({
+    'args.team_id': teamId,
+    'args.digests.length': digests.length,
+    'args.arch': arch,
+  })
+})
 
 /**
  * Batch query to get SBOM data for multiple image digests.

--- a/securebuild-api/lib/externalimage/externalimage.ts
+++ b/securebuild-api/lib/externalimage/externalimage.ts
@@ -829,6 +829,7 @@ export interface BatchScanResult {
 export interface BatchScanSummaryResult {
   digest: string;
   parsedResults: string | null;
+  isInObjectStore: boolean;
   scanCompletedAt: string | null;
   digestFirstSeenAt: string | null;
   imageSizeBytes: number;
@@ -1045,6 +1046,7 @@ export const getBatchExternalImageScanSummaries = traceFunction('lib.externalima
     SELECT
       requested.digest,
       escan.parsed_results,
+      escan.is_in_object_store,
       escan.scan_completed_at,
       esbom.created_at AS digest_first_seen_at,
       esbom.image_size_bytes,
@@ -1079,6 +1081,7 @@ export const getBatchExternalImageScanSummaries = traceFunction('lib.externalima
     resultMap.set(row.digest, {
       digest: row.digest,
       parsedResults: row.parsed_results,
+      isInObjectStore: row.is_in_object_store === true,
       scanCompletedAt: row.scan_completed_at,
       digestFirstSeenAt: row.digest_first_seen_at,
       imageSizeBytes: parseInt(row.image_size_bytes || '0'),


### PR DESCRIPTION
- /scan-summary now reads small parsed_results counts directly from PostgreSQL instead of downloading full detail blobs.
- Supports both stored formats: direct counts and legacy { "counts": ... }.
- Non-success status updates now preserve the last successful parsed_results.
- Added regression tests for database-only summaries and count preservation.