### PR TITLE
Spike: add Nix-native local SecureBuild CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,22 @@ run-autoimg: build-autoimg
 build-securebuild-cli:
 	go build -ldflags "$(BUILD_LDFLAGS)" -o bin/securebuild securebuild-cmd/main.go
 
+.PHONY: build-securebuild-cli-nix
+build-securebuild-cli-nix:
+	nix build path:.#securebuild
+
+.PHONY: run-securebuild-cli-nix
+run-securebuild-cli-nix:
+	nix run path:.#securebuild -- $(ARGS)
+
+.PHONY: build-securebuild-cli-image-nix
+build-securebuild-cli-image-nix:
+	nix run path:.#securebuild -- local image
+
+.PHONY: check-securebuild-cli-nix
+check-securebuild-cli-nix:
+	nix run path:.#securebuild -- local check
+
 # Cross-compiled securebuild-cli binaries for release (linux/amd64 and linux/arm64).
 # Set VERSION and GIT_SHA in CI (e.g. VERSION=1.2.3 GIT_SHA=abc1234 make build-securebuild-cli-release-amd64).
 .PHONY: build-securebuild-cli-release

--- a/docs/cli-local-nix-spike.md
+++ b/docs/cli-local-nix-spike.md
@@ -1,0 +1,126 @@
+# Nix-native local SecureBuild CLI
+
+This spike adds a local build path to the existing `securebuild` CLI. Nix is
+the build engine and the package/image definition format. The local path does
+not invoke Melange, APKO, `apk`, or an Alpine/Wolfi package repository.
+
+It is deliberately separate from the production worker pipeline. Local builds
+do not use the SecureBuild API, database, queues, publishing, or registry
+orchestration. The existing remote commands continue to work unchanged.
+
+## Check the environment
+
+```sh
+nix run path:.#securebuild -- local doctor
+```
+
+The doctor checks that the `nix` executable and its default store are usable.
+The CLI deliberately uses the host's Nix executable so it matches the running
+daemon and store configuration. The flake inputs that determine build contents
+are pinned by this repository's `flake.lock`.
+
+## Build a package locally
+
+Build the default package from the current flake:
+
+```sh
+nix run path:.#securebuild -- local package
+```
+
+Build a named output:
+
+```sh
+nix run path:.#securebuild -- local package .#securebuild
+```
+
+The output is a symlink named `result` pointing to an immutable Nix store path.
+Use `--out-link` to choose another link or `--out-link ''` to create no link:
+
+```sh
+nix run path:.#securebuild -- local package .#securebuild \
+  --out-link .securebuild/package
+```
+
+For local `.` and `.#name` references, the CLI uses an explicit `path:` flake
+reference. This includes untracked working-tree files in a spike build instead
+of silently using only files known to Git.
+
+## Run declared tests
+
+```sh
+nix run path:.#securebuild -- local check
+```
+
+This runs `nix flake check`. The flake exposes the CLI derivation as a check,
+and its Nix build runs `go test ./securebuild-cmd/...`.
+
+By default the CLI prevents lock-file changes with
+`--no-update-lock-file --no-write-lock-file`. Pass `--update-lock-file` only
+when intentionally refreshing inputs. Pure evaluation is also the default;
+`--impure` is available as an explicit escape hatch.
+
+## Build an image locally
+
+On Linux:
+
+```sh
+nix run path:.#securebuild -- local image
+```
+
+The flake's `securebuild-image` output uses
+`nixpkgs.dockerTools.buildLayeredImage`. It assembles the image directly from
+the SecureBuild CLI's Nix closure and CA certificates. There is no base image,
+Dockerfile, APKO configuration, or APK installation step.
+
+The output is a `result-image` symlink to the image archive in `/nix/store`.
+Choose a different output link with:
+
+```sh
+nix run path:.#securebuild -- local image .#securebuild-image \
+  --out-link .securebuild/securebuild-image
+```
+
+Container outputs are Linux derivations. A macOS machine therefore needs a
+configured Linux Nix builder, and can select the Linux output explicitly:
+
+```sh
+nix run path:.#securebuild -- local image \
+  .#packages.aarch64-linux.securebuild-image
+```
+
+Use `x86_64-linux` instead when targeting that platform.
+
+## Runtime packages
+
+The image currently declares only these top-level runtime contents:
+
+```nix
+contents = [ securebuild pkgs.cacert ];
+```
+
+Nix includes the complete referenced runtime closure automatically. Compilers
+and other build-only dependencies do not enter the image just because they were
+needed to compile the CLI. If the application later requires Bash, Git, or
+another executable at runtime, that dependency should be added explicitly.
+
+Nix package outputs are store paths rather than `.apk` files. The Nix-native
+equivalent of an APK repository is a signed Nix binary cache; container images
+can still be published to an OCI registry.
+
+## Remote builds still work
+
+These API-backed commands are unchanged:
+
+```sh
+nix run path:.#securebuild -- build package --package-family-name go --tag 1.24.13
+nix run path:.#securebuild -- build image --image-name go --tag 1.24.13
+```
+
+## Scope of this spike
+
+This is a complete Nix-native implementation of the new local CLI path, but it
+does not yet migrate SecureBuild's production data model and workers. The
+existing server still understands Melange YAML, APKO YAML, APK repositories,
+and their associated build records. A production migration would replace those
+with locked flake references, Nix output metadata, binary-cache publishing, and
+OCI publication from Nix image outputs.

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,126 @@
         x86_64-linux = f "x86_64-linux";
         aarch64-linux = f "aarch64-linux";
       };
+      securebuildCliGoMod = builtins.toFile "securebuild-cli.go.mod" ''
+        module github.com/securebuildhq/securebuild
+
+        go 1.25.5
+
+        require (
+          github.com/spf13/cobra v1.10.2
+          github.com/spf13/viper v1.21.0
+          github.com/stretchr/testify v1.11.1
+        )
+
+        require (
+          github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+          github.com/fsnotify/fsnotify v1.9.0 // indirect
+          github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
+          github.com/inconshreveable/mousetrap v1.1.0 // indirect
+          github.com/pelletier/go-toml/v2 v2.3.1 // indirect
+          github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+          github.com/sagikazarmark/locafero v0.11.0 // indirect
+          github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
+          github.com/spf13/afero v1.15.0 // indirect
+          github.com/spf13/cast v1.10.0 // indirect
+          github.com/spf13/pflag v1.0.10 // indirect
+          github.com/subosito/gotenv v1.6.0 // indirect
+          go.yaml.in/yaml/v3 v3.0.4 // indirect
+          golang.org/x/sys v0.45.0 // indirect
+          golang.org/x/text v0.37.0 // indirect
+          gopkg.in/yaml.v3 v3.0.1 // indirect
+        )
+      '';
+      mkSecurebuild = pkgs:
+        pkgs.buildGoModule {
+          pname = "securebuild";
+          version = self.shortRev or self.dirtyShortRev or "dev";
+
+          # Keep the derivation focused on the public CLI. The repository also
+          # contains services and web applications that are not part of this
+          # artifact.
+          src = pkgs.lib.cleanSourceWith {
+            src = ./.;
+            filter = path: type:
+              let
+                relative = pkgs.lib.removePrefix (toString ./. + "/") (toString path);
+              in
+                relative == ""
+                || relative == "go.mod"
+                || relative == "go.sum"
+                || relative == "securebuild-cmd"
+                || pkgs.lib.hasPrefix "securebuild-cmd/" relative;
+          };
+
+          subPackages = [ "securebuild-cmd" ];
+          env.CGO_ENABLED = 0;
+          ldflags = [ "-s" "-w" ];
+
+          checkPhase = ''
+            runHook preCheck
+            go test ./securebuild-cmd/...
+            runHook postCheck
+          '';
+
+          # The service-level module has hundreds of dependencies that are not
+          # reachable from this client. Use the CLI-specific module graph and
+          # the compiler supplied by the locked nixpkgs revision.
+          postPatch = ''
+            cp ${securebuildCliGoMod} go.mod
+          '';
+
+          vendorHash = "sha256-UIZAc9g1LbKd2qODHciFS5xNyh7Antq+HDjtU7B0mOQ=";
+
+          postInstall = ''
+            mv "$out/bin/securebuild-cmd" "$out/bin/securebuild"
+          '';
+
+          meta = {
+            description = "SecureBuild CLI for local and remote builds";
+            mainProgram = "securebuild";
+          };
+        };
     in {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          securebuild = mkSecurebuild pkgs;
+        in
+          {
+            inherit securebuild;
+            default = securebuild;
+          }
+          // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+            # This image is assembled directly from Nix store closures. There
+            # is intentionally no base image, Dockerfile, Alpine, or apk step.
+            securebuild-image = pkgs.dockerTools.buildLayeredImage {
+              name = "securebuild-cli";
+              tag = "nix";
+              contents = [ securebuild pkgs.cacert ];
+              config = {
+                Entrypoint = [ "/bin/securebuild" ];
+                Env = [ "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt" ];
+                Labels = {
+                  "org.opencontainers.image.title" = "SecureBuild CLI";
+                  "org.opencontainers.image.description" = "SecureBuild CLI assembled directly from a Nix closure";
+                };
+              };
+            };
+          });
+
+      checks = forAllSystems (system: {
+        # buildGoModule's checkPhase runs the securebuild-cmd test suite.
+        securebuild-cli = self.packages.${system}.securebuild;
+      });
+
+      apps = forAllSystems (system: {
+        securebuild = {
+          type = "app";
+          program = "${self.packages.${system}.securebuild}/bin/securebuild";
+        };
+        default = self.apps.${system}.securebuild;
+      });
+
       devShells = forAllSystems (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};

--- a/securebuild-cmd/cli/local.go
+++ b/securebuild-cmd/cli/local.go
@@ -1,0 +1,270 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type localCommandRunner func(context.Context, string, string, ...string) error
+
+type localNixBuildOptions struct {
+	workDir       string
+	installable   string
+	outLink       string
+	updateLock    bool
+	impure        bool
+	commandRunner localCommandRunner
+}
+
+type localNixCheckOptions struct {
+	workDir       string
+	flakeRef      string
+	updateLock    bool
+	impure        bool
+	commandRunner localCommandRunner
+}
+
+func LocalCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "local",
+		Short: "Build Nix packages and images on this machine",
+		Long:  "Build and test flake outputs locally with Nix. No SecureBuild API, database, Melange, APKO, or APK repository is used.",
+	}
+
+	cmd.AddCommand(LocalPackageCmd())
+	cmd.AddCommand(LocalImageCmd())
+	cmd.AddCommand(LocalCheckCmd())
+	cmd.AddCommand(LocalDoctorCmd())
+	return cmd
+}
+
+func LocalPackageCmd() *cobra.Command {
+	opts := localNixBuildOptions{
+		workDir:       ".",
+		installable:   ".",
+		outLink:       "result",
+		commandRunner: runLocalCommand,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "package [flake-installable]",
+		Short: "Build a Nix package output",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				opts.installable = args[0]
+			}
+			return runLocalNixBuild(cmd.Context(), "package", opts)
+		},
+	}
+
+	addLocalNixBuildFlags(cmd, &opts)
+	return cmd
+}
+
+func LocalImageCmd() *cobra.Command {
+	opts := localNixBuildOptions{
+		workDir:       ".",
+		installable:   defaultLocalImageInstallable(runtime.GOOS, runtime.GOARCH),
+		outLink:       "result-image",
+		commandRunner: runLocalCommand,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "image [flake-installable]",
+		Short: "Build a Nix-defined container image",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				opts.installable = args[0]
+			}
+			return runLocalNixBuild(cmd.Context(), "image", opts)
+		},
+	}
+
+	addLocalNixBuildFlags(cmd, &opts)
+	return cmd
+}
+
+func LocalCheckCmd() *cobra.Command {
+	opts := localNixCheckOptions{
+		workDir:       ".",
+		flakeRef:      ".",
+		commandRunner: runLocalCommand,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "check [flake-ref]",
+		Short: "Run the checks declared by a Nix flake",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				opts.flakeRef = args[0]
+			}
+			return runLocalNixCheck(cmd.Context(), opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.workDir, "work-dir", opts.workDir, "Directory containing the flake")
+	cmd.Flags().BoolVar(&opts.updateLock, "update-lock-file", false, "Allow Nix to update flake.lock")
+	cmd.Flags().BoolVar(&opts.impure, "impure", false, "Allow impure Nix evaluation")
+	return cmd
+}
+
+func LocalDoctorCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "doctor",
+		Short: "Check that Nix and its store are usable",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			nixPath, err := exec.LookPath("nix")
+			if err != nil {
+				fmt.Fprintln(cmd.OutOrStdout(), "missing  nix")
+				return fmt.Errorf("nix is not on PATH; install Nix before using local builds")
+			}
+
+			versionCmd := exec.CommandContext(cmd.Context(), nixPath, "--version")
+			version, err := versionCmd.Output()
+			if err != nil {
+				return fmt.Errorf("run nix --version: %w", err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "ready    nix      %s (%s)\n", nixPath, strings.TrimSpace(string(version)))
+
+			pingCmd := exec.CommandContext(cmd.Context(), nixPath, "store", "ping")
+			if output, err := pingCmd.CombinedOutput(); err != nil {
+				return fmt.Errorf("Nix store is not usable: %w: %s", err, strings.TrimSpace(string(output)))
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "ready    store    default Nix store responded")
+			return nil
+		},
+	}
+}
+
+func addLocalNixBuildFlags(cmd *cobra.Command, opts *localNixBuildOptions) {
+	cmd.Flags().StringVar(&opts.workDir, "work-dir", opts.workDir, "Directory containing the flake")
+	cmd.Flags().StringVarP(&opts.outLink, "out-link", "o", opts.outLink, "Symlink to the Nix store output; use an empty value for no link")
+	cmd.Flags().BoolVar(&opts.updateLock, "update-lock-file", false, "Allow Nix to update flake.lock")
+	cmd.Flags().BoolVar(&opts.impure, "impure", false, "Allow impure Nix evaluation")
+}
+
+func runLocalNixBuild(ctx context.Context, artifactKind string, opts localNixBuildOptions) error {
+	workDir, err := resolveLocalWorkDir(opts.workDir)
+	if err != nil {
+		return err
+	}
+
+	installable := normalizeLocalFlakeRef(workDir, opts.installable)
+	args := []string{"build", installable, "--print-out-paths"}
+	args = appendLockOptions(args, opts.updateLock)
+	if opts.impure {
+		args = append(args, "--impure")
+	}
+
+	if opts.outLink == "" {
+		args = append(args, "--no-link")
+	} else {
+		outLink := resolveFromWorkDir(workDir, opts.outLink)
+		if err := os.MkdirAll(filepath.Dir(outLink), 0o755); err != nil {
+			return fmt.Errorf("create output link directory: %w", err)
+		}
+		args = append(args, "--out-link", outLink)
+	}
+
+	fmt.Fprintf(os.Stderr, "Building Nix %s %s\n", artifactKind, installable)
+	if err := opts.commandRunner(ctx, workDir, "nix", args...); err != nil {
+		return fmt.Errorf("nix build %s: %w", installable, err)
+	}
+	if opts.outLink != "" {
+		fmt.Fprintf(os.Stderr, "Local %s output link: %s\n", artifactKind, resolveFromWorkDir(workDir, opts.outLink))
+	}
+	return nil
+}
+
+func runLocalNixCheck(ctx context.Context, opts localNixCheckOptions) error {
+	workDir, err := resolveLocalWorkDir(opts.workDir)
+	if err != nil {
+		return err
+	}
+
+	flakeRef := normalizeLocalFlakeRef(workDir, opts.flakeRef)
+	args := []string{"flake", "check", flakeRef}
+	args = appendLockOptions(args, opts.updateLock)
+	if opts.impure {
+		args = append(args, "--impure")
+	}
+
+	fmt.Fprintf(os.Stderr, "Checking Nix flake %s\n", flakeRef)
+	if err := opts.commandRunner(ctx, workDir, "nix", args...); err != nil {
+		return fmt.Errorf("nix flake check %s: %w", flakeRef, err)
+	}
+	return nil
+}
+
+func appendLockOptions(args []string, updateLock bool) []string {
+	if updateLock {
+		return args
+	}
+	return append(args, "--no-update-lock-file", "--no-write-lock-file")
+}
+
+func runLocalCommand(ctx context.Context, workDir, name string, args ...string) error {
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return fmt.Errorf("%s is not on PATH: %w", name, err)
+	}
+	cmd := exec.CommandContext(ctx, path, args...)
+	cmd.Dir = workDir
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func resolveLocalWorkDir(workDir string) (string, error) {
+	absWorkDir, err := filepath.Abs(workDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve work directory: %w", err)
+	}
+	info, err := os.Stat(absWorkDir)
+	if err != nil {
+		return "", fmt.Errorf("read work directory %s: %w", absWorkDir, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("work directory %s is not a directory", absWorkDir)
+	}
+	return absWorkDir, nil
+}
+
+func normalizeLocalFlakeRef(workDir, ref string) string {
+	if ref == "." {
+		return "path:" + workDir
+	}
+	if strings.HasPrefix(ref, ".#") {
+		return "path:" + workDir + strings.TrimPrefix(ref, ".")
+	}
+	return ref
+}
+
+func defaultLocalImageInstallable(goos, goarch string) string {
+	if goos != "darwin" {
+		return ".#securebuild-image"
+	}
+	if goarch == "arm64" {
+		return ".#packages.aarch64-linux.securebuild-image"
+	}
+	return ".#packages.x86_64-linux.securebuild-image"
+}
+
+func resolveFromWorkDir(workDir, path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(workDir, path)
+}

--- a/securebuild-cmd/cli/local_test.go
+++ b/securebuild-cmd/cli/local_test.go
@@ -1,0 +1,157 @@
+package cli
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+type recordedLocalCommand struct {
+	workDir string
+	name    string
+	args    []string
+}
+
+func TestRunLocalNixBuildUsesLocalPathFlakeAndPinnedLock(t *testing.T) {
+	workDir := t.TempDir()
+	commands := []recordedLocalCommand{}
+	runner := func(_ context.Context, dir, name string, args ...string) error {
+		commands = append(commands, recordedLocalCommand{workDir: dir, name: name, args: append([]string(nil), args...)})
+		return nil
+	}
+
+	err := runLocalNixBuild(context.Background(), "package", localNixBuildOptions{
+		workDir:       workDir,
+		installable:   ".#example",
+		outLink:       "output/package",
+		commandRunner: runner,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := recordedLocalCommand{
+		workDir: workDir,
+		name:    "nix",
+		args: []string{
+			"build",
+			"path:" + workDir + "#example",
+			"--print-out-paths",
+			"--no-update-lock-file",
+			"--no-write-lock-file",
+			"--out-link",
+			filepath.Join(workDir, "output/package"),
+		},
+	}
+	if !reflect.DeepEqual(commands, []recordedLocalCommand{want}) {
+		t.Fatalf("unexpected Nix build command: %#v", commands)
+	}
+}
+
+func TestRunLocalNixBuildSupportsImpureUnlockedBuildWithoutLink(t *testing.T) {
+	workDir := t.TempDir()
+	commands := []recordedLocalCommand{}
+	runner := func(_ context.Context, dir, name string, args ...string) error {
+		commands = append(commands, recordedLocalCommand{workDir: dir, name: name, args: append([]string(nil), args...)})
+		return nil
+	}
+
+	err := runLocalNixBuild(context.Background(), "image", localNixBuildOptions{
+		workDir:       workDir,
+		installable:   "github:example/project#image",
+		outLink:       "",
+		updateLock:    true,
+		impure:        true,
+		commandRunner: runner,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantArgs := []string{
+		"build",
+		"github:example/project#image",
+		"--print-out-paths",
+		"--impure",
+		"--no-link",
+	}
+	if len(commands) != 1 || commands[0].name != "nix" || !reflect.DeepEqual(commands[0].args, wantArgs) {
+		t.Fatalf("unexpected Nix build command: %#v", commands)
+	}
+}
+
+func TestRunLocalNixCheck(t *testing.T) {
+	workDir := t.TempDir()
+	commands := []recordedLocalCommand{}
+	runner := func(_ context.Context, dir, name string, args ...string) error {
+		commands = append(commands, recordedLocalCommand{workDir: dir, name: name, args: append([]string(nil), args...)})
+		return nil
+	}
+
+	err := runLocalNixCheck(context.Background(), localNixCheckOptions{
+		workDir:       workDir,
+		flakeRef:      ".",
+		commandRunner: runner,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantArgs := []string{
+		"flake",
+		"check",
+		"path:" + workDir,
+		"--no-update-lock-file",
+		"--no-write-lock-file",
+	}
+	if len(commands) != 1 || commands[0].name != "nix" || !reflect.DeepEqual(commands[0].args, wantArgs) {
+		t.Fatalf("unexpected Nix check command: %#v", commands)
+	}
+}
+
+func TestNormalizeLocalFlakeRef(t *testing.T) {
+	workDir := "/workspace/example"
+	tests := map[string]string{
+		".":                              "path:/workspace/example",
+		".#package":                      "path:/workspace/example#package",
+		"path:/another/project#package":  "path:/another/project#package",
+		"github:example/project#package": "github:example/project#package",
+		"nixpkgs#hello":                  "nixpkgs#hello",
+	}
+	for input, want := range tests {
+		if got := normalizeLocalFlakeRef(workDir, input); got != want {
+			t.Errorf("normalizeLocalFlakeRef(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestDefaultLocalImageInstallable(t *testing.T) {
+	tests := []struct {
+		goos   string
+		goarch string
+		want   string
+	}{
+		{goos: "linux", goarch: "arm64", want: ".#securebuild-image"},
+		{goos: "darwin", goarch: "arm64", want: ".#packages.aarch64-linux.securebuild-image"},
+		{goos: "darwin", goarch: "amd64", want: ".#packages.x86_64-linux.securebuild-image"},
+	}
+	for _, test := range tests {
+		if got := defaultLocalImageInstallable(test.goos, test.goarch); got != test.want {
+			t.Errorf("defaultLocalImageInstallable(%q, %q) = %q, want %q", test.goos, test.goarch, got, test.want)
+		}
+	}
+}
+
+func TestLocalCommandsAreExposed(t *testing.T) {
+	root := RootCmd()
+	for _, args := range [][]string{{"local"}, {"local", "package"}, {"local", "image"}, {"local", "check"}, {"local", "doctor"}} {
+		cmd, _, err := root.Find(args)
+		if err != nil {
+			t.Fatalf("find %v: %v", args, err)
+		}
+		if cmd == root {
+			t.Fatalf("%v resolved to root command", args)
+		}
+	}
+}

--- a/securebuild-cmd/cli/root.go
+++ b/securebuild-cmd/cli/root.go
@@ -5,11 +5,12 @@ import "github.com/spf13/cobra"
 func RootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:           "securebuild",
-		Short:         "SecureBuild CLI client",
+		Short:         "SecureBuild CLI",
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
 	rootCmd.PersistentFlags().Bool("debug", false, "Print API requests and responses (auth token redacted)")
 	rootCmd.AddCommand(BuildCmd())
+	rootCmd.AddCommand(LocalCmd())
 	return rootCmd
 }


### PR DESCRIPTION
## Summary

- add `securebuild local package`, `image`, `check`, and `doctor` commands backed directly by Nix
- package the existing SecureBuild CLI with `buildGoModule` and expose it as a flake package/app/check
- assemble the Linux CLI container image from a Nix closure with `dockerTools`, without a base image, Melange, APKO, or APK repositories
- preserve the existing API-backed `securebuild build package` and `securebuild build image` behavior
- document the local workflow, runtime closure, platform behavior, and production migration boundary

## Verification

- `nix build path:.#securebuild --no-link --print-out-paths`
- `nix run path:.#securebuild -- local doctor`
- `nix run path:.#securebuild -- local package .#securebuild --out-link ''`
- `nix run path:.#securebuild -- local check`
- `nix build path:.#packages.aarch64-linux.securebuild-image --dry-run`

The CLI build runs `go test ./securebuild-cmd/...` through the Nix derivation.

## Spike boundaries

This converts the new local CLI path to Nix. It does not yet migrate the production worker, database, or UI data model away from Melange/APKO.

The Linux image derivation evaluates on macOS. Producing the archive itself requires a configured Linux Nix builder, which was not available on the development Mac used for this spike.
